### PR TITLE
Fix make clean warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 all: clean build test integration_test archive
 
 clean:
-	xcrun swift build --clean
+	xcrun swift package clean
 
 lint:
 	./Utility/lint.sh


### PR DESCRIPTION
Fixes:

```
$ make clean
xcrun swift build --clean
warning: swift build --clean is deprecated. Use 'swift package clean' instead. (SR-2082)
```