### PR TITLE
Remove FilePrinter protocol

### DIFF
--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -33,10 +33,6 @@ public protocol FileGenerator {
     var fileName: String { mutating get }
 }
 
-protocol FilePrinter {
-    func print(statement: String)
-}
-
 extension FileGenerator {
 
     func renderCommentHeader() -> String {


### PR DESCRIPTION
Do we use the FilePrinter protocol somewhere. Should we remove it for now?