### PR TITLE
Access schema using NSFileCoordinator 

### DIFF
--- a/Sources/Core/SchemaLoader.swift
+++ b/Sources/Core/SchemaLoader.swift
@@ -55,6 +55,7 @@ class FileSchemaLoader: SchemaLoader {
             self.refs[schemaUrl] = schema
         }
 
+<<<<<<< HEAD
         guard error == nil else {
             fatalError("Error accessing schema at URL: \(schemaUrl)")
         }
@@ -63,6 +64,11 @@ class FileSchemaLoader: SchemaLoader {
             fatalError("Error loading or parsing schema at URL: \(schemaUrl)")
         }
 
+=======
+        guard let resultSchema = loadedSchema else {
+            fatalError("Error accessing schema at URL: \(schemaUrl)")
+        }
+>>>>>>> Fix lint errors
         return resultSchema
     }
 }

--- a/Sources/Core/SchemaLoader.swift
+++ b/Sources/Core/SchemaLoader.swift
@@ -55,8 +55,8 @@ class FileSchemaLoader: SchemaLoader {
             self.refs[schemaUrl] = schema
         }
 
-        guard error == nil else {
-            fatalError("Error accessing schema at URL: \(schemaUrl)")
+        if let err = error {
+            fatalError("Error accessing schema at URL: \(err)")
         }
 
         guard let resultSchema = refs[schemaUrl] else {

--- a/Sources/Core/SchemaLoader.swift
+++ b/Sources/Core/SchemaLoader.swift
@@ -55,7 +55,6 @@ class FileSchemaLoader: SchemaLoader {
             self.refs[schemaUrl] = schema
         }
 
-<<<<<<< HEAD
         guard error == nil else {
             fatalError("Error accessing schema at URL: \(schemaUrl)")
         }
@@ -64,11 +63,6 @@ class FileSchemaLoader: SchemaLoader {
             fatalError("Error loading or parsing schema at URL: \(schemaUrl)")
         }
 
-=======
-        guard let resultSchema = loadedSchema else {
-            fatalError("Error accessing schema at URL: \(schemaUrl)")
-        }
->>>>>>> Fix lint errors
         return resultSchema
     }
 }


### PR DESCRIPTION
By using NSFileCoordinator to read schema files, we can allow the OS to synchronize schema reads if plank is executed in parallel across multiple processes.

> The NSFile​Coordinator class coordinates the reading and writing of files and directories among multiple processes and objects in the same process. You use instances of this class as is to read from, write to, modify the attributes of, change the location of, or delete a file or directory, but before your code to perform those actions executes, the file coordinator lets registered file presenter objects perform any tasks that they might require to ensure their own integrity. For example, if you want to change the location of a file, other objects interested in that file need to know where you intend to move it so that they can update their references.
