### PR TITLE
Update ObjC builder extension to be aware of nullability of properties

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -422,14 +422,10 @@ struct BoardDirtyProperties {
     }
     if (modelObject.boardDirtyProperties.BoardDirtyPropertyImage) {
         id value = modelObject.image;
-        if (value != nil) {
-            if (builder.image) {
-                builder.image = [builder.image mergeWithModel:value initType:PlankModelInitTypeFromSubmerge];
-            } else {
-                builder.image = value;
-            }
+        if (builder.image) {
+            builder.image = [builder.image mergeWithModel:value initType:PlankModelInitTypeFromSubmerge];
         } else {
-            builder.image = nil;
+            builder.image = value;
         }
     }
     if (modelObject.boardDirtyProperties.BoardDirtyPropertyCounts) {

--- a/Examples/Cocoa/Sources/Objective_C/include/Board.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Board.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface Board : NSObject<NSCopying, NSSecureCoding>
 @property (nullable, nonatomic, copy, readonly) NSString * name;
 @property (nullable, nonatomic, copy, readonly) NSString * identifier;
-@property (nullable, nonatomic, strong, readonly) Image * image;
+@property (nonnull, nonatomic, strong, readonly) Image * image;
 @property (nullable, nonatomic, strong, readonly) NSDictionary<NSString *, NSNumber /* Integer */ *> * counts;
 @property (nullable, nonatomic, strong, readonly) NSDate * createdAt;
 @property (nullable, nonatomic, copy, readonly) NSString * descriptionText;
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface BoardBuilder : NSObject
 @property (nullable, nonatomic, copy, readwrite) NSString * name;
 @property (nullable, nonatomic, copy, readwrite) NSString * identifier;
-@property (nullable, nonatomic, strong, readwrite) Image * image;
+@property (nonnull, nonatomic, strong, readwrite) Image * image;
 @property (nullable, nonatomic, strong, readwrite) NSDictionary<NSString *, NSNumber /* Integer */ *> * counts;
 @property (nullable, nonatomic, strong, readwrite) NSDate * createdAt;
 @property (nullable, nonatomic, copy, readwrite) NSString * descriptionText;

--- a/Examples/PDK/board.json
+++ b/Examples/PDK/board.json
@@ -26,5 +26,5 @@
 		},
 		"image": { "$ref": "image.json" }
 	},
-    "required": []
+    "required": ["image"]
 }


### PR DESCRIPTION
- To avoid assigning null to a callee that requires a non-null argument