### PR TITLE
Add support for file based indentation

### DIFF
--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -31,10 +31,17 @@ public protocol FileGeneratorManager {
 public protocol FileGenerator {
     func renderFile() -> String
     var fileName: String { mutating get }
+    var indentation: Int { get }
 }
 
 protocol FilePrinter {
     func print(statement: String)
+}
+
+extension FileGenerator {
+    var indentation: Int {
+        return 4
+    }
 }
 
 extension FileGenerator {
@@ -64,6 +71,7 @@ extension FileGenerator {
 extension FileGeneratorManager {
     func generateFile(_ schema: SchemaObjectRoot, outputDirectory: URL, generationParameters: GenerationParameters) {
         for var file in Self.filesToGenerate(descriptor: schema, generatorParameters: generationParameters) {
+            String.indentation = file.indentation // Update indentation before rendering file
             let fileContents = file.renderFile() + "\n" // Ensure there is exactly one new line a the end of the file
             do {
                 try fileContents.write(

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -32,17 +32,6 @@ public enum ObjCPrimitiveType: String {
     case boolean = "BOOL"
 }
 
-extension String {
-    // Objective-C String Literal
-    func objcLiteral() -> String {
-        return "@\"\(self)\""
-    }
-
-    func indent() -> String {
-        return "    "  + self // Four space indentation for now. Might be configurable in the future.
-    }
-}
-
 extension Sequence {
     func objcLiteral() -> String {
         let inner = self.map { "\($0)" }.joined(separator: ", ")

--- a/Sources/Core/StringExtensions.swift
+++ b/Sources/Core/StringExtensions.swift
@@ -8,6 +8,22 @@
 
 import Foundation
 
+extension String {
+    // Custom indentation support. Default to 4 for now
+    static var indentation = 4
+
+    func indent() -> String {
+        return String(repeating:" ", count:String.indentation) + self
+    }
+}
+
+extension String {
+    // Objective-C String Literal
+    func objcLiteral() -> String {
+        return "@\"\(self)\""
+    }
+}
+
 #if os(Linux)
     // className is not found in Linux implementation of NSObject https://bugs.swift.org/browse/SR-957
     extension NSString {


### PR DESCRIPTION
Currently there is no way to set an indentation level per kind of file basis. This is usually the default one for Objective-C. Other languages have different indentation level defaults. This PR adds a way to define the indentation level per FileGenerator (file) basis.

Furthermore it moves the String extension that handles indentation from `ObjectiveCIR` to `StringExtension` file.

Optimally we would like to have different ways to adjust the indentation level e.g. set the default indentation level for a specific language / file via the command line ...  but I think that could be added in a further update on top of that.