### PR TITLE
Added support for NSSet properties

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -8,8 +8,10 @@
 
 #import "Board.h"
 #import "Image.h"
+#import "User.h"
 
 struct BoardDirtyProperties {
+    unsigned int BoardDirtyPropertyContributors:1;
     unsigned int BoardDirtyPropertyCounts:1;
     unsigned int BoardDirtyPropertyCreatedAt:1;
     unsigned int BoardDirtyPropertyCreator:1;
@@ -100,6 +102,15 @@ struct BoardDirtyProperties {
             }
         }
         {
+            __unsafe_unretained id value = modelDictionary[@"contributors"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_contributors = value;
+                }
+                self->_boardDirtyProperties.BoardDirtyPropertyContributors = 1;
+            }
+        }
+        {
             __unsafe_unretained id value = modelDictionary[@"description"]; // Collection will retain.
             if (value != nil) {
                 if (value != (id)kCFNull) {
@@ -154,6 +165,7 @@ struct BoardDirtyProperties {
     _image = builder.image;
     _counts = builder.counts;
     _createdAt = builder.createdAt;
+    _contributors = builder.contributors;
     _descriptionText = builder.descriptionText;
     _creator = builder.creator;
     _url = builder.url;
@@ -166,7 +178,7 @@ struct BoardDirtyProperties {
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
-    NSMutableArray *descriptionFields = [NSMutableArray arrayWithCapacity:8];
+    NSMutableArray *descriptionFields = [NSMutableArray arrayWithCapacity:9];
     [descriptionFields addObject:parentDebugDescription];
     struct BoardDirtyProperties props = _boardDirtyProperties;
     if (props.BoardDirtyPropertyName) {
@@ -183,6 +195,9 @@ struct BoardDirtyProperties {
     }
     if (props.BoardDirtyPropertyCreatedAt) {
         [descriptionFields addObject:[@"_createdAt = " stringByAppendingFormat:@"%@", _createdAt]];
+    }
+    if (props.BoardDirtyPropertyContributors) {
+        [descriptionFields addObject:[@"_contributors = " stringByAppendingFormat:@"%@", _contributors]];
     }
     if (props.BoardDirtyPropertyDescriptionText) {
         [descriptionFields addObject:[@"_descriptionText = " stringByAppendingFormat:@"%@", _descriptionText]];
@@ -221,6 +236,7 @@ struct BoardDirtyProperties {
         (_image == anObject.image || [_image isEqual:anObject.image]) &&
         (_counts == anObject.counts || [_counts isEqualToDictionary:anObject.counts]) &&
         (_createdAt == anObject.createdAt || [_createdAt isEqualToDate:anObject.createdAt]) &&
+        (_contributors == anObject.contributors || [_contributors isEqualToSet:anObject.contributors]) &&
         (_descriptionText == anObject.descriptionText || [_descriptionText isEqualToString:anObject.descriptionText]) &&
         (_creator == anObject.creator || [_creator isEqualToDictionary:anObject.creator]) &&
         (_url == anObject.url || [_url isEqual:anObject.url])
@@ -235,6 +251,7 @@ struct BoardDirtyProperties {
         [_image hash],
         [_counts hash],
         [_createdAt hash],
+        [_contributors hash],
         [_descriptionText hash],
         [_creator hash],
         [_url hash]
@@ -254,7 +271,7 @@ struct BoardDirtyProperties {
 }
 - (NSDictionary *)dictionaryRepresentation
 {
-    NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity:8];
+    NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity:9];
     if (_boardDirtyProperties.BoardDirtyPropertyName) {
         if (_name != nil) {
             [dict setObject:_name forKey:@"name"];
@@ -290,6 +307,16 @@ struct BoardDirtyProperties {
         } else {
             [dict setObject:[NSNull null] forKey:@"created_at"];
         }
+    }
+    if (_boardDirtyProperties.BoardDirtyPropertyContributors) {
+        NSSet *items0 = _contributors;
+        NSMutableSet *result0 = [NSMutableSet setWithCapacity:items0.count];
+        for (id obj0 in items0) {
+            if (obj0 != (id)kCFNull) {
+                [result0 addObject:[obj0 dictionaryRepresentation]];
+            }
+        }
+        [dict setObject:result0 forKey:@"contributors"];
     }
     if (_boardDirtyProperties.BoardDirtyPropertyDescriptionText) {
         if (_descriptionText != nil) {
@@ -334,6 +361,7 @@ struct BoardDirtyProperties {
     _image = [aDecoder decodeObjectOfClass:[Image class] forKey:@"image"];
     _counts = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSNumber class]]] forKey:@"counts"];
     _createdAt = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"created_at"];
+    _contributors = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSSet class], [User class]]] forKey:@"contributors"];
     _descriptionText = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"description"];
     _creator = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSString class]]] forKey:@"creator"];
     _url = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"url"];
@@ -342,6 +370,7 @@ struct BoardDirtyProperties {
     _boardDirtyProperties.BoardDirtyPropertyImage = [aDecoder decodeIntForKey:@"image_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyCounts = [aDecoder decodeIntForKey:@"counts_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyCreatedAt = [aDecoder decodeIntForKey:@"created_at_dirty_property"] & 0x1;
+    _boardDirtyProperties.BoardDirtyPropertyContributors = [aDecoder decodeIntForKey:@"contributors_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyDescriptionText = [aDecoder decodeIntForKey:@"description_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyCreator = [aDecoder decodeIntForKey:@"creator_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyUrl = [aDecoder decodeIntForKey:@"url_dirty_property"] & 0x1;
@@ -357,6 +386,7 @@ struct BoardDirtyProperties {
     [aCoder encodeObject:self.image forKey:@"image"];
     [aCoder encodeObject:self.counts forKey:@"counts"];
     [aCoder encodeObject:self.createdAt forKey:@"created_at"];
+    [aCoder encodeObject:self.contributors forKey:@"contributors"];
     [aCoder encodeObject:self.descriptionText forKey:@"description"];
     [aCoder encodeObject:self.creator forKey:@"creator"];
     [aCoder encodeObject:self.url forKey:@"url"];
@@ -365,6 +395,7 @@ struct BoardDirtyProperties {
     [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyImage forKey:@"image_dirty_property"];
     [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyCounts forKey:@"counts_dirty_property"];
     [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyCreatedAt forKey:@"created_at_dirty_property"];
+    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyContributors forKey:@"contributors_dirty_property"];
     [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyDescriptionText forKey:@"description_dirty_property"];
     [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyCreator forKey:@"creator_dirty_property"];
     [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyUrl forKey:@"url_dirty_property"];
@@ -393,6 +424,9 @@ struct BoardDirtyProperties {
     }
     if (boardDirtyProperties.BoardDirtyPropertyCreatedAt) {
         _createdAt = modelObject.createdAt;
+    }
+    if (boardDirtyProperties.BoardDirtyPropertyContributors) {
+        _contributors = modelObject.contributors;
     }
     if (boardDirtyProperties.BoardDirtyPropertyDescriptionText) {
         _descriptionText = modelObject.descriptionText;
@@ -434,6 +468,9 @@ struct BoardDirtyProperties {
     if (modelObject.boardDirtyProperties.BoardDirtyPropertyCreatedAt) {
         builder.createdAt = modelObject.createdAt;
     }
+    if (modelObject.boardDirtyProperties.BoardDirtyPropertyContributors) {
+        builder.contributors = modelObject.contributors;
+    }
     if (modelObject.boardDirtyProperties.BoardDirtyPropertyDescriptionText) {
         builder.descriptionText = modelObject.descriptionText;
     }
@@ -468,6 +505,11 @@ struct BoardDirtyProperties {
 {
     _createdAt = createdAt;
     _boardDirtyProperties.BoardDirtyPropertyCreatedAt = 1;
+}
+- (void)setContributors:(NSSet<User *> *)contributors
+{
+    _contributors = contributors;
+    _boardDirtyProperties.BoardDirtyPropertyContributors = 1;
 }
 - (void)setDescriptionText:(NSString *)descriptionText
 {

--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -105,7 +105,18 @@ struct BoardDirtyProperties {
             __unsafe_unretained id value = modelDictionary[@"contributors"]; // Collection will retain.
             if (value != nil) {
                 if (value != (id)kCFNull) {
-                    self->_contributors = value;
+                    NSSet *items = value;
+                    NSMutableSet *result0 = [NSMutableSet setWithCapacity:items.count];
+                    for (id obj0 in items) {
+                        if (obj0 != (id)kCFNull) {
+                            id tmp0 = nil;
+                            tmp0 = [User modelObjectWithDictionary:obj0];
+                            if (tmp0 != nil) {
+                                [result0 addObject:tmp0];
+                            }
+                        }
+                    }
+                    self->_contributors = result0;
                 }
                 self->_boardDirtyProperties.BoardDirtyPropertyContributors = 1;
             }

--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -105,7 +105,7 @@ struct BoardDirtyProperties {
             __unsafe_unretained id value = modelDictionary[@"contributors"]; // Collection will retain.
             if (value != nil) {
                 if (value != (id)kCFNull) {
-                    NSSet *items = value;
+                    NSArray *items = value;
                     NSMutableSet *result0 = [NSMutableSet setWithCapacity:items.count];
                     for (id obj0 in items) {
                         if (obj0 != (id)kCFNull) {

--- a/Examples/Cocoa/Sources/Objective_C/include/Board.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Board.h
@@ -10,6 +10,7 @@
 #import "PlankModelRuntime.h"
 @class BoardBuilder;
 @class Image;
+@class User;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonnull, nonatomic, strong, readonly) Image * image;
 @property (nullable, nonatomic, strong, readonly) NSDictionary<NSString *, NSNumber /* Integer */ *> * counts;
 @property (nullable, nonatomic, strong, readonly) NSDate * createdAt;
+@property (nullable, nonatomic, strong, readonly) NSSet<User *> * contributors;
 @property (nullable, nonatomic, copy, readonly) NSString * descriptionText;
 @property (nullable, nonatomic, strong, readonly) NSDictionary<NSString *, NSString *> * creator;
 @property (nullable, nonatomic, strong, readonly) NSURL * url;
@@ -41,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonnull, nonatomic, strong, readwrite) Image * image;
 @property (nullable, nonatomic, strong, readwrite) NSDictionary<NSString *, NSNumber /* Integer */ *> * counts;
 @property (nullable, nonatomic, strong, readwrite) NSDate * createdAt;
+@property (nullable, nonatomic, strong, readwrite) NSSet<User *> * contributors;
 @property (nullable, nonatomic, copy, readwrite) NSString * descriptionText;
 @property (nullable, nonatomic, strong, readwrite) NSDictionary<NSString *, NSString *> * creator;
 @property (nullable, nonatomic, strong, readwrite) NSURL * url;

--- a/Examples/JS/flow/BoardType.js
+++ b/Examples/JS/flow/BoardType.js
@@ -9,13 +9,15 @@
 
 import type { PlankDate, PlankURI } from './runtime.flow.js';
 import type { ImageType } from './ImageType.js';
+import type { UserType } from './UserType.js';
 
 export type BoardType = $Shape<{|
   +name: ?string,
   +id: ?string,
-  +image: ?ImageType,
+  +image: ImageType,
   +counts: ?{ +[string]: number } /* Integer */,
   +created_at: ?PlankDate,
+  +contributors: ?Set<UserType>,
   +description: ?string,
   +creator: ?{ +[string]: string },
   +url: ?PlankURI,

--- a/Examples/PDK/board.json
+++ b/Examples/PDK/board.json
@@ -20,6 +20,11 @@
 			"type": "string",
 			"format": "date-time"
 		},
+		"contributors": {
+			"type": "array",
+			"unique": "true",
+			"items": { "$ref": "user.json" }
+		},
 		"counts": {
 			"type": "object",
 			"additionalProperties": { "type": "integer" }

--- a/Sources/Core/JSADTExtension.swift
+++ b/Sources/Core/JSADTExtension.swift
@@ -29,6 +29,7 @@ extension JSModelRenderer {
         case .enumT(.integer): return ""  // TODO: Not supported at the moment
         case .boolean: return "boolean"
         case .array(itemType: _): return "Array<*>"
+        case .set(itemType: _): return "Set<*>"
         case .map(valueType: .none): return "{}"
         case .map(valueType: .some(let valueType)) where valueType.isObjCPrimitiveType:
             return "{ +[string]: number } /* \(valueType.debugDescription) */"

--- a/Sources/Core/JSFileRenderer.swift
+++ b/Sources/Core/JSFileRenderer.swift
@@ -50,7 +50,7 @@ extension JSFileRenderer {
             return [schemaRoot.className(with: self.params)]
         case .map(valueType: .some(let valueType)):
             return referencedClassNames(schema: valueType)
-        case .array(itemType: .some(let itemType)):
+        case .array(itemType: .some(let itemType)), .set(itemType: .some(let itemType)):
             return referencedClassNames(schema: itemType)
         case .oneOf(types: let itemTypes):
             return itemTypes.flatMap(referencedClassNames)
@@ -72,6 +72,12 @@ extension JSFileRenderer {
             return "Array<number /* \(itemType.debugDescription) */>"
         case .array(itemType: .some(let itemType)):
             return "Array<\(flowTypeName(param, itemType))>"
+        case .set(itemType: .none):
+            return "Set<*>"
+        case .set(itemType: .some(let itemType)) where itemType.isObjCPrimitiveType:
+            return "Set<number /* \(itemType.debugDescription)> */>"
+        case .set(itemType: .some(let itemType)):
+            return "Set<\(flowTypeName(param, itemType))>"
         case .map(valueType: .none):
             return "{}"
         case .map(valueType: .some(let valueType)) where valueType.isObjCPrimitiveType:

--- a/Sources/Core/ObjCADTRenderer.swift
+++ b/Sources/Core/ObjCADTRenderer.swift
@@ -60,6 +60,7 @@ struct ObjCADTRenderer: ObjCFileRenderer {
         case .enumT(.integer): return "IntegerEnum"  // TODO: Allow custom names
         case .boolean: return "Boolean"
         case .array(itemType: _): return "Array"
+        case .set(itemType: _): return "Set"
         case .map(valueType: _): return "Dictionary"
         case .string(.some(.uri)): return "URL"
         case .string(.some(.dateTime)): return "Date"
@@ -135,6 +136,10 @@ struct ObjCADTRenderer: ObjCFileRenderer {
                                     ObjCIR.stmt("return [NSNumber numberWithBool:self.value\(index)]")
                                     ]}
                             case .array(itemType: _):
+                                return ObjCIR.caseStmt(self.internalTypeEnumName + ObjCADTRenderer.objectName(schemaObj.schema)) {[
+                                    ObjCIR.stmt("return [[NSDictionary alloc]initWithDictionary:[self.value\(index) dictionaryRepresentation]]")
+                                    ]}
+                            case .set(itemType: _):
                                 return ObjCIR.caseStmt(self.internalTypeEnumName + ObjCADTRenderer.objectName(schemaObj.schema)) {[
                                     ObjCIR.stmt("return [[NSDictionary alloc]initWithDictionary:[self.value\(index) dictionaryRepresentation]]")
                                     ]}

--- a/Sources/Core/ObjCFileRenderer.swift
+++ b/Sources/Core/ObjCFileRenderer.swift
@@ -51,7 +51,7 @@ extension ObjCFileRenderer {
             return [schemaRoot.className(with: self.params)]
         case .map(valueType: .some(let valueType)):
             return referencedClassNames(schema: valueType)
-        case .array(itemType: .some(let itemType)):
+        case .array(itemType: .some(let itemType)), .set(itemType: .some(let itemType)):
             return referencedClassNames(schema: itemType)
         case .oneOf(types: let itemTypes):
             return itemTypes.flatMap(referencedClassNames)
@@ -73,6 +73,12 @@ extension ObjCFileRenderer {
             return "NSArray<NSNumber /* \(itemType.debugDescription) */ *> *"
         case .array(itemType: .some(let itemType)):
             return "NSArray<\(objcClassFromSchema(param, itemType))> *"
+        case .set(itemType: .none):
+            return "NSSet *"
+        case .set(itemType: .some(let itemType)) where itemType.isObjCPrimitiveType:
+            return "NSSet<NSNumber /*> \(itemType.debugDescription) */ *> *"
+        case .set(itemType: .some(let itemType)):
+            return "NSSet<\(objcClassFromSchema(param, itemType))> *"
         case .map(valueType: .none):
             return "NSDictionary *"
         case .map(valueType: .some(let valueType)) where valueType.isObjCPrimitiveType:

--- a/Sources/Core/ObjectiveCDebugExtension.swift
+++ b/Sources/Core/ObjectiveCDebugExtension.swift
@@ -63,6 +63,8 @@ extension ObjCFileRenderer {
             return propIVarName
         case .array(itemType: _):
             return propIVarName
+        case .set(itemType: _):
+            return propIVarName
         case .map(valueType: _):
             return propIVarName
         case .object:

--- a/Sources/Core/ObjectiveCDictionaryExtension.swift
+++ b/Sources/Core/ObjectiveCDictionaryExtension.swift
@@ -72,62 +72,77 @@ extension ObjCFileRenderer {
             return "[\(dictionary) setObject:@(\(propIVarName)) forKey:@\"\(param)\"];"
         case .enumT(.string):
             return "[\(dictionary) setObject:"+enumToStringMethodName(propertyName: param, className: self.className) + "(\(propIVarName))" + " forKey:@\"\(param)\"];"
-        case .array(itemType: let itemType?):
-            func createArray(destArray: String, processObject: String, arraySchema: Schema, arrayCounter: Int = 0) -> String {
-                switch arraySchema {
+        case .array(itemType: let itemType?), .set(itemType: let itemType?):
+            func collectionSetup(schema: Schema) -> (String, String, String) {
+                let collectionName, mutableCollectionName, initializerName: String
+                if case .array = schema {
+                    collectionName = "NSArray"
+                    mutableCollectionName = "NSMutableArray"
+                    initializerName = "arrayWithCapacity"
+                } else {
+                    collectionName = "NSSet"
+                    mutableCollectionName = "NSMutableSet"
+                    initializerName = "setWithCapacity"
+                }
+                return (collectionName, mutableCollectionName, initializerName)
+            }
+            func createCollection(destCollection: String, processObject: String, collectionSchema: Schema, collectionCounter: Int = 0) -> String {
+                switch collectionSchema {
                 case .reference, .object, .oneOf(types: _):
-                    return "[\(destArray) addObject:[\(processObject) dictionaryRepresentation]];"
-                case .array(itemType: let type):
-                    let currentResult = "result\(arrayCounter)"
-                    let parentResult = "result\(arrayCounter-1)"
-                    let currentObj = "obj\(arrayCounter)"
+                    return "[\(destCollection) addObject:[\(processObject) dictionaryRepresentation]];"
+                case .array(itemType: let type), .set(itemType: let type):
+                    let currentResult = "result\(collectionCounter)"
+                    let parentResult = "result\(collectionCounter-1)"
+                    let currentObj = "obj\(collectionCounter)"
+                    let (collectionName, mutableCollectionName, initializerName) = collectionSetup(schema: collectionSchema)
                     return [
-                        "NSArray *items\(arrayCounter) = \(processObject);",
-                        "NSMutableArray *\(currentResult) = [NSMutableArray arrayWithCapacity:items\(arrayCounter).count];",
-                        ObjCIR.forStmt("id \(currentObj) in items\(arrayCounter)") { [
+                        "\(collectionName) *items\(collectionCounter) = \(processObject);",
+                        "\(mutableCollectionName) *\(currentResult) = [\(mutableCollectionName) \(initializerName):items\(collectionCounter).count];",
+                        ObjCIR.forStmt("id \(currentObj) in items\(collectionCounter)") { [
                             ObjCIR.ifStmt("\(currentObj) != (id)kCFNull") { [
-                                createArray(destArray: currentResult, processObject: currentObj, arraySchema: type!, arrayCounter: arrayCounter+1)
+                                createCollection(destCollection: currentResult, processObject: currentObj, collectionSchema: type!, collectionCounter: collectionCounter+1)
                                 ]}
                             ]},
                         "[\(parentResult) addObject:\(currentResult)];"
                     ].joined(separator: "\n")
                 case .map(valueType: .none):
-                    return "[\(destArray) addObject:\(processObject)];"
+                    return "[\(destCollection) addObject:\(processObject)];"
                 case .map(valueType: .some(let valueType)):
                     return self.renderAddObjectStatement(processObject, valueType, processObject)
                 case .integer, .float, .boolean:
-                    return "[\(destArray) addObject:@(\(processObject))] ];"
+                    return "[\(destCollection) addObject:@(\(processObject))] ];"
                 case .string(format: .none),
                      .string(format: .some(.email)),
                      .string(format: .some(.hostname)),
                      .string(format: .some(.ipv4)),
                      .string(format: .some(.ipv6)):
-                    return "[\(destArray) addObject:\(processObject) ];"
+                    return "[\(destCollection) addObject:\(processObject) ];"
                 case .string(format: .some(.uri)):
-                    return "[\(destArray) addObject:[\(processObject) absoluteString] ];"
+                    return "[\(destCollection) addObject:[\(processObject) absoluteString] ];"
                 case .string(format: .some(.dateTime)):
                     return [
                         "NSValueTransformer *valueTransformer = [NSValueTransformer valueTransformerForName:\(dateValueTransformerKey)];",
                         ObjCIR.ifElseStmt("\(propIVarName) != nil && [[valueTransformer class] allowsReverseTransformation]") {[
-                            "[\(destArray) addObject:[valueTransformer reverseTransformedValue:\(propIVarName)]];"
+                            "[\(destCollection) addObject:[valueTransformer reverseTransformedValue:\(propIVarName)]];"
                         ]} {[
-                            "[\(destArray) addObject:[NSNull null]];"
+                            "[\(destCollection) addObject:[NSNull null]];"
                         ]}
                     ].joined(separator: "\n")
                 case .enumT(.integer):
-                    return "[\(destArray) addObject:@(\(processObject))];"
+                    return "[\(destCollection) addObject:@(\(processObject))];"
                 case .enumT(.string):
-                    return "[\(destArray) addObject:"+enumToStringMethodName(propertyName: param, className: self.className) + "(\(propIVarName))];"
+                    return "[\(destCollection) addObject:"+enumToStringMethodName(propertyName: param, className: self.className) + "(\(propIVarName))];"
                 }
             }
             let currentResult = "result\(counter)"
             let currentObj = "obj\(counter)"
+            let (collectionName, mutableCollectionName, initializerName) = collectionSetup(schema: schema)
                 return [
-                    "NSArray *items\(counter) = \(propIVarName);",
-                    "NSMutableArray *\(currentResult) = [NSMutableArray arrayWithCapacity:items\(counter).count];",
+                    "\(collectionName) *items\(counter) = \(propIVarName);",
+                    "\(mutableCollectionName) *\(currentResult) = [\(mutableCollectionName) \(initializerName):items\(counter).count];",
                     ObjCIR.forStmt("id \(currentObj) in items\(counter)") { [
                         ObjCIR.ifStmt("\(currentObj) != (id)kCFNull") { [
-                            createArray(destArray: currentResult, processObject: currentObj, arraySchema: itemType, arrayCounter: counter+1)
+                            createCollection(destCollection: currentResult, processObject: currentObj, collectionSchema: itemType, collectionCounter: counter+1)
                         ]}
                     ]},
                     "[\(dictionary) setObject:\(currentResult) forKey:@\"\(param)\"];"

--- a/Sources/Core/ObjectiveCDictionaryExtension.swift
+++ b/Sources/Core/ObjectiveCDictionaryExtension.swift
@@ -136,7 +136,7 @@ extension ObjCFileRenderer {
                 case .map(valueType: .some(let valueType)):
                     return self.renderAddObjectStatement(processObject, valueType, processObject)
                 case .integer, .float, .boolean:
-                    return "[\(destCollection) addObject:@(\(processObject))] ];"
+                    return "[\(destCollection) addObject:\(processObject)];"
                 case .string(format: .none),
                      .string(format: .some(.email)),
                      .string(format: .some(.hostname)),

--- a/Sources/Core/ObjectiveCEqualityExtension.swift
+++ b/Sources/Core/ObjectiveCEqualityExtension.swift
@@ -61,6 +61,8 @@ extension ObjCFileRenderer {
                 return ""
             case .array:
                 return ObjCIR.msg("_\(param)", ("isEqualToArray", "anObject.\(param)"))
+            case .set:
+                return ObjCIR.msg("_\(param)", ("isEqualToSet", "anObject.\(param)"))
             case .map:
                 return ObjCIR.msg("_\(param)", ("isEqualToDictionary", "anObject.\(param)"))
             case .string(format: .some(.dateTime)):

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -86,6 +86,24 @@ extension ObjCModelRenderer {
                         ]},
                     "\(propertyToAssign) = \(currentResult);"
                 ]
+            case .set(itemType: .some(let itemType)):
+                let currentResult = "result\(counter)"
+                let currentTmp = "tmp\(counter)"
+                let currentObj = "obj\(counter)"
+                return [
+                    "NSSet *items = \(rawObjectName);",
+                    "NSMutableSet *\(currentResult) = [NSMutableSet setWithCapacity:items.count];",
+                    ObjCIR.forStmt("id \(currentObj) in items") { [
+                        ObjCIR.ifStmt("\(currentObj) != (id)kCFNull") { [
+                            "id \(currentTmp) = nil;",
+                            renderPropertyInit(currentTmp, currentObj, schema: itemType, firstName: firstName, counter: counter + 1).joined(separator: "\n"),
+                            ObjCIR.ifStmt("\(currentTmp) != nil") {[
+                                "[\(currentResult) addObject:\(currentTmp)];"
+                                ]}
+                            ]}
+                        ]},
+                    "\(propertyToAssign) = \(currentResult);"
+                ]
             case .map(valueType: .some(let valueType)) where valueType.isObjCPrimitiveType == false:
                 let currentResult = "result\(counter)"
                 let currentItems = "items\(counter)"

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -191,6 +191,10 @@ extension ObjCModelRenderer {
                         return ObjCIR.ifStmt("[\(rawObjectName) isKindOfClass:[NSArray class]]") {
                             return transformToADTInit(renderPropertyInit(propertyToAssign, rawObjectName, schema: schema, firstName: firstName, counter: counter))
                         }
+                    case .set(itemType: _):
+                        return ObjCIR.ifStmt("[\(rawObjectName) isKindOfClass:[NSSet class]]") {
+                            return transformToADTInit(renderPropertyInit(propertyToAssign, rawObjectName, schema: schema, firstName: firstName, counter: counter))
+                        }
                     case .map(valueType: _):
                         return ObjCIR.ifStmt("[\(rawObjectName) isKindOfClass:[NSDictionary class]]") {
                             return transformToADTInit(renderPropertyInit(propertyToAssign, rawObjectName, schema: schema, firstName: firstName, counter: counter))

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -72,13 +72,14 @@ extension ObjCModelRenderer {
                 let currentResult = "result\(counter)"
                 let currentTmp = "tmp\(counter)"
                 let currentObj = "obj\(counter)"
+                let propertyInit = itemType.isObjCPrimitiveType ? "\(propertyToAssign) = \(rawObjectName);" : renderPropertyInit(currentTmp, currentObj, schema: itemType, firstName: firstName, counter: counter + 1).joined(separator: "\n")
                 return [
                     "NSArray *items = \(rawObjectName);",
                     "NSMutableArray *\(currentResult) = [NSMutableArray arrayWithCapacity:items.count];",
                     ObjCIR.forStmt("id \(currentObj) in items") { [
                         ObjCIR.ifStmt("\(currentObj) != (id)kCFNull") { [
                             "id \(currentTmp) = nil;",
-                            renderPropertyInit(currentTmp, currentObj, schema: itemType, firstName: firstName, counter: counter + 1).joined(separator: "\n"),
+                            propertyInit,
                             ObjCIR.ifStmt("\(currentTmp) != nil") {[
                                 "[\(currentResult) addObject:\(currentTmp)];"
                                 ]}
@@ -90,13 +91,14 @@ extension ObjCModelRenderer {
                 let currentResult = "result\(counter)"
                 let currentTmp = "tmp\(counter)"
                 let currentObj = "obj\(counter)"
+                let propertyInit = itemType.isObjCPrimitiveType ? "\(propertyToAssign) = \(rawObjectName);" : renderPropertyInit(currentTmp, currentObj, schema: itemType, firstName: firstName, counter: counter + 1).joined(separator: "\n")
                 return [
                     "NSArray *items = \(rawObjectName);",
                     "NSMutableSet *\(currentResult) = [NSMutableSet setWithCapacity:items.count];",
                     ObjCIR.forStmt("id \(currentObj) in items") { [
                         ObjCIR.ifStmt("\(currentObj) != (id)kCFNull") { [
                             "id \(currentTmp) = nil;",
-                            renderPropertyInit(currentTmp, currentObj, schema: itemType, firstName: firstName, counter: counter + 1).joined(separator: "\n"),
+                            propertyInit,
                             ObjCIR.ifStmt("\(currentTmp) != nil") {[
                                 "[\(currentResult) addObject:\(currentTmp)];"
                                 ]}

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -91,7 +91,7 @@ extension ObjCModelRenderer {
                 let currentTmp = "tmp\(counter)"
                 let currentObj = "obj\(counter)"
                 return [
-                    "NSSet *items = \(rawObjectName);",
+                    "NSArray *items = \(rawObjectName);",
                     "NSMutableSet *\(currentResult) = [NSMutableSet setWithCapacity:items.count];",
                     ObjCIR.forStmt("id \(currentObj) in items") { [
                         ObjCIR.ifStmt("\(currentObj) != (id)kCFNull") { [

--- a/Sources/Core/ObjectiveCNSCodingExtension.swift
+++ b/Sources/Core/ObjectiveCNSCodingExtension.swift
@@ -75,6 +75,10 @@ extension ObjCFileRenderer {
             return Set(["NSArray"])
         case .array(itemType: .some(let itemType)):
             return Set(["NSArray"]).union(referencedObjectClasses(itemType))
+        case .set(itemType: .none):
+            return Set(["NSSet"])
+        case .set(itemType: .some(let itemType)):
+            return Set(["NSSet"]).union(referencedObjectClasses(itemType))
         case .map(valueType: .none):
             return Set(["NSDictionary"])
         case .map(valueType: .some(let valueType)):
@@ -116,7 +120,7 @@ extension ObjCFileRenderer {
             return "[aDecoder decodeDoubleForKey:\(param.objcLiteral())];"
         case .integer:
             return "[aDecoder decodeIntegerForKey:\(param.objcLiteral())];"
-        case .string, .map, .array, .oneOf, .reference, .object:
+        case .string, .map, .array, .set, .oneOf, .reference, .object:
             let refObjectClasses = referencedObjectClasses(schema).map { "[\($0) class]" }
             let refObjectClassesString = refObjectClasses.count == 1 ? refObjectClasses.joined(separator: ",") : "[NSSet setWithArray:\(refObjectClasses.objcLiteral())]"
             if refObjectClasses.count == 0 { fatalError("Can't determine class for decode for \(schema)") }
@@ -140,7 +144,7 @@ extension ObjCFileRenderer {
             return "[aCoder encodeDouble:\(propGetter) forKey:\(param.objcLiteral())];"
         case .integer:
             return "[aCoder encodeInteger:\(propGetter) forKey:\(param.objcLiteral())];"
-        case .string, .map, .array, .oneOf, .reference, .object:
+        case .string, .map, .array, .set, .oneOf, .reference, .object:
             return "[aCoder encodeObject:\(propGetter) forKey:\(param.objcLiteral())];"
         }
     }

--- a/Sources/Core/Schema.swift
+++ b/Sources/Core/Schema.swift
@@ -242,7 +242,7 @@ extension Schema {
                     return .set(itemType: (propertyInfo["items"] as? JSONObject)
                         .flatMap { propertyForType(propertyInfo: $0, source: source)})
                 }
-                
+
                 return .array(itemType: (propertyInfo["items"] as? JSONObject)
                         .flatMap { propertyForType(propertyInfo: $0, source: source)})
             case JSONType.integer:

--- a/Sources/Core/Schema.swift
+++ b/Sources/Core/Schema.swift
@@ -131,6 +131,7 @@ extension SchemaObjectRoot : CustomDebugStringConvertible {
 public indirect enum Schema {
     case object(SchemaObjectRoot)
     case array(itemType: Schema?)
+    case set(itemType: Schema?)
     case map(valueType: Schema?) // TODO: Should we have an option to specify the key type? (probably yes)
     case integer
     case float
@@ -148,6 +149,8 @@ extension Schema : CustomDebugStringConvertible {
         switch self {
         case .array(itemType: let itemType):
             return "Array: \(itemType.debugDescription)"
+        case .set(itemType: let itemType):
+            return "Set: \(itemType.debugDescription)"
         case .object(let root):
             return "Object: \(root.debugDescription)"
         case .map(valueType: let valueType):
@@ -199,7 +202,7 @@ extension Schema {
                         rootObject.properties.values.flatMap { (prop: SchemaObjectProperty) -> Set<URL> in
                             return prop.schema.deps()
                     }))
-        case .array(itemType: let itemType):
+        case .array(itemType: let itemType), .set(itemType: let itemType):
             return itemType?.deps() ?? []
         case .map(valueType: let valueType):
             return valueType?.deps() ?? []
@@ -235,6 +238,11 @@ extension Schema {
                     return Schema.string(format: (propertyInfo["format"] as? String).flatMap(StringFormatType.init))
                 }
             case JSONType.array:
+                if let unique = propertyInfo["unique"] as? String, unique == "true" {
+                    return .set(itemType: (propertyInfo["items"] as? JSONObject)
+                        .flatMap { propertyForType(propertyInfo: $0, source: source)})
+                }
+                
                 return .array(itemType: (propertyInfo["items"] as? JSONObject)
                         .flatMap { propertyForType(propertyInfo: $0, source: source)})
             case JSONType.integer:


### PR DESCRIPTION
Taking https://github.com/pinterest/plank/issues/70 as inspiration for how to spec it, this PR takes into consideration the `unique` key that can be defined for `array` properties. Is set, instead of creating a `NSArray`, it will create a `NSSet` instead.

Example:

```
some_prop: {
  type: "array",
  unique: true
}
```