### PR TITLE
Support primitive value types in collections

### DIFF
--- a/Sources/Core/ObjCRootsRenderer.swift
+++ b/Sources/Core/ObjCRootsRenderer.swift
@@ -83,10 +83,15 @@ struct ObjCRootsRenderer {
         switch schema {
         case .Array(itemType: .none):
             return "NSArray *"
+        case .Array(itemType: .some(let itemType)) where itemType.isObjCPrimitiveType:
+            // Objective-C primitive types are represented as NSNumber
+            return "NSArray<NSNumber /* \(itemType.debugDescription) */ *> *"
         case .Array(itemType: .some(let itemType)):
             return "NSArray<\(objcClassFromSchema(param, itemType))> *"
         case .Map(valueType: .none):
             return "NSDictionary *"
+        case .Map(valueType: .some(let valueType)) where valueType.isObjCPrimitiveType:
+            return "NSDictionary<NSString *, NSNumber /* \(valueType.debugDescription) */ *> *"
         case .Map(valueType: .some(let valueType)):
             return "NSDictionary<NSString *, \(objcClassFromSchema(param, valueType))> *"
         case .String(format: .none),

--- a/Sources/Core/ObjectiveCBuilderExtension.swift
+++ b/Sources/Core/ObjectiveCBuilderExtension.swift
@@ -2,7 +2,7 @@
 //  ObjectiveCBuilderExtension.swift
 //  plank
 //
-//  Created by rmalik on 2/14/17.
+//  Created by Rahul Malik on 2/14/17.
 //
 //
 

--- a/Sources/Core/ObjectiveCEqualityExtension.swift
+++ b/Sources/Core/ObjectiveCEqualityExtension.swift
@@ -2,7 +2,7 @@
 //  ObjectiveCEqualityExtension.swift
 //  plank
 //
-//  Created by rmalik on 2/14/17.
+//  Created by Rahul Malik on 2/14/17.
 //
 //
 
@@ -44,10 +44,11 @@ extension ObjCRootsRenderer {
         }
 
         return ObjCIR.method("- (NSUInteger)hash") {[
-            "return (",
-            -->[propReturnStatements.map { "(\($0))" }.joined(separator: " ^\n")],
-            ");"
-            ]}
+            "NSUInteger subhashes[] = {",
+            -->[propReturnStatements.joined(separator: ",\n")],
+            "};",
+            "return PINIntegerArrayHash(subhashes, sizeof(subhashes) / sizeof(subhashes[0]));"
+        ]}
     }
 
     // MARK: Equality Methods inspired from NSHipster article on Equality: http://nshipster.com/equality/

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -2,7 +2,7 @@
 //  ObjectiveCInitExtension.swift
 //  plank
 //
-//  Created by rmalik on 2/14/17.
+//  Created by Rahul Malik on 2/14/17.
 //
 //
 
@@ -80,7 +80,7 @@ extension ObjCRootsRenderer {
                         ]},
                     "\(propertyToAssign) = \(currentResult);"
                 ]
-            case .Map(valueType: .some(let valueType)):
+            case .Map(valueType: .some(let valueType)) where valueType.isObjCPrimitiveType == false:
                 let currentResult = "result\(counter)"
                 let currentItems = "items\(counter)"
                 let (currentKey, currentObj, currentStop) = ("key\(counter)", "obj\(counter)", "stop\(counter)")

--- a/Sources/Core/ObjectiveCNSCodingExtension.swift
+++ b/Sources/Core/ObjectiveCNSCodingExtension.swift
@@ -2,7 +2,7 @@
 //  ObjectiveCNSCodingExtension.swift
 //  plank
 //
-//  Created by rmalik on 2/14/17.
+//  Created by Rahul Malik on 2/14/17.
 //
 //
 

--- a/plank.xcodeproj/project.pbxproj
+++ b/plank.xcodeproj/project.pbxproj
@@ -154,17 +154,17 @@
 		OBJ_8 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				812A69D51E53D44D006A510E /* ObjectiveCNSCodingExtension.swift */,
-				812A69D31E53D35F006A510E /* ObjectiveCBuilderExtension.swift */,
-				812A69D11E53D30F006A510E /* ObjectiveCInitExtension.swift */,
 				OBJ_9 /* FileGenerator.swift */,
 				OBJ_10 /* ObjCRootsRenderer.swift */,
+				812A69D31E53D35F006A510E /* ObjectiveCBuilderExtension.swift */,
+				812A69CF1E53D2A1006A510E /* ObjectiveCEqualityExtension.swift */,
 				OBJ_11 /* ObjectiveCFileGenerator.swift */,
+				812A69D11E53D30F006A510E /* ObjectiveCInitExtension.swift */,
 				OBJ_12 /* ObjectiveCIR.swift */,
+				812A69D51E53D44D006A510E /* ObjectiveCNSCodingExtension.swift */,
 				OBJ_13 /* Schema.swift */,
 				OBJ_14 /* SchemaLoader.swift */,
 				OBJ_15 /* StringExtensions.swift */,
-				812A69CF1E53D2A1006A510E /* ObjectiveCEqualityExtension.swift */,
 			);
 			name = Core;
 			path = Sources/Core;


### PR DESCRIPTION
Support primitive types in collections (Map, Array) by representing them as NSNumber

This allows you to have values in `NSDictionary` and `NSArray` properties that normally are `BOOL`, `double`, `NSInteger`.

You'll be able to have dictionary property definitions like:
```
       "some_map" : {
           "type" : "object",
           "additionalProperties": { "type": "number" }
       }
```
Which will be converted to `NSDictionary<NSString *, NSNumber *> *someMap`

And array property definitions like:
```
       "some_array" : {
           "type" : "array",
           "items": { "type": "number" }
       }
```
Which will be converted to `NSArray<NSNumber *> *someArray`