### PR TITLE
[Dictionary Extension] Remove default case that will never be executed

### DIFF
--- a/Sources/Core/ObjectiveCDictionaryExtension.swift
+++ b/Sources/Core/ObjectiveCDictionaryExtension.swift
@@ -118,9 +118,6 @@ extension ObjCFileRenderer {
                     return "[\(destArray) addObject:@(\(processObject))];"
                 case .enumT(.string):
                     return "[\(destArray) addObject:"+enumToStringMethodName(propertyName: param, className: self.className) + "(\(propIVarName))];"
-                default:
-                    assert(false, "Array of oneOf is not possible")
-                    return ""
                 }
             }
             let currentResult = "result\(counter)"


### PR DESCRIPTION
After #85, this default case is no longer needed and causes a warning at compile time.