### PR TITLE
Use relative schema urls internally

### DIFF
--- a/Sources/Core/Schema.swift
+++ b/Sources/Core/Schema.swift
@@ -90,12 +90,9 @@ func decodeRef(from source: URL, with ref: String) -> URL {
         // Local URL
         return URL(string:ref, relativeTo:source)!
     } else {
-        var baseUrl = source.deletingLastPathComponent()
-        if baseUrl.path == "." {
-            baseUrl = URL(fileURLWithPath: (baseUrl.path))
-        }
+        let baseUrl = source.deletingLastPathComponent()
         let lastPathComponentString = URL(string: ref)?.pathComponents.last
-        return URL(string:lastPathComponentString!, relativeTo:baseUrl)!
+        return baseUrl.appendingPathComponent(lastPathComponentString!)
     }
 }
 

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -161,7 +161,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     }
     outputDirectory = URL(fileURLWithPath: outputDirectory.absoluteString, isDirectory: true)
 
-    let urls = args.map { URL(fileURLWithPath: $0).standardizedFileURL }
+    let urls = args.map { URL(string: $0)! }
 
     if flags[.printDeps] != nil {
         generateDeps(urls: Set(urls))


### PR DESCRIPTION
As discussed in person, given that compilers should (if they have a
choice) produce bit-for-bit identical output, and a codegen tool like
plank is used in builds, it makes sense for `--print_deps` to output
dependencies via their relative paths.

Even if all things were equal and we didn't care about bit-for-bit identical output, this is still a nice change because:

1. The print_deps output is more readable and fewer bytes since absolute
paths are mostly repetitive and noisy
2. The logic for `decodeRef` can be simplified

I verified that Pinterest still builds correctly with this plank and
that we are still able to load schemas located in a different directory
(I tested with `../../foo.json`).