### PR TITLE
Objective-C init extension to better handle null model dictionary in prod builds

### DIFF
--- a/Examples/Cocoa/Sources/objc/Board.m
+++ b/Examples/Cocoa/Sources/objc/Board.m
@@ -48,6 +48,9 @@ struct BoardDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary
 {
     NSParameterAssert(modelDictionary);
+    if (!modelDictionary) {
+        return self;
+    }
     if (!(self = [super init])) {
         return self;
     }

--- a/Examples/Cocoa/Sources/objc/Image.m
+++ b/Examples/Cocoa/Sources/objc/Image.m
@@ -42,6 +42,9 @@ struct ImageDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary
 {
     NSParameterAssert(modelDictionary);
+    if (!modelDictionary) {
+        return self;
+    }
     if (!(self = [super init])) {
         return self;
     }

--- a/Examples/Cocoa/Sources/objc/Pin.m
+++ b/Examples/Cocoa/Sources/objc/Pin.m
@@ -55,6 +55,9 @@ struct PinDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary
 {
     NSParameterAssert(modelDictionary);
+    if (!modelDictionary) {
+        return self;
+    }
     if (!(self = [super init])) {
         return self;
     }

--- a/Examples/Cocoa/Sources/objc/User.m
+++ b/Examples/Cocoa/Sources/objc/User.m
@@ -48,6 +48,9 @@ struct UserDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary
 {
     NSParameterAssert(modelDictionary);
+    if (!modelDictionary) {
+        return self;
+    }
     if (!(self = [super init])) {
         return self;
     }

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -225,6 +225,7 @@ extension ObjCModelRenderer {
         return ObjCIR.method("- (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary") {
             return [
                 "NSParameterAssert(modelDictionary);",
+                ObjCIR.ifStmt("!modelDictionary") { ["return self;"] },
                 self.isBaseClass ? ObjCIR.ifStmt("!(self = [super init])") { ["return self;"] } :
                 "if (!(self = [super initWithModelDictionary:modelDictionary])) { return self; }",
                 -->self.properties.map { (name, prop) in


### PR DESCRIPTION
- The generated initializer asserts the nullability of its model dictionary parameter. But since assertions are turned off by default for prod builds, the initializer proceeds and causes a NSInvalidErgumentException: "-[NSNull objectForKeyedSubscript:]: unrecognized selector sent to instance".
- Fix by checking nullability and bail early.
- Update Cocoa examples to include this new check.

![screen shot 2017-09-20 at 12 39 48 pm](https://user-images.githubusercontent.com/587874/30642006-f7df609a-9e00-11e7-8488-4d843bbbecda.png)
