### PR TITLE
Support for no_recursive and only_runtime flags. Fix print_deps

### DIFF
--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -86,15 +86,17 @@ public func generateFileRuntime(outputDirectory: URL) {
     }
 }
 
-public func loadSchemasForUrls(urls: Set<URL>) -> [Schema] {
-    return urls.map { FileSchemaLoader.sharedInstance.loadSchema($0) }
+public func loadSchemasForUrls(urls: Set<URL>) -> [(URL, Schema)] {
+    return urls.map { ($0, FileSchemaLoader.sharedInstance.loadSchema($0)) }
 }
 
 public func generateDeps(urls: Set<URL>) {
-    let initialSchemas = loadSchemasForUrls(urls: urls)
-    let deps = Set(initialSchemas.flatMap { s in s.deps() })
+    let urlSchemas = loadSchemasForUrls(urls: urls)
+    let deps = Set(urlSchemas.map { (url, schema) -> String in
+        ([url] + schema.deps()).map { $0.path }.joined(separator: ":")
+    })
     deps.forEach { dep in
-        print(dep.relativePath)
+        print(dep)
     }
 }
 

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -15,6 +15,8 @@ let date = Date()
 
 public enum GenerationParameterType {
     case classPrefix
+    case recursive
+    case includeRuntime
 }
 
 protocol FileGeneratorManager {
@@ -69,7 +71,7 @@ func generateFile(_ schema: SchemaObjectRoot, outputDirectory: URL, generationPa
     }
 }
 
-func generateFileRuntime(outputDirectory: URL) {
+public func generateFileRuntime(outputDirectory: URL) {
     let files: [FileGenerator] = [ObjCRuntimeHeaderFile(), ObjCRuntimeImplementationFile()]
     for var file in files {
         let fileContents = file.renderFile() + "\n" // Ensure there is exactly one new line a the end of the file
@@ -114,6 +116,10 @@ public func generateFiles(urls: Set<URL>, outputDirectory: URL, generationParame
                 assert(false, "Incorrect Schema for root") // TODO Better error message.
             }
         })
-    } while (processedSchemas.count != FileSchemaLoader.sharedInstance.refs.keys.count)
-    generateFileRuntime(outputDirectory: outputDirectory)
+    } while (
+        generationParameters[.recursive] != nil &&
+        processedSchemas.count != FileSchemaLoader.sharedInstance.refs.keys.count)
+    if generationParameters[.includeRuntime] != nil {
+        generateFileRuntime(outputDirectory: outputDirectory)
+    }
 }

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -40,7 +40,7 @@ extension FlagOptions : HelpCommandOutput {
             "    --\(FlagOptions.outputDirectory.rawValue) - The directory where generated code will be written.",
             "    --\(FlagOptions.printDeps.rawValue) - Just print the path to the dependent schemas necessary to generate the schemas provided and exit.",
             "    --\(FlagOptions.noRecursive.rawValue) - Don't generate files recursively. Only generate the one file I ask for.",
-            "    --\(FlagOptions.onlyRuntime.rawValue) - Only the plank generate runtime files and exit.",
+            "    --\(FlagOptions.onlyRuntime.rawValue) - Only generate runtime files and exit.",
             "    --\(FlagOptions.help.rawValue) - Show this text and exit."
         ].joined(separator: "\n")
     }
@@ -128,9 +128,9 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     ].reduce([:]) { (dict: GenerationParameters, tuple: (GenerationParameterType, String?)) in
             var d = dict
             if let v = tuple.1 {
-            d[tuple.0] = v
-        }
-        return d
+                d[tuple.0] = v
+            }
+            return d
     }
 
     guard !args.isEmpty || flags[.onlyRuntime] != nil else {

--- a/docs/_posts/2017-02-13-installation.md
+++ b/docs/_posts/2017-02-13-installation.md
@@ -55,7 +55,7 @@ plank.
 |---|---|
 | `output_dir` | Specifies the directory where Plank will write generated files |
 | `objc_class_prefix` | Specifies a prefix to append to the beginning of all classes (i.e. `PIN` for `PINUser`) |
-| `print_deps` | Displays schema dependencies for any schemas passed as arguments and then exits (i.e. for `pin.json` return `user.json`, `board.json`, and `image.json`) |
+| `print_deps` | Displays schema dependencies for any schemas passed as arguments and then exits (i.e. for `pin.json` return `user.json`, `board.json`, and `image.json` separated by colons) |
 | `no_recursive` | Only generates files passed in on the commandline (i.e. for `pin.json` only generate `Pin.m` and `Pin.h`) |
 | `only_runtime` | Only generates runtime files and exits |
 | `help` | Displays usage documentation |

--- a/docs/_posts/2017-02-13-installation.md
+++ b/docs/_posts/2017-02-13-installation.md
@@ -56,6 +56,8 @@ plank.
 | `output_dir` | Specifies the directory where Plank will write generated files |
 | `objc_class_prefix` | Specifies a prefix to append to the beginning of all classes (i.e. `PIN` for `PINUser`) |
 | `print_deps` | Displays schema dependencies for any schemas passed as arguments and then exits (i.e. for `pin.json` return `user.json`, `board.json`, and `image.json`) |
+| `no_recursive` | Only generates files passed in on the commandline (i.e. for `pin.json` only generate `Pin.m` and `Pin.h`) |
+| `only_runtime` | Only generates runtime files and exits |
 | `help` | Displays usage documentation |
 
 ## Next Steps


### PR DESCRIPTION
`--no_recursive` only makes the schemas passed in
and
`--only_runtime` just makes the PlankRuntime files
and
`--print_deps` outputs with `:`s separating the paths of each dependency (like the $PATH variable)

These are needed for better incremental builds with Bazel