### PR TITLE
Rename dictionaryRepresentation method so it doesn't conflict with Foundation's one

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -280,7 +280,7 @@ struct BoardDirtyProperties {
     [builder mergeWithModel:modelObject];
     return [[Board alloc] initWithBuilder:builder initType:initType];
 }
-- (NSDictionary *)dictionaryRepresentation
+- (NSDictionary *)dictionaryObjectRepresentation
 {
     NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity:9];
     if (_boardDirtyProperties.BoardDirtyPropertyName) {
@@ -299,7 +299,7 @@ struct BoardDirtyProperties {
     }
     if (_boardDirtyProperties.BoardDirtyPropertyImage) {
         if (_image != nil) {
-            [dict setObject:[_image dictionaryRepresentation] forKey:@"image"];
+            [dict setObject:[_image dictionaryObjectRepresentation] forKey:@"image"];
         } else {
             [dict setObject:[NSNull null] forKey:@"image"];
         }
@@ -324,7 +324,7 @@ struct BoardDirtyProperties {
         NSMutableSet *result0 = [NSMutableSet setWithCapacity:items0.count];
         for (id obj0 in items0) {
             if (obj0 != (id)kCFNull) {
-                [result0 addObject:[obj0 dictionaryRepresentation]];
+                [result0 addObject:[obj0 dictionaryObjectRepresentation]];
             }
         }
         [dict setObject:result0 forKey:@"contributors"];

--- a/Examples/Cocoa/Sources/Objective_C/Image.m
+++ b/Examples/Cocoa/Sources/Objective_C/Image.m
@@ -164,7 +164,7 @@ struct ImageDirtyProperties {
     [builder mergeWithModel:modelObject];
     return [[Image alloc] initWithBuilder:builder initType:initType];
 }
-- (NSDictionary *)dictionaryRepresentation
+- (NSDictionary *)dictionaryObjectRepresentation
 {
     NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity:3];
     if (_imageDirtyProperties.ImageDirtyPropertyHeight) {

--- a/Examples/Cocoa/Sources/Objective_C/Pin.m
+++ b/Examples/Cocoa/Sources/Objective_C/Pin.m
@@ -76,14 +76,14 @@
     };
     return PINIntegerArrayHash(subhashes, sizeof(subhashes) / sizeof(subhashes[0]));
 }
-- (id)dictionaryRepresentation
+- (id)dictionaryObjectRepresentation
 {
     switch (self.internalType) {
     case PinAttributionObjectsInternalTypeBoard:
-        return [[NSDictionary alloc]initWithDictionary:[self.value0 dictionaryRepresentation]];
+        return [[NSDictionary alloc]initWithDictionary:[self.value0 dictionaryObjectRepresentation]];
         break;
     case PinAttributionObjectsInternalTypeUser:
-        return [[NSDictionary alloc]initWithDictionary:[self.value1 dictionaryRepresentation]];
+        return [[NSDictionary alloc]initWithDictionary:[self.value1 dictionaryObjectRepresentation]];
         break;
     }
 }
@@ -527,7 +527,7 @@ struct PinDirtyProperties {
     [builder mergeWithModel:modelObject];
     return [[Pin alloc] initWithBuilder:builder initType:initType];
 }
-- (NSDictionary *)dictionaryRepresentation
+- (NSDictionary *)dictionaryObjectRepresentation
 {
     NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity:16];
     if (_pinDirtyProperties.PinDirtyPropertyNote) {
@@ -562,7 +562,7 @@ struct PinDirtyProperties {
         NSMutableDictionary *items0 = [NSMutableDictionary new];
         for (id key in _creator) {
             if ([_creator objectForKey:key] != (id)kCFNull) {
-                [items0 setObject:[[_creator objectForKey:key] dictionaryRepresentation] forKey:key];
+                [items0 setObject:[[_creator objectForKey:key] dictionaryObjectRepresentation] forKey:key];
             }
         }
         [dict setObject:items0 forKey: @"_creator" ];
@@ -586,7 +586,7 @@ struct PinDirtyProperties {
     }
     if (_pinDirtyProperties.PinDirtyPropertyBoard) {
         if (_board != nil) {
-            [dict setObject:[_board dictionaryRepresentation] forKey:@"board"];
+            [dict setObject:[_board dictionaryObjectRepresentation] forKey:@"board"];
         } else {
             [dict setObject:[NSNull null] forKey:@"board"];
         }
@@ -621,7 +621,7 @@ struct PinDirtyProperties {
     }
     if (_pinDirtyProperties.PinDirtyPropertyImage) {
         if (_image != nil) {
-            [dict setObject:[_image dictionaryRepresentation] forKey:@"image"];
+            [dict setObject:[_image dictionaryObjectRepresentation] forKey:@"image"];
         } else {
             [dict setObject:[NSNull null] forKey:@"image"];
         }
@@ -639,7 +639,7 @@ struct PinDirtyProperties {
         NSMutableArray *result0 = [NSMutableArray arrayWithCapacity:items0.count];
         for (id obj0 in items0) {
             if (obj0 != (id)kCFNull) {
-                [result0 addObject:[obj0 dictionaryRepresentation]];
+                [result0 addObject:[obj0 dictionaryObjectRepresentation]];
             }
         }
         [dict setObject:result0 forKey:@"attribution_objects"];

--- a/Examples/Cocoa/Sources/Objective_C/User.m
+++ b/Examples/Cocoa/Sources/Objective_C/User.m
@@ -245,7 +245,7 @@ struct UserDirtyProperties {
     [builder mergeWithModel:modelObject];
     return [[User alloc] initWithBuilder:builder initType:initType];
 }
-- (NSDictionary *)dictionaryRepresentation
+- (NSDictionary *)dictionaryObjectRepresentation
 {
     NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity:8];
     if (_userDirtyProperties.UserDirtyPropertyLastName) {
@@ -271,7 +271,7 @@ struct UserDirtyProperties {
     }
     if (_userDirtyProperties.UserDirtyPropertyImage) {
         if (_image != nil) {
-            [dict setObject:[_image dictionaryRepresentation] forKey:@"image"];
+            [dict setObject:[_image dictionaryObjectRepresentation] forKey:@"image"];
         } else {
             [dict setObject:[NSNull null] forKey:@"image"];
         }

--- a/Examples/Cocoa/Sources/Objective_C/include/Board.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Board.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToBoard:(Board *)anObject;
 - (instancetype)mergeWithModel:(Board *)modelObject;
 - (instancetype)mergeWithModel:(Board *)modelObject initType:(PlankModelInitType)initType;
-- (NSDictionary *)dictionaryRepresentation;
+- (NSDictionary *)dictionaryObjectRepresentation;
 @end
 
 @interface BoardBuilder : NSObject

--- a/Examples/Cocoa/Sources/Objective_C/include/Image.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Image.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToImage:(Image *)anObject;
 - (instancetype)mergeWithModel:(Image *)modelObject;
 - (instancetype)mergeWithModel:(Image *)modelObject initType:(PlankModelInitType)initType;
-- (NSDictionary *)dictionaryRepresentation;
+- (NSDictionary *)dictionaryObjectRepresentation;
 @end
 
 @interface ImageBuilder : NSObject

--- a/Examples/Cocoa/Sources/Objective_C/include/Pin.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Pin.h
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSInteger, PinAttributionObjectsInternalType) {
 + (instancetype)objectWithUser:(User *)user;
 - (void)matchBoard:(nullable PLANK_NOESCAPE void (^)(Board * board))boardMatchHandler orUser:(nullable PLANK_NOESCAPE void (^)(User * user))userMatchHandler;
 - (BOOL)isEqualToPinAttributionObjects:(PinAttributionObjects *)anObject;
-- (id)dictionaryRepresentation;
+- (id)dictionaryObjectRepresentation;
 @end
 
 NS_ASSUME_NONNULL_END
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToPin:(Pin *)anObject;
 - (instancetype)mergeWithModel:(Pin *)modelObject;
 - (instancetype)mergeWithModel:(Pin *)modelObject initType:(PlankModelInitType)initType;
-- (NSDictionary *)dictionaryRepresentation;
+- (NSDictionary *)dictionaryObjectRepresentation;
 @end
 
 @interface PinBuilder : NSObject

--- a/Examples/Cocoa/Sources/Objective_C/include/User.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/User.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToUser:(User *)anObject;
 - (instancetype)mergeWithModel:(User *)modelObject;
 - (instancetype)mergeWithModel:(User *)modelObject initType:(PlankModelInitType)initType;
-- (NSDictionary *)dictionaryRepresentation;
+- (NSDictionary *)dictionaryObjectRepresentation;
 @end
 
 @interface UserBuilder : NSObject

--- a/Sources/Core/ObjCADTRenderer.swift
+++ b/Sources/Core/ObjCADTRenderer.swift
@@ -105,19 +105,19 @@ struct ObjCADTRenderer: ObjCFileRenderer {
         }
     }
 
-    func renderDictionaryRepresentation() -> ObjCIR.Method {
-            return ObjCIR.method("- (id)dictionaryRepresentation") {
+    func renderDictionaryObjectRepresentation() -> ObjCIR.Method {
+            return ObjCIR.method("- (id)dictionaryObjectRepresentation") {
                 [
                     ObjCIR.switchStmt("self.internalType") {
                         self.dataTypes.enumerated().map { (index, schemaObj) -> ObjCIR.SwitchCase in
                             switch schemaObj.schema {
                             case .object:
                                 return ObjCIR.caseStmt(self.internalTypeEnumName + ObjCADTRenderer.objectName(schemaObj.schema)) {[
-                                    ObjCIR.stmt("return [[NSDictionary alloc]initWithDictionary:[self.value\(index) dictionaryRepresentation]]")
+                                    ObjCIR.stmt("return [[NSDictionary alloc]initWithDictionary:[self.value\(index) dictionaryObjectRepresentation]]")
                                     ]}
                             case .reference:
                                 return ObjCIR.caseStmt(self.internalTypeEnumName + ObjCADTRenderer.objectName(schemaObj.schema)) {[
-                                    ObjCIR.stmt("return [[NSDictionary alloc]initWithDictionary:[self.value\(index) dictionaryRepresentation]]")
+                                    ObjCIR.stmt("return [[NSDictionary alloc]initWithDictionary:[self.value\(index) dictionaryObjectRepresentation]]")
                                     ]}
                             case .float:
                                 return ObjCIR.caseStmt(self.internalTypeEnumName + ObjCADTRenderer.objectName(schemaObj.schema)) {[
@@ -137,11 +137,11 @@ struct ObjCADTRenderer: ObjCFileRenderer {
                                     ]}
                             case .array(itemType: _):
                                 return ObjCIR.caseStmt(self.internalTypeEnumName + ObjCADTRenderer.objectName(schemaObj.schema)) {[
-                                    ObjCIR.stmt("return [[NSDictionary alloc]initWithDictionary:[self.value\(index) dictionaryRepresentation]]")
+                                    ObjCIR.stmt("return [[NSDictionary alloc]initWithDictionary:[self.value\(index) dictionaryObjectRepresentation]]")
                                     ]}
                             case .set(itemType: _):
                                 return ObjCIR.caseStmt(self.internalTypeEnumName + ObjCADTRenderer.objectName(schemaObj.schema)) {[
-                                    ObjCIR.stmt("return [[NSDictionary alloc]initWithDictionary:[self.value\(index) dictionaryRepresentation]]")
+                                    ObjCIR.stmt("return [[NSDictionary alloc]initWithDictionary:[self.value\(index) dictionaryObjectRepresentation]]")
                                     ]}
                             case .map(valueType: _):
                                 return ObjCIR.caseStmt(self.internalTypeEnumName + ObjCADTRenderer.objectName(schemaObj.schema)) {[
@@ -229,7 +229,7 @@ struct ObjCADTRenderer: ObjCFileRenderer {
                                     (.privateM, self.renderIsEqual()),
                                     (.publicM, self.renderIsEqualToClass()),
                                     (.privateM, self.renderHash()),
-                                    (.publicM, self.renderDictionaryRepresentation())
+                                    (.publicM, self.renderDictionaryObjectRepresentation())
                                     ],
                                  properties: [],
                                  protocols: protocols),

--- a/Sources/Core/ObjectiveCDictionaryExtension.swift
+++ b/Sources/Core/ObjectiveCDictionaryExtension.swift
@@ -16,10 +16,10 @@ extension ObjCModelRenderer {
                 [renderAddObjectStatement(param, schemaObj.schema, dictionary)]
             }
         }.joined(separator: "\n")
-        return ObjCIR.method("- (NSDictionary *)dictionaryRepresentation") {[
+        return ObjCIR.method("- (NSDictionary *)dictionaryObjectRepresentation") {[
             "NSMutableDictionary *\(dictionary) = " +
                 (self.isBaseClass ? "[[NSMutableDictionary alloc] initWithCapacity:\(self.properties.count)];" :
-                    "[[super dictionaryRepresentation] mutableCopy];"),
+                    "[[super dictionaryObjectRepresentation] mutableCopy];"),
             props,
             "return \(dictionary);"
         ]}
@@ -69,7 +69,7 @@ extension ObjCFileRenderer {
         case .object:
             return
                 ObjCIR.ifElseStmt("\(propIVarName) != nil") {[
-                    "[\(dictionary) setObject:[\(propIVarName) dictionaryRepresentation] forKey:@\"\(param)\"];"
+                    "[\(dictionary) setObject:[\(propIVarName) dictionaryObjectRepresentation] forKey:@\"\(param)\"];"
                 ]} {[
                     "[\(dictionary) setObject:[NSNull null] forKey:@\"\(param)\"];"
                 ]}
@@ -115,7 +115,7 @@ extension ObjCFileRenderer {
             func createCollection(destCollection: String, processObject: String, collectionSchema: Schema, collectionCounter: Int = 0) -> String {
                 switch collectionSchema {
                 case .reference, .object, .oneOf(types: _):
-                    return "[\(destCollection) addObject:[\(processObject) dictionaryRepresentation]];"
+                    return "[\(destCollection) addObject:[\(processObject) dictionaryObjectRepresentation]];"
                 case .array(itemType: let type), .set(itemType: let type):
                     let currentResult = "result\(collectionCounter)"
                     let parentResult = "result\(collectionCounter-1)"
@@ -194,7 +194,7 @@ extension ObjCFileRenderer {
                     "NSMutableDictionary *items\(counter) = [NSMutableDictionary new];",
                     ObjCIR.forStmt("id key in \(propIVarName)") { [
                         ObjCIR.ifStmt("[\(propIVarName) objectForKey:key] != (id)kCFNull") { [
-                            "[items\(counter) setObject:[[\(propIVarName) objectForKey:key] dictionaryRepresentation] forKey:key];"
+                            "[items\(counter) setObject:[[\(propIVarName) objectForKey:key] dictionaryObjectRepresentation] forKey:key];"
                         ]}
                     ]},
                     "[\(dictionary) setObject:items\(counter) forKey: @\"\(propIVarName)\" ];"
@@ -213,7 +213,7 @@ extension ObjCFileRenderer {
                     ObjCIR.switchStmt("\(propIVarName).internalType") {
                         avTypes.enumerated().map { (_, schema) -> ObjCIR.SwitchCase in
                             return ObjCIR.caseStmt(self.className+propIVarName.snakeCaseToCamelCase()+"InternalType"+ObjCADTRenderer.objectName(schema)) {[
-                                    "[\(dictionary) setObject:[\(propIVarName) dictionaryRepresentation] forKey:@\"\(param)\"];"
+                                    "[\(dictionary) setObject:[\(propIVarName) dictionaryObjectRepresentation] forKey:@\"\(param)\"];"
                                 ]}
                         }
                     }


### PR DESCRIPTION
Foundation has a `dictionaryRepresentation` method already, so Plank's is conflicting with that one. This PR renames it to `dictionaryObjectRepresentation` to address https://github.com/pinterest/plank/issues/90.