### PR TITLE
Don't camel case the description for EnumValue by default

### DIFF
--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -139,17 +139,6 @@ func == (lhs: MethodVisibility, rhs: MethodVisibility) -> Bool {
     }
 }
 
-prefix operator -->
-
-prefix func --> (strs: [String]) -> String {
-  return strs.flatMap { $0.components(separatedBy: "\n").map {$0.indent() } }
-    .joined(separator: "\n")
-}
-
-prefix func --> (body: () -> [String]) -> String {
-  return -->body()
-}
-
 public struct ObjCIR {
 
     static let ret = "return"

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -117,9 +117,13 @@ extension Schema {
 }
 
 extension EnumValue {
-  func objcOptionName(param: String, className: String) -> String {
-    return enumTypeName(propertyName: param, className: className) + self.description
-  }
+    var camelCaseDescription: String {
+        return description.snakeCaseToCamelCase()
+    }
+
+    func objcOptionName(param: String, className: String) -> String {
+        return enumTypeName(propertyName: param, className: className) + self.camelCaseDescription
+    }
 }
 
 enum MethodVisibility: Equatable {
@@ -341,14 +345,14 @@ public struct ObjCIR {
                 return [ObjCIR.enumStmt(name) {
                     switch values {
                     case .integer(let options):
-                        return options.map { "\(name + $0.description) = \($0.defaultValue)" }
+                        return options.map { "\(name + $0.camelCaseDescription) = \($0.defaultValue)" }
                     case .string(let options, _):
-                        return options.map { "\(name + $0.description) /* \($0.defaultValue) */" }
+                        return options.map { "\(name + $0.camelCaseDescription) /* \($0.defaultValue) */" }
                     }
                 }]
             case .optionSetEnum(let name, let values):
                 return [ObjCIR.optionEnumStmt(name) {
-                    values.map { "\(name + $0.description) = 1 << \($0.defaultValue)" }
+                    values.map { "\(name + $0.camelCaseDescription) = 1 << \($0.defaultValue)" }
                 }]
             }
         }

--- a/Sources/Core/Schema.swift
+++ b/Sources/Core/Schema.swift
@@ -54,7 +54,7 @@ public struct EnumValue<ValueType> {
     init(withObject object: JSONObject) {
         if let defaultVal = object["default"] as? ValueType, let descriptionVal = object["description"] as? String {
             defaultValue = defaultVal
-            description = descriptionVal.snakeCaseToCamelCase()
+            description = descriptionVal
         } else {
            fatalError("Invalid schema specification for enum: \(object)")
         }

--- a/Sources/Core/StringExtensions.swift
+++ b/Sources/Core/StringExtensions.swift
@@ -52,6 +52,17 @@ extension NSObject {
     }
 }
 
+prefix operator -->
+
+prefix func --> (strs: [String]) -> String {
+    return strs.flatMap { $0.components(separatedBy: "\n").map {$0.indent() } }
+        .joined(separator: "\n")
+}
+
+prefix func --> (body: () -> [String]) -> String {
+    return -->body()
+}
+
 let objectiveCReservedWordReplacements = [
     "description": "description_text",
     "id": "identifier"

--- a/Sources/Core/StringExtensions.swift
+++ b/Sources/Core/StringExtensions.swift
@@ -59,20 +59,20 @@ let objectiveCReservedWordReplacements = [
 ]
 
 extension String {
+    /// All components separated by _ will be capitalized including the first one
     func snakeCaseToCamelCase() -> String {
         var str: String = self
+
         if let replacementString = objectiveCReservedWordReplacements[self] as String? {
             str = replacementString
         }
 
         let components = str.components(separatedBy: "_")
-
-        let name: [String] = components.map { (component: String) -> String in
-            return component.capitalized
-        }
+        let name = components.map { return $0.uppercaseFirst }
         return name.joined(separator: "")
     }
 
+    /// All components separated by _ will be capitalized execpt the first
     func snakeCaseToPropertyName() -> String {
         var str: String = self
 
@@ -104,5 +104,10 @@ extension String {
     /// Get the last n characters of a string
     func suffixSubstring(_ length: Int) -> String {
         return self.substring(from: self.characters.index(self.endIndex, offsetBy: -length))
+    }
+
+    /// Uppercase the first character
+    var uppercaseFirst: String {
+       	return String(characters.prefix(1)).uppercased() + String(characters.dropFirst())
     }
 }

--- a/Sources/Core/StringExtensions.swift
+++ b/Sources/Core/StringExtensions.swift
@@ -108,6 +108,6 @@ extension String {
 
     /// Uppercase the first character
     var uppercaseFirst: String {
-       	return String(characters.prefix(1)).uppercased() + String(characters.dropFirst())
+        return String(characters.prefix(1)).uppercased() + String(characters.dropFirst())
     }
 }

--- a/Sources/Core/StringExtensions.swift
+++ b/Sources/Core/StringExtensions.swift
@@ -87,8 +87,13 @@ extension String {
             // Hack: Force URL's to be uppercase
             if idx != 0 && component == "url" {
                 name += component.uppercased()
+                continue
+            }
+
+            if idx != 0 {
+                name +=	component.uppercaseFirst
             } else {
-                name += idx != 0 ? component.capitalized: component
+                name += component.lowercaseFirst
             }
         }
 
@@ -109,5 +114,9 @@ extension String {
     /// Uppercase the first character
     var uppercaseFirst: String {
         return String(characters.prefix(1)).uppercased() + String(characters.dropFirst())
+    }
+
+    var lowercaseFirst: String {
+        return String(characters.prefix(1)).lowercased() + String(characters.dropFirst())
     }
 }

--- a/Tests/CoreTests/LinuxTestIndex.swift
+++ b/Tests/CoreTests/LinuxTestIndex.swift
@@ -8,4 +8,14 @@ extension ObjectiveCInitTests {
        ("testOneOfInit", testOneOfInit)
    ]
 }
+// Generated Test Extension for StringExtensionsTests
+extension StringExtensionsTests {
+   static var allTests = [
+       ("testUppercaseFirstCharacter", testUppercaseFirstCharacter),
+       ("testSuffixSubstring", testSuffixSubstring),
+       ("testSnakeCaseToCamelCase", testSnakeCaseToCamelCase),
+       ("testSnakeCaseToPropertyName", testSnakeCaseToPropertyName),
+       ("testSnakeCaseToCapitalizedPropertyName", testSnakeCaseToCapitalizedPropertyName)
+   ]
+}
 #endif

--- a/Tests/CoreTests/LinuxTestIndex.swift
+++ b/Tests/CoreTests/LinuxTestIndex.swift
@@ -11,7 +11,8 @@ extension ObjectiveCInitTests {
 // Generated Test Extension for StringExtensionsTests
 extension StringExtensionsTests {
    static var allTests = [
-       ("testUppercaseFirstCharacter", testUppercaseFirstCharacter),
+       ("testUppercaseFirst", testUppercaseFirst),
+       ("testLowercaseFirst", testLowercaseFirst),
        ("testSuffixSubstring", testSuffixSubstring),
        ("testSnakeCaseToCamelCase", testSnakeCaseToCamelCase),
        ("testSnakeCaseToPropertyName", testSnakeCaseToPropertyName),

--- a/Tests/CoreTests/StringExtensionsTests.swift
+++ b/Tests/CoreTests/StringExtensionsTests.swift
@@ -12,8 +12,15 @@ import XCTest
 
 class StringExtensionsTests: XCTestCase {
 
-    func testUppercaseFirstCharacter() {
+    func testUppercaseFirst() {
         XCTAssert("plank".uppercaseFirst == "Plank")
+        XCTAssert("Plank".uppercaseFirst == "Plank")
+        XCTAssert("plAnK".uppercaseFirst == "PlAnK")
+    }
+
+    func testLowercaseFirst() {
+        XCTAssert("Plank".lowercaseFirst == "plank")
+        XCTAssert("PlAnK".lowercaseFirst == "plAnK")
     }
 
     func testSuffixSubstring() {
@@ -22,14 +29,20 @@ class StringExtensionsTests: XCTestCase {
 
     func testSnakeCaseToCamelCase() {
         XCTAssert("created_at".snakeCaseToCamelCase() == "CreatedAt")
+        XCTAssert("created_aT".snakeCaseToCamelCase() == "CreatedAT")
         XCTAssert("CreatedAt".snakeCaseToCamelCase() == "CreatedAt")
     }
 
     func testSnakeCaseToPropertyName() {
         XCTAssert("created_at".snakeCaseToPropertyName() == "createdAt")
+        XCTAssert("CreatedAt".snakeCaseToPropertyName() == "createdAt")
+        XCTAssert("created_At".snakeCaseToPropertyName() == "createdAt")
+        XCTAssert("CreatedAt".snakeCaseToPropertyName() == "createdAt")
+        XCTAssert("CreaTedAt".snakeCaseToPropertyName() == "creaTedAt")
+        XCTAssert("Created_At".snakeCaseToPropertyName() == "createdAt")
+        XCTAssert("Test_url".snakeCaseToPropertyName() == "testURL")
+        XCTAssert("url_test".snakeCaseToPropertyName() == "urlTest")
 
-        // (@maicki): This test would currently fail as the result is "CreatedAt". 
-        // XCTAssert("CreatedAt".snakeCaseToPropertyName() == "createdAt")
     }
 
     func testSnakeCaseToCapitalizedPropertyName() {

--- a/Tests/CoreTests/StringExtensionsTests.swift
+++ b/Tests/CoreTests/StringExtensionsTests.swift
@@ -1,0 +1,39 @@
+//
+//  StringExtensionsTests.swift
+//  plank
+//
+//  Created by Michael Schneider on 6/16/17.
+//
+//
+
+import XCTest
+
+@testable import Core
+
+class StringExtensionsTests: XCTestCase {
+
+    func testUppercaseFirstCharacter() {
+        XCTAssert("plank".uppercaseFirst == "Plank")
+    }
+
+    func testSuffixSubstring() {
+        XCTAssert("plank".suffixSubstring(2) == "nk")
+    }
+
+    func testSnakeCaseToCamelCase() {
+        XCTAssert("created_at".snakeCaseToCamelCase() == "CreatedAt")
+        XCTAssert("CreatedAt".snakeCaseToCamelCase() == "CreatedAt")
+    }
+
+    func testSnakeCaseToPropertyName() {
+        XCTAssert("created_at".snakeCaseToPropertyName() == "createdAt")
+
+        // (@maicki): This test would currently fail as the result is "CreatedAt". 
+        // XCTAssert("CreatedAt".snakeCaseToPropertyName() == "createdAt")
+    }
+
+    func testSnakeCaseToCapitalizedPropertyName() {
+        XCTAssert("created_at".snakeCaseToCapitalizedPropertyName() == "CreatedAt")
+        XCTAssert("CreatedAt".snakeCaseToCapitalizedPropertyName() == "CreatedAt")
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,5 +4,6 @@ import XCTest
 
 var tests = [XCTestCaseEntry]()
    tests += [testCase(ObjectiveCInitTests.allTests)]
+   tests += [testCase(StringExtensionsTests.allTests)]
 
 XCTMain(tests)

--- a/plank.xcodeproj/project.pbxproj
+++ b/plank.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		6948DB321EB6AB2C00EA902D /* JSFileRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6948DB311EB6AB2C00EA902D /* JSFileRenderer.swift */; };
 		6948DB341EB6C41700EA902D /* JSADTExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6948DB331EB6C41700EA902D /* JSADTExtension.swift */; };
 		696C6E811EA928030039B52F /* JSFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696C6E801EA928030039B52F /* JSFileGenerator.swift */; };
+		691F9DFF1EF41CD10002CE40 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691F9DFE1EF41CD10002CE40 /* StringExtensionsTests.swift */; };
 		812A69D01E53D2A1006A510E /* ObjectiveCEqualityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812A69CF1E53D2A1006A510E /* ObjectiveCEqualityExtension.swift */; };
 		812A69D21E53D30F006A510E /* ObjectiveCInitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812A69D11E53D30F006A510E /* ObjectiveCInitExtension.swift */; };
 		812A69D41E53D35F006A510E /* ObjectiveCBuilderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812A69D31E53D35F006A510E /* ObjectiveCBuilderExtension.swift */; };
@@ -61,6 +62,7 @@
 		6948DB311EB6AB2C00EA902D /* JSFileRenderer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSFileRenderer.swift; sourceTree = "<group>"; };
 		6948DB331EB6C41700EA902D /* JSADTExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSADTExtension.swift; sourceTree = "<group>"; };
 		696C6E801EA928030039B52F /* JSFileGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSFileGenerator.swift; sourceTree = "<group>"; };
+		691F9DFE1EF41CD10002CE40 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		812A69CF1E53D2A1006A510E /* ObjectiveCEqualityExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCEqualityExtension.swift; sourceTree = "<group>"; };
 		812A69D11E53D30F006A510E /* ObjectiveCInitExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCInitExtension.swift; sourceTree = "<group>"; };
 		812A69D31E53D35F006A510E /* ObjectiveCBuilderExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveCBuilderExtension.swift; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 				OBJ_22 /* PlankTestExtension.swift */,
 				815A01191E54D2BA00017AFB /* ObjectiveCInitTests.swift */,
 				815A011B1E55100E00017AFB /* MockSchemaLoader.swift */,
+				691F9DFE1EF41CD10002CE40 /* StringExtensionsTests.swift */,
 			);
 			name = CoreTests;
 			path = Tests/CoreTests;
@@ -345,6 +348,7 @@
 				OBJ_56 /* LinuxTestIndex.swift in Sources */,
 				OBJ_57 /* PlankTestExtension.swift in Sources */,
 				815A011A1E54D2BA00017AFB /* ObjectiveCInitTests.swift in Sources */,
+				691F9DFF1EF41CD10002CE40 /* StringExtensionsTests.swift in Sources */,
 				815A011C1E55100E00017AFB /* MockSchemaLoader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
The description for an EnumValue is always in camel case. This should be the responsibility of the consumer to change between different cases and not assumed that camel case is expected every time.

One example is within the integer enum case of #57. We would like to add a comment with the description, currently by default this is in camel case although it's defined in snake case and wanted in snake case.