### PR TITLE
Bazel build support for Plank

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,9 @@
+# Default options that are applied to common commands (build, test, etc)
+
+# For more details on bazelrc's:
+# https://docs.bazel.build/versions/master/bazel-user-manual.html#bazelrc
+
+build --xcode_toolchain=com.apple.dt.toolchain.Swift_3_1
+build --apple_crosstool_transition
+build --experimental_objc_crosstool=all
+build --symlink_prefix=.bazel/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ Packages
 docs/.jekyll-metadata
 docs/.sass-cache
 docs/_site
+
+# Bazel
+.bazel/
+bazel-out/
+bazel-out

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,23 @@
+load("@build_bazel_rules_apple//apple:swift.bzl", "swift_library")
+load("@build_bazel_rules_apple//apple:macos.bzl", "macos_command_line_application")
+
+swift_library(
+    name = "PlankCore",
+    srcs = glob(["Sources/Core/*.swift"]),
+    module_name = "Core",
+    swift_version = 3,
+    copts = ["-whole-module-optimization"]
+)
+
+swift_library(
+    name = "PlankLib",
+    srcs = glob(["Sources/plank/*.swift"]),
+    swift_version = 3,
+    copts = ["-whole-module-optimization"],
+    deps = [":PlankCore"]
+)
+
+macos_command_line_application(
+    name = "plank",
+    deps = [":PlankLib"]
+)

--- a/Sources/Core/StringExtensions.swift
+++ b/Sources/Core/StringExtensions.swift
@@ -41,17 +41,6 @@ import Foundation
     }
 #endif
 
-extension NSObject {
-    // prefix with "pin_" since protocol extensions cannot override parent implementations
-    class func pin_className() -> String {
-        #if os(Linux)
-            return "NSObject"
-        #else
-            return NSObject.className()
-        #endif
-    }
-}
-
 prefix operator -->
 
 prefix func --> (strs: [String]) -> String {

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,7 @@
+load('@bazel_tools//tools/build_defs/repo:git.bzl', system_git_repository='git_repository')
+
+system_git_repository(
+    name = "build_bazel_rules_apple",
+    remote = "https://github.com/bazelbuild/rules_apple.git",
+    commit = "f336855ceed6201ad3a0fe7008641f161291cd76",
+)


### PR DESCRIPTION
- We're using the rules_apple repository for swift support
- WORKSPACE defines external dependencies
- BUILD defines the specific targets (similar to Swift PM)