### PR TITLE
Add custom indentation support

### DIFF
--- a/Examples/JS/flow/BoardType.js
+++ b/Examples/JS/flow/BoardType.js
@@ -11,15 +11,15 @@ import type { PlankDate, PlankURI } from './runtime.flow.js';
 import type { ImageType } from './ImageType.js';
 
 export type BoardType = $Shape<{|
-    +name: ?string,
-    +id: ?string,
-    +image: ?ImageType,
-    +counts: ?{ +[string]: number } /* Integer */,
-    +created_at: ?PlankDate,
-    +description: ?string,
-    +creator: ?{ +[string]: string },
-    +url: ?PlankURI,
+  +name: ?string,
+  +id: ?string,
+  +image: ?ImageType,
+  +counts: ?{ +[string]: number } /* Integer */,
+  +created_at: ?PlankDate,
+  +description: ?string,
+  +creator: ?{ +[string]: string },
+  +url: ?PlankURI,
 |}> & {
-    id: string
+  id: string
 };
 

--- a/Examples/JS/flow/ImageType.js
+++ b/Examples/JS/flow/ImageType.js
@@ -11,10 +11,10 @@ import type { PlankDate, PlankURI } from './runtime.flow.js';
 
 
 export type ImageType = $Shape<{|
-    +height: ?number,
-    +url: ?PlankURI,
-    +width: ?number,
+  +height: ?number,
+  +url: ?PlankURI,
+  +width: ?number,
 |}> & {
-    id: string
+  id: string
 };
 

--- a/Examples/JS/flow/PinType.js
+++ b/Examples/JS/flow/PinType.js
@@ -13,20 +13,20 @@ import type { ImageType } from './ImageType.js';
 import type { UserType } from './UserType.js';
 
 export type PinType = $Shape<{|
-    +note: ?string,
-    +media: ?{ +[string]: string },
-    +counts: ?{ +[string]: number } /* Integer */,
-    +description: ?string,
-    +creator: ?{ +[string]: UserType },
-    +attribution: ?{ +[string]: string },
-    +board: ?BoardType,
-    +color: ?string,
-    +link: ?PlankURI,
-    +id: ?string,
-    +image: ?ImageType,
-    +created_at: ?PlankDate,
-    +url: ?PlankURI,
+  +note: ?string,
+  +media: ?{ +[string]: string },
+  +counts: ?{ +[string]: number } /* Integer */,
+  +description: ?string,
+  +creator: ?{ +[string]: UserType },
+  +attribution: ?{ +[string]: string },
+  +board: ?BoardType,
+  +color: ?string,
+  +link: ?PlankURI,
+  +id: ?string,
+  +image: ?ImageType,
+  +created_at: ?PlankDate,
+  +url: ?PlankURI,
 |}> & {
-    id: string
+  id: string
 };
 

--- a/Examples/JS/flow/UserType.js
+++ b/Examples/JS/flow/UserType.js
@@ -11,15 +11,15 @@ import type { PlankDate, PlankURI } from './runtime.flow.js';
 import type { ImageType } from './ImageType.js';
 
 export type UserType = $Shape<{|
-    +last_name: ?string,
-    +id: ?string,
-    +first_name: ?string,
-    +image: ?ImageType,
-    +counts: ?{ +[string]: number } /* Integer */,
-    +created_at: ?PlankDate,
-    +username: ?string,
-    +bio: ?string,
+  +last_name: ?string,
+  +id: ?string,
+  +first_name: ?string,
+  +image: ?ImageType,
+  +counts: ?{ +[string]: number } /* Integer */,
+  +created_at: ?PlankDate,
+  +username: ?string,
+  +bio: ?string,
 |}> & {
-    id: string
+  id: string
 };
 

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -36,11 +36,25 @@ public protocol FileGenerator {
     var indent: Int { get }
 }
 
-extension Dictionary where Key == GenerationParameterType, Value == String {
+// Currently not usable until upgrading the Swift Toolchain on CI
+//extension Dictionary where Key == GenerationParameterType, Value == String {
+//    func indent(file: FileGenerator) -> Int {
+//        // Check if the GenerationParameters have an indentation set on it else just use the file indent
+//        if let indentFlag = self[.indent], let indent = Int(indentFlag) {
+//            return indent
+//        }
+//        return file.indent
+//    }
+//}
+
+// Workaround until we can use the version from above
+extension Dictionary where Value: ExpressibleByStringLiteral {
+    // Check if the GenerationParameters have an indentation set on it else just use the file indent
     func indent(file: FileGenerator) -> Int {
-        // Check if the GenerationParameters have an indentation set on it else just use the file indent
-        if let indentFlag = self[.indent], let indent = Int(indentFlag) {
-            return indent
+        if let this = self as? [GenerationParameterType : String] {
+            if let indentFlag = this[.indent], let indent = Int(indentFlag) {
+                return indent
+            }
         }
         return file.indent
     }

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -40,10 +40,8 @@ public protocol FileGenerator {
 //extension Dictionary where Key == GenerationParameterType, Value == String {
 //    func indent(file: FileGenerator) -> Int {
 //        // Check if the GenerationParameters have an indentation set on it else just use the file indent
-//        if let indentFlag = self[.indent], let indent = Int(indentFlag) {
-//            return indent
-//        }
-//        return file.indent
+//        let indent: Int? = self[.indent].flatMap { Int($0) }
+//        return indent ?? file.indent
 //    }
 //}
 
@@ -51,12 +49,10 @@ public protocol FileGenerator {
 extension Dictionary where Value: ExpressibleByStringLiteral {
     // Check if the GenerationParameters have an indentation set on it else just use the file indent
     func indent(file: FileGenerator) -> Int {
-        if let this = self as? [GenerationParameterType : String] {
-            if let indentFlag = this[.indent], let indent = Int(indentFlag) {
-                return indent
-            }
-        }
-        return file.indent
+        let key: Key? = GenerationParameterType.indent as? Key
+        let indentFlag: String? = key.flatMap { self[$0] as? String }
+        let indent: Int? = indentFlag.flatMap { Int($0) }
+        return indent ?? file.indent
     }
 }
 

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -95,7 +95,9 @@ func generator(forLanguage language: Languages) -> FileGeneratorManager {
 
 public func generateRuntimeFiles(outputDirectory: URL, generationParameters: GenerationParameters, forLanguages languages: [Languages]) {
     let fileGenerators: [FileGeneratorManager] = languages.map(generator)
-    fileGenerators.forEach { $0.generateFileRuntime(outputDirectory: outputDirectory, generationParameters:generationParameters) }
+    fileGenerators.forEach {
+        $0.generateFileRuntime(outputDirectory: outputDirectory, generationParameters:generationParameters)
+    }
 }
 
 public func writeFile(file: FileGenerator, outputDirectory: URL, generationParameters: GenerationParameters) {

--- a/Sources/Core/JSFileGenerator.swift
+++ b/Sources/Core/JSFileGenerator.swift
@@ -31,6 +31,10 @@ struct JSModelFile: FileGenerator {
         return "\(className)Type.js"
     }
 
+    var indent: Int {
+        return 2
+    }
+
     func renderFile() -> String {
         return (
             [self.renderCommentHeader()] +

--- a/Sources/Core/JSRuntimeFile.swift
+++ b/Sources/Core/JSRuntimeFile.swift
@@ -18,6 +18,10 @@ struct JSRuntimeFile: FileGenerator {
         return "runtime.flow.js"
     }
 
+    var indent: Int {
+        return 2
+    }
+
     func renderContent() -> String {
         return [
             "export type $Object<V> = { +[key: string]: V }",

--- a/Sources/Core/ObjectiveCFileGenerator.swift
+++ b/Sources/Core/ObjectiveCFileGenerator.swift
@@ -26,12 +26,22 @@ struct ObjectiveCFileGenerator: FileGeneratorManager {
     }
 }
 
+fileprivate extension FileGenerator {
+    var objcDefaultIndent: Int {
+        return 4
+    }
+}
+
 struct ObjCHeaderFile: FileGenerator {
     let roots: [ObjCIR.Root]
     let className: String
 
     var fileName: String {
         return "\(className).h"
+    }
+
+    var indent: Int {
+        return objcDefaultIndent
     }
 
     func renderFile() -> String {
@@ -52,6 +62,10 @@ struct ObjCImplementationFile: FileGenerator {
 
     var fileName: String {
         return "\(className).m"
+    }
+
+    var indent: Int {
+        return objcDefaultIndent
     }
 
     func renderFile() -> String {
@@ -152,6 +166,10 @@ struct ObjCRuntimeHeaderFile: FileGenerator {
         return "PlankModelRuntime.h"
     }
 
+    var indent: Int {
+        return objcDefaultIndent
+    }
+
     func renderFile() -> String {
         let roots: [ObjCIR.Root] = ObjCRuntimeFile.renderRoots()
         let outputs = roots.map { $0.renderHeader() }.reduce([], +)
@@ -164,6 +182,10 @@ struct ObjCRuntimeHeaderFile: FileGenerator {
 struct ObjCRuntimeImplementationFile: FileGenerator {
     var fileName: String {
         return "PlankModelRuntime.m"
+    }
+
+    var indent: Int {
+        return objcDefaultIndent
     }
 
     func renderFile() -> String {

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -39,7 +39,8 @@ extension String {
     }
 
     func indent() -> String {
-        return "    "  + self // Four space indentation for now. Might be configurable in the future.
+        // We indent with tabs and in a post process the tabs are changed to a specific number of spaces
+        return "\t"  + self
     }
 }
 


### PR DESCRIPTION
Initial work to support custom indentation support for plank. The current idea is that every object that conforms to `FileGenerator` needs to implement `indent` that will tell plank the default indentation for this file.

Furthermore a new cli parameter was added `--indent` to overwrite the default indent level defined in the `FileGenerator` for the current run.

Also some code cleanup want in on the way especially around writing the file.