### PR TITLE
Use copy for NSURL and NSDate

### DIFF
--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -110,7 +110,8 @@ extension Schema {
 
     func memoryAssignmentType() -> ObjCMemoryAssignmentType {
         switch self {
-        case .string(format: .none):
+        // Use copy for any string, date, url etc.
+        case .string:
             return .copy
         case .boolean, .float, .integer, .enumT:
             return .assign


### PR DESCRIPTION
This is pretty pedantic, but technically correct and it will improve the world for the 0 developers who created `MYMutableDate : NSDate` and set that on a builder object.