### PR TITLE
Switch DSL should render "break" statements

### DIFF
--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -174,11 +174,13 @@ struct ObjCIR {
             switch self {
             case .Case(let condition, let body):
                 return [ "case \(condition):",
-                    -->body
+                    -->body,
+                    -->[ObjCIR.stmt("break")]
                 ].joined(separator: "\n")
             case .Default(let body):
                 return [ "default:",
-                    -->body
+                    -->body,
+                    -->[ObjCIR.stmt("break")]
                 ].joined(separator: "\n")
             }
         }


### PR DESCRIPTION
This hasn't been an issue since the current generated switch statements `return` in each case but would easily be a bug if it didn't.