### PR TITLE
Add autocorrect step to Swiftlint

### DIFF
--- a/Utility/lint.sh
+++ b/Utility/lint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if which swiftlint >/dev/null; then
+    swiftlint autocorrect
     LINT_ERRS=`swiftlint lint --reporter emoji --quiet`
     if [[ $LINT_ERRS != "" ]]; then
         echo "Error: Fix lint errors from swiftlint"

--- a/plank.xcodeproj/project.pbxproj
+++ b/plank.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_29 /* Build configuration list for PBXNativeTarget "Core" */;
 			buildPhases = (
-				812A69CC1E53D00E006A510E /* ShellScript */,
+				812A69CC1E53D00E006A510E /* Run Swiftlint */,
 				OBJ_32 /* Sources */,
 				OBJ_40 /* Frameworks */,
 			);
@@ -308,13 +308,14 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		812A69CC1E53D00E006A510E /* ShellScript */ = {
+		812A69CC1E53D00E006A510E /* Run Swiftlint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Run Swiftlint";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/plank.xcodeproj/project.pbxproj
+++ b/plank.xcodeproj/project.pbxproj
@@ -319,7 +319,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if which swiftlint >/dev/null; then\nswiftlint autocorrect\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Some Swiftlint rules like "no whitespaces at an empty line" does not play nice with Xcode and having to fix all of this can become quit annoying.

What about letting Swiftlint doing that for us in the Swiftlint build step.