### PR TITLE
Simplify initWithModelDictionary

### DIFF
--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -168,15 +168,15 @@ public struct ObjCIR {
             "}"
         ].joined(separator: "\n")
     }
-	
-	static func scope(body: () -> [String]) -> String {
-		return [
-			"{",
-			  -->body,
-			"}"
-		].joined(separator: "\n")
-	}
-
+    
+    static func scope(body: () -> [String]) -> String {
+        return [
+            "{",
+            -->body,
+            "}"
+        ].joined(separator: "\n")
+    }
+    
     enum SwitchCase {
         case caseStmt(condition: String, body: () -> [String])
         case defaultStmt(body: () -> [String])

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -168,6 +168,14 @@ public struct ObjCIR {
             "}"
         ].joined(separator: "\n")
     }
+	
+	static func scope(body: () -> [String]) -> String {
+		return [
+			"{",
+			  -->body,
+			"}"
+		].joined(separator: "\n")
+	}
 
     enum SwitchCase {
         case caseStmt(condition: String, body: () -> [String])

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -168,7 +168,7 @@ public struct ObjCIR {
             "}"
         ].joined(separator: "\n")
     }
-    
+
     static func scope(body: () -> [String]) -> String {
         return [
             "{",
@@ -176,7 +176,7 @@ public struct ObjCIR {
             "}"
         ].joined(separator: "\n")
     }
-    
+
     enum SwitchCase {
         case caseStmt(condition: String, body: () -> [String])
         case defaultStmt(body: () -> [String])

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -223,16 +223,16 @@ extension ObjCModelRenderer {
                 self.isBaseClass ? ObjCIR.ifStmt("!(self = [super init])") { ["return self;"] } :
                 "if (!(self = [super initWithModelDictionary:modelDictionary])) { return self; }",
                 -->self.properties.map { (name, schema) in
-					ObjCIR.scope {[
-						"id value = modelDictionary[\(name.objcLiteral())];",
-						ObjCIR.ifStmt("value != nil") {[
-							ObjCIR.ifStmt("value != [NSNull null]") {
-								renderPropertyInit("self->_\(name.snakeCaseToPropertyName())", "value", schema: schema, firstName: name)
-							},
-							"self->_\(dirtyPropertiesIVarName).\(dirtyPropertyOption(propertyName: name, className: className)) = 1;"
-							]},
-						]}
-				},
+                    ObjCIR.scope {[
+                        "id value = modelDictionary[\(name.objcLiteral())];",
+                        ObjCIR.ifStmt("value != nil") {[
+                            ObjCIR.ifStmt("value != [NSNull null]") {
+                                renderPropertyInit("self->_\(name.snakeCaseToPropertyName())", "value", schema: schema, firstName: name)
+                            },
+                            "self->_\(dirtyPropertiesIVarName).\(dirtyPropertyOption(propertyName: name, className: className)) = 1;"
+                            ]},
+                        ]}
+                },
                 ObjCIR.ifStmt("[self class] == [\(self.className) class]") {
                     [renderPostInitNotification(type: "PlankModelInitTypeDefault")]
                 },

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -76,7 +76,7 @@ extension ObjCModelRenderer {
                     "NSArray *items = \(rawObjectName);",
                     "NSMutableArray *\(currentResult) = [NSMutableArray arrayWithCapacity:items.count];",
                     ObjCIR.forStmt("id \(currentObj) in items") { [
-                        ObjCIR.ifStmt("\(currentObj) != (id)kCFNull]") { [
+                        ObjCIR.ifStmt("\(currentObj) != (id)kCFNull") { [
                             "id \(currentTmp) = nil;",
                             renderPropertyInit(currentTmp, currentObj, schema: itemType, firstName: firstName, counter: counter + 1).joined(separator: "\n"),
                             ObjCIR.ifStmt("\(currentTmp) != nil") {[

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -230,7 +230,7 @@ extension ObjCModelRenderer {
                                 renderPropertyInit("self->_\(name.snakeCaseToPropertyName())", "value", schema: schema, firstName: name)
                             },
                             "self->_\(dirtyPropertiesIVarName).\(dirtyPropertyOption(propertyName: name, className: className)) = 1;"
-                            ]},
+                            ]}
                         ]}
                 },
                 ObjCIR.ifStmt("[self class] == [\(self.className) class]") {

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -217,14 +217,14 @@ extension ObjCModelRenderer {
             }
         }
 
-        return ObjCIR.method("- (instancetype)initWithModelDictionary:(NSDictionary *)modelDictionary") {
+        return ObjCIR.method("- (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary") {
             return [
                 "NSParameterAssert(modelDictionary);",
                 self.isBaseClass ? ObjCIR.ifStmt("!(self = [super init])") { ["return self;"] } :
                 "if (!(self = [super initWithModelDictionary:modelDictionary])) { return self; }",
                 -->self.properties.map { (name, schema) in
                     ObjCIR.scope {[
-                        "id value = modelDictionary[\(name.objcLiteral())];",
+                        "__unsafe_unretained id value = modelDictionary[\(name.objcLiteral())]; // Collection will retain.",
                         ObjCIR.ifStmt("value != nil") {[
                             ObjCIR.ifStmt("value != [NSNull null]") {
                                 renderPropertyInit("self->_\(name.snakeCaseToPropertyName())", "value", schema: schema, firstName: name)

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -76,7 +76,7 @@ extension ObjCModelRenderer {
                     "NSArray *items = \(rawObjectName);",
                     "NSMutableArray *\(currentResult) = [NSMutableArray arrayWithCapacity:items.count];",
                     ObjCIR.forStmt("id \(currentObj) in items") { [
-                        ObjCIR.ifStmt("[\(currentObj) isEqual:[NSNull null]] == NO") { [
+                        ObjCIR.ifStmt("\(currentObj) != (id)kCFNull]") { [
                             "id \(currentTmp) = nil;",
                             renderPropertyInit(currentTmp, currentObj, schema: itemType, firstName: firstName, counter: counter + 1).joined(separator: "\n"),
                             ObjCIR.ifStmt("\(currentTmp) != nil") {[
@@ -100,7 +100,7 @@ extension ObjCModelRenderer {
                                         "id  _Nonnull \(currentObj)",
                                         "__unused BOOL * _Nonnull \(currentStop)"]) {
                                             [
-                                                ObjCIR.ifStmt("\(currentObj) != nil && [\(currentObj) isEqual:[NSNull null]] == NO") {
+                                                ObjCIR.ifStmt("\(currentObj) != nil && \(currentObj) != (id)kCFNull") {
                                                     renderPropertyInit("\(currentResult)[\(currentKey)]", currentObj, schema: valueType, firstName: firstName, counter: counter + 1)
                                                 }
                                             ]
@@ -226,12 +226,12 @@ extension ObjCModelRenderer {
                     ObjCIR.scope {[
                         "__unsafe_unretained id value = modelDictionary[\(name.objcLiteral())]; // Collection will retain.",
                         ObjCIR.ifStmt("value != nil") {[
-                            ObjCIR.ifStmt("value != [NSNull null]") {
+                            ObjCIR.ifStmt("value != (id)kCFNull") {
                                 renderPropertyInit("self->_\(name.snakeCaseToPropertyName())", "value", schema: schema, firstName: name)
                             },
                             "self->_\(dirtyPropertiesIVarName).\(dirtyPropertyOption(propertyName: name, className: className)) = 1;"
-                            ]}
                         ]}
+                    ]}
                 },
                 ObjCIR.ifStmt("[self class] == [\(self.className) class]") {
                     [renderPostInitNotification(type: "PlankModelInitTypeDefault")]

--- a/plank.xcodeproj/project.pbxproj
+++ b/plank.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 				OBJ_24 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		OBJ_7 /* Sources */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
@rahul-malik I haven't learned how to test this component yet, but the idea here is to replace:

```objc
[modelDictionary enumerateKeysAndObjectsUsingBlock:^(NSString *  _Nonnull key, id  _Nonnull obj, __unused BOOL * _Nonnull stop){
    if ([key isEqualToString:@"viewer_invitation"]) {
        id value = valueOrNil(modelDictionary, @"viewer_invitation");
        if (value != nil) {
            self->_viewerInvitation = [PIBoardInvitation modelObjectWithDictionary:value];
        }
        self->_boardDirtyProperties.PIBoardDirtyPropertyViewerInvitation = 1;
    }
    if ([key isEqualToString:@"conversation"]) {
        id value = valueOrNil(modelDictionary, @"conversation");
        if (value != nil) {
            self->_conversation = [PIConversation modelObjectWithDictionary:value];
        }
        self->_boardDirtyProperties.PIBoardDirtyPropertyConversation = 1;
    }
];
```

with something like:

```objc
{
    id value = modelDictionary[@"viewer_invitation"];
    if (value != nil) {
        if (value != [NSNull null]) {
            self->_viewerInvitation = [PIBoardInvitation modelObjectWithDictionary:value];
        }
        self->_boardDirtyProperties.PIBoardDirtyPropertyViewerInvitation = 1;
    }
}
{
    id value = modelDictionary[@"conversation"];
    if (value != nil) {
        if (value != [NSNull null]) {
            self->_conversation = [PIConversation modelObjectWithDictionary:value];
        }
        self->_boardDirtyProperties.PIBoardDirtyPropertyConversation = 1;
    }
}
```

This should improve performance when mapping models.