### PR TITLE
Print deps option

### DIFF
--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -15,7 +15,6 @@ let date = Date()
 
 public enum GenerationParameterType {
     case classPrefix
-    case printDeps
 }
 
 protocol FileGeneratorManager {
@@ -89,15 +88,16 @@ public func loadSchemasForUrls(urls: Set<URL>) -> [Schema] {
     return urls.map { FileSchemaLoader.sharedInstance.loadSchema($0) }
 }
 
-public func generateFilesWithInitialUrl(urls: Set<URL>, outputDirectory: URL, generationParameters: GenerationParameters) {
+public func generateDeps(urls: Set<URL>) {
     let initialSchemas = loadSchemasForUrls(urls: urls)
-    if let _ = generationParameters[GenerationParameterType.printDeps] {
-        let deps = Set(initialSchemas.flatMap { s in s.deps() })
-        deps.forEach { dep in
-            print(dep.relativePath)
-        }
-        exit(0)
+    let deps = Set(initialSchemas.flatMap { s in s.deps() })
+    deps.forEach { dep in
+        print(dep.relativePath)
     }
+}
+
+public func generateFiles(urls: Set<URL>, outputDirectory: URL, generationParameters: GenerationParameters) {
+    _ = loadSchemasForUrls(urls: urls)
     var processedSchemas = Set<URL>([])
     repeat {
         let _ = FileSchemaLoader.sharedInstance.refs.map({ (url: URL, schema: Schema) -> Void in

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -92,7 +92,7 @@ public func loadSchemasForUrls(urls: Set<URL>) -> [Schema] {
 public func generateFilesWithInitialUrl(urls: Set<URL>, outputDirectory: URL, generationParameters: GenerationParameters) {
     let initialSchemas = loadSchemasForUrls(urls: urls)
     if let _ = generationParameters[GenerationParameterType.printDeps] {
-        let deps = initialSchemas.flatMap { s in s.deps() }
+        let deps = Set(initialSchemas.flatMap { s in s.deps() })
         deps.forEach { dep in
             print(dep.relativePath)
         }

--- a/Sources/Core/ObjCADTRenderer.swift
+++ b/Sources/Core/ObjCADTRenderer.swift
@@ -48,8 +48,8 @@ struct ObjCADTRenderer: ObjCFileRenderer {
         case .Object(let objectRoot):
             // Intentionally drop prefix
             return objectRoot.className(with: [:])
-        case .Reference(with: let refFunc):
-            return refFunc().map(objectName) ?? {
+        case .Reference(with: let ref):
+            return ref.force().map(objectName) ?? {
                 assert(false, "TODO: Forward optional across methods")
                 return ""
                 }()

--- a/Sources/Core/ObjCFileRenderer.swift
+++ b/Sources/Core/ObjCFileRenderer.swift
@@ -27,7 +27,7 @@ extension ObjCFileRenderer {
     }
 
     var parentDescriptor: Schema? {
-        return self.rootSchema.extends.flatMap { $0() }
+        return self.rootSchema.extends.flatMap { $0.force() }
     }
 
     var properties: [(Parameter, Schema)] {
@@ -40,8 +40,8 @@ extension ObjCFileRenderer {
 
     fileprivate func referencedClassNames(schema: Schema) -> [String] {
         switch schema {
-        case .Reference(with: let fn):
-            switch fn() {
+        case .Reference(with: let ref):
+            switch ref.force() {
             case .some(.Object(let schemaRoot)):
                 return [schemaRoot.className(with: self.params)]
             default:
@@ -99,8 +99,8 @@ extension ObjCFileRenderer {
             return enumTypeName(propertyName: param, className: className)
         case .Object(let objSchemaRoot):
             return "\(objSchemaRoot.className(with: params)) *"
-        case .Reference(with: let fn):
-            switch fn() {
+        case .Reference(with: let ref):
+            switch ref.force() {
             case .some(.Object(let schemaRoot)):
                 return objcClassFromSchema(param, .Object(schemaRoot))
             default:

--- a/Sources/Core/ObjCModelRenderer.swift
+++ b/Sources/Core/ObjCModelRenderer.swift
@@ -124,8 +124,8 @@ public struct ObjCModelRenderer: ObjCFileRenderer {
             switch schema {
             case .some(.Object(let root)):
                 return root.className(with: self.params)
-            case .some(.Reference(with: let fn)):
-                return resolveClassName(fn())
+            case .some(.Reference(with: let ref)):
+                return resolveClassName(ref.force())
             default:
                 return nil
             }

--- a/Sources/Core/ObjectiveCBuilderExtension.swift
+++ b/Sources/Core/ObjectiveCBuilderExtension.swift
@@ -59,8 +59,8 @@ extension ObjCModelRenderer {
                                     "builder.\(param.snakeCaseToPropertyName()) = nil;"
                                     ]}
                         ]
-                    case .Reference(with: let fn):
-                        switch fn() {
+                    case .Reference(with: let ref):
+                        switch ref.force() {
                         case .some(.Object(let objSchema)):
                             return loop(.Object(objSchema))
                         default:

--- a/Sources/Core/ObjectiveCDebugExtension.swift
+++ b/Sources/Core/ObjectiveCDebugExtension.swift
@@ -69,8 +69,8 @@ extension ObjCFileRenderer {
             return propIVarName
         case .OneOf(types: _):
             return propIVarName
-        case .Reference(with: let fn):
-            switch fn() {
+        case .Reference(with: let ref):
+            switch ref.force() {
             case .some(.Object(let schemaRoot)):
                 return renderDebugStatement(param, .Object(schemaRoot))
             default:

--- a/Sources/Core/ObjectiveCEqualityExtension.swift
+++ b/Sources/Core/ObjectiveCEqualityExtension.swift
@@ -25,8 +25,8 @@ extension ObjCFileRenderer {
                 // Values 1231 for true and 1237 for false are adopted from the Java hashCode specification
                 // http://docs.oracle.com/javase/7/docs/api/java/lang/Boolean.html#hashCode
                 return "(_\(param) ? 1231 : 1237)"
-            case .Reference(with: let fn):
-                switch fn() {
+            case .Reference(with: let ref):
+                switch ref.force() {
                 case .some(.Object(let schemaRoot)):
                     return schemaHashStatement(with: param, for: .Object(schemaRoot))
                 default:
@@ -71,8 +71,8 @@ extension ObjCFileRenderer {
                 return ObjCIR.msg("_\(param)", ("isEqualToString", "anObject.\(param)"))
             case .OneOf(types:_), .Object(_), .Array(_), .String(format: .some(.Uri)):
                 return ObjCIR.msg("_\(param)", ("isEqual", "anObject.\(param)"))
-            case .Reference(with: let fn):
-                switch fn() {
+            case .Reference(with: let ref):
+                switch ref.force() {
                 case .some(.Object(let schemaRoot)):
                     return schemaIsEqualStatement(with: param, for: .Object(schemaRoot))
                 default:

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -119,8 +119,8 @@ extension ObjCModelRenderer {
                 return ["\(propertyToAssign) = [NSURL URLWithString:\(rawObjectName)];"]
             case .String(format: .some(.DateTime)):
                 return ["\(propertyToAssign) = [[NSValueTransformer valueTransformerForName:\(dateValueTransformerKey)] transformedValue:\(rawObjectName)];"]
-            case .Reference(with: let refFunc):
-                return refFunc().map {
+            case .Reference(with: let ref):
+                return ref.force().map {
                     renderPropertyInit(propertyToAssign, rawObjectName, schema: $0, firstName: firstName, counter: counter)
                     } ?? {
                         assert(false, "TODO: Forward optional across methods")
@@ -153,8 +153,8 @@ extension ObjCModelRenderer {
                         return ObjCIR.ifStmt("[\(rawObjectName) isKindOfClass:[NSDictionary class]] && [\(rawObjectName)[\("type".objcLiteral())] isEqualToString:\(objectRoot.typeIdentifier.objcLiteral())]") {
                             transformToADTInit(["\(propertyToAssign) = [\(objectRoot.className(with: self.params)) modelObjectWithDictionary:\(rawObjectName)];"])
                         }
-                    case .Reference(with: let refFunc):
-                        return refFunc().map(loop) ?? {
+                    case .Reference(with: let ref):
+                        return ref.force().map(loop) ?? {
                             assert(false, "TODO: Forward optional across methods")
                             return ""
                             }()

--- a/Sources/Core/ObjectiveCNSCodingExtension.swift
+++ b/Sources/Core/ObjectiveCNSCodingExtension.swift
@@ -92,8 +92,8 @@ extension ObjCFileRenderer {
             return Set(["NSNumber"])
         case .Object(let objSchemaRoot):
             return Set([objSchemaRoot.className(with: self.params)])
-        case .Reference(with: let fn):
-            switch fn() {
+        case .Reference(with: let ref):
+            switch ref.force() {
             case .some(.Object(let schemaRoot)):
                 return referencedObjectClasses(.Object(schemaRoot))
             default:

--- a/Sources/Core/SchemaLoader.swift
+++ b/Sources/Core/SchemaLoader.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol SchemaLoader {
-    func loadSchema(_ schemaUrl: URL) -> Schema?
+    func loadSchema(_ schemaUrl: URL) -> Schema
 }
 
 class FileSchemaLoader: SchemaLoader {
@@ -21,7 +21,7 @@ class FileSchemaLoader: SchemaLoader {
         self.refs = [URL: Schema]()
     }
 
-    func loadSchema(_ schemaUrl: URL) -> Schema? {
+    func loadSchema(_ schemaUrl: URL) -> Schema {
         if let cachedValue = refs[schemaUrl] {
             return cachedValue
         }
@@ -50,6 +50,5 @@ class FileSchemaLoader: SchemaLoader {
         } else {
             fatalError("Error loading or parsing schema at URL: \(schemaUrl)")
         }
-        return nil
     }
 }

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -9,14 +9,6 @@
 import Foundation
 import Core
 
-func beginFileGeneration(_ schemaPaths: Set<String>, outputDirectoryPath: String, generationParameters: GenerationParameters = [:]) {
-    let urls = schemaPaths.map { URL(fileURLWithPath: $0).standardizedFileURL }
-    let outputDirectory = URL(fileURLWithPath: outputDirectoryPath, isDirectory: true)
-    generateFilesWithInitialUrl(urls: Set(urls),
-                                outputDirectory: outputDirectory,
-                                generationParameters: generationParameters)
-}
-
 protocol HelpCommandOutput {
     static func printHelp() -> String
 }
@@ -124,9 +116,6 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     if objc_class_prefix.characters.count > 0 {
         generationParameters[GenerationParameterType.classPrefix] = objc_class_prefix
     }
-    if flags[.printDeps] != nil {
-        generationParameters[GenerationParameterType.printDeps] = ""
-    }
 
     guard !args.isEmpty else {
         print("Error: Missing or invalid URL to JSONSchema")
@@ -152,9 +141,15 @@ func handleGenerateCommand(withArguments arguments: [String]) {
         outputDirectory = URL(string: FileManager.default.currentDirectoryPath)!
     }
 
-    beginFileGeneration(Set(args),
-                        outputDirectoryPath: outputDirectory.absoluteString,
-                        generationParameters: generationParameters)
+    let urls = args.map { URL(fileURLWithPath: $0).standardizedFileURL }
+
+    if flags[.printDeps] != nil {
+        generateDeps(urls: Set(urls))
+    } else {
+        generateFiles(urls: Set(urls),
+                      outputDirectory: URL(fileURLWithPath: outputDirectory.absoluteString, isDirectory: true),
+                      generationParameters: generationParameters)
+    }
 }
 
 func handleHelpCommand() {

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -111,7 +111,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     var generationParameters: GenerationParameters = [:]
     let (flags, args) = parseFlags(fromArguments: arguments)
 
-    if let _ = flags[.help] {
+    if flags[.help] != nil {
         handleHelpCommand()
         return
     }

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -124,7 +124,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     if objc_class_prefix.characters.count > 0 {
         generationParameters[GenerationParameterType.classPrefix] = objc_class_prefix
     }
-    if let _ = flags[.printDeps] {
+    if flags[.printDeps] != nil {
         generationParameters[GenerationParameterType.printDeps] = ""
     }
 

--- a/Sources/plank/main.swift
+++ b/Sources/plank/main.swift
@@ -10,7 +10,7 @@ import Foundation
 
 func handleProcess(processInfo: ProcessInfo) {
     let arguments = processInfo.arguments.dropFirst() // Drop executable name
-    handleGenerateCommand(withArguments: arguments)
+    handleGenerateCommand(withArguments: Array(arguments))
 }
 
 handleProcess(processInfo: ProcessInfo.processInfo)

--- a/Tests/CoreTests/MockSchemaLoader.swift
+++ b/Tests/CoreTests/MockSchemaLoader.swift
@@ -13,10 +13,10 @@ import Foundation
 struct MockSchemaLoader: SchemaLoader {
     let schema: Schema
     let url: URL
-    func loadSchema(_ schemaUrl: URL) -> Schema? {
+    func loadSchema(_ schemaUrl: URL) -> Schema {
         if schemaUrl == url {
             return schema
         }
-        return nil
+        fatalError("Can't open schema")
     }
 }

--- a/Tests/CoreTests/MockSchemaLoader.swift
+++ b/Tests/CoreTests/MockSchemaLoader.swift
@@ -17,6 +17,6 @@ struct MockSchemaLoader: SchemaLoader {
         if schemaUrl == url {
             return schema
         }
-        fatalError("Can't open schema")
+        fatalError("Can't open schema at \(schemaUrl)")
     }
 }

--- a/docs/_posts/2017-02-13-installation.md
+++ b/docs/_posts/2017-02-13-installation.md
@@ -55,6 +55,7 @@ plank.
 |---|---|
 | `output_dir` | Specifies the directory where Plank will write generated files |
 | `objc_class_prefix` | Specifies a prefix to append to the beginning of all classes (i.e. `PIN` for `PINUser`) |
+| `print_deps` | Displays schema dependencies for any schemas passed as arguments and then exits (i.e. for `pin.json` return `user.json`, `board.json`, and `image.json`) |
 | `help` | Displays usage documentation |
 
 ## Next Steps


### PR DESCRIPTION
This option can be used by build systems that need to know which files dirty require a rebuild (like Bazel or Buck).

Deps are all contained within the initial SchemaObjectRoot, but they used to be hidden by a lambda. I changed LazySchemaReference to a protocol and made the concrete implementation that the FileLoader uses expose the concrete file URL so it could be dumped.

I had to do a heavy refactor the argument parser since it assumed that all options took values. This part I struggled with the most actually. I spent a while on this, and I think landed with a pretty clean implementation.