### PR TITLE
Depend on SwiftCheck when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build: lint
 	xcrun swift build -v -Xswiftc -static-stdlib
 
 test: build_test_index_linux build
-	xcrun swift test
+	SWIFTPM_TEST_Plank=YES xcrun swift test
 
 integration_test: build
 	./Utility/integration-test.sh

--- a/Package.pins
+++ b/Package.pins
@@ -1,0 +1,12 @@
+{
+  "autoPin": true,
+  "pins": [
+    {
+      "package": "SwiftCheck",
+      "reason": null,
+      "repositoryURL": "https://github.com/typelift/SwiftCheck.git",
+      "version": "0.8.0"
+    }
+  ],
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,19 @@
+// swift-tools-version:3.1
+
 import PackageDescription
+import Foundation
+
+// HACK from https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Package.swift
+var isSwiftPMTest: Bool {
+    return ProcessInfo.processInfo.environment["SWIFTPM_TEST_Plank"] == "YES"
+}
 
 let package = Package(
     name: "plank",
     targets: [Target(name: "plank", dependencies:["Core"]),
               Target(name: "Core", dependencies:[])],
+    dependencies: isSwiftPMTest ?
+                [.Package(url: "https://github.com/typelift/SwiftCheck.git", versions: Version(0,6,0)..<Version(1,0,0))] : [],
     exclude: ["Utility", "Examples"]
 )
 

--- a/Tests/CoreTests/LinuxTestIndex.swift
+++ b/Tests/CoreTests/LinuxTestIndex.swift
@@ -8,4 +8,10 @@ extension ObjectiveCInitTests {
        ("testOneOfInit", testOneOfInit)
    ]
 }
+// Generated Test Extension for PlankSpecs
+extension PlankSpecs {
+   static var allTests = [
+       ("testSwiftCheckWorks", testSwiftCheckWorks)
+   ]
+}
 #endif

--- a/Tests/CoreTests/PlankSpecs.swift
+++ b/Tests/CoreTests/PlankSpecs.swift
@@ -1,0 +1,9 @@
+import SwiftCheck
+import XCTest
+@testable import Core
+
+class PlankSpecs: XCTestCase {
+  func testSwiftCheckWorks() {
+    property("equality is reflexive on ints") <- forAll(Int.arbitrary) { (elem: Int) in elem == elem }
+  }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,5 +4,6 @@ import XCTest
 
 var tests = [XCTestCaseEntry]()
    tests += [testCase(ObjectiveCInitTests.allTests)]
+   tests += [testCase(PlankSpecs.allTests)]
 
 XCTMain(tests)


### PR DESCRIPTION
Add SwiftCheck as a test dependency so that when toJson lands, we can make a SwiftCheck test that does `toJson(fromJson(arbitrarySchema)) == arbitrarySchema`.

SwiftPM doesn't have a legit test dependency solution right now, but the strategy most SwiftPM authors are following right now is to define an environment variable of the form SWIFTPM_TEST_libname and conditioning on that in the Package.swift (see [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Package.swift#L4) and [Algebra](https://github.com/typelift/Algebra/blob/master/Package.swift#L7))