### PR TITLE
Cleanup if else indentation

### DIFF
--- a/Examples/Cocoa/Sources/objc/Board.m
+++ b/Examples/Cocoa/Sources/objc/Board.m
@@ -361,11 +361,11 @@ struct BoardDirtyProperties {
             if (builder.image) {
                 builder.image = [builder.image mergeWithModel:value initType:PlankModelInitTypeFromSubmerge];
             }
-             else {
+            else {
                 builder.image = value;
             }
         }
-         else {
+        else {
             builder.image = nil;
         }
     }

--- a/Examples/Cocoa/Sources/objc/Pin.m
+++ b/Examples/Cocoa/Sources/objc/Pin.m
@@ -504,11 +504,11 @@ struct PinDirtyProperties {
             if (builder.board) {
                 builder.board = [builder.board mergeWithModel:value initType:PlankModelInitTypeFromSubmerge];
             }
-             else {
+            else {
                 builder.board = value;
             }
         }
-         else {
+        else {
             builder.board = nil;
         }
     }
@@ -527,11 +527,11 @@ struct PinDirtyProperties {
             if (builder.image) {
                 builder.image = [builder.image mergeWithModel:value initType:PlankModelInitTypeFromSubmerge];
             }
-             else {
+            else {
                 builder.image = value;
             }
         }
-         else {
+        else {
             builder.image = nil;
         }
     }

--- a/Examples/Cocoa/Sources/objc/PlankModelRuntime.m
+++ b/Examples/Cocoa/Sources/objc/PlankModelRuntime.m
@@ -33,7 +33,7 @@ NSString *debugDescriptionForFields(NSArray *descriptionFields)
                 }
             }
         }
-         else {
+        else {
             [stringBuf appendFormat:format, [obj description]];
         }
         if (obj != [descriptionFields lastObject]) {

--- a/Examples/Cocoa/Sources/objc/User.m
+++ b/Examples/Cocoa/Sources/objc/User.m
@@ -357,11 +357,11 @@ struct UserDirtyProperties {
             if (builder.image) {
                 builder.image = [builder.image mergeWithModel:value initType:PlankModelInitTypeFromSubmerge];
             }
-             else {
+            else {
                 builder.image = value;
             }
         }
-         else {
+        else {
             builder.image = nil;
         }
     }

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -220,7 +220,7 @@ public struct ObjCIR {
 
     static func elseIfStmt(_ condition: String, _ body:() -> [String]) -> String {
         return [
-            " else if (\(condition)) {",
+            "else if (\(condition)) {",
                 -->body,
             "}"
         ].joined(separator: "\n")
@@ -228,7 +228,7 @@ public struct ObjCIR {
 
     static func elseStmt(_ body: () -> [String]) -> String {
         return [
-            " else {",
+            "else {",
                 -->body,
             "}"
         ].joined(separator: "\n")


### PR DESCRIPTION
As the `ifStmt` always joins with a newline, I think we should not have a space before the else.