### PR TITLE
Enumeration of schema properties should occur in a specific order 

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -57,30 +57,23 @@ struct BoardDirtyProperties {
         return self;
     }
         {
-            __unsafe_unretained id value = modelDictionary[@"name"]; // Collection will retain.
+            __unsafe_unretained id value = modelDictionary[@"contributors"]; // Collection will retain.
             if (value != nil) {
                 if (value != (id)kCFNull) {
-                    self->_name = [value copy];
+                    NSArray *items = value;
+                    NSMutableSet *result0 = [NSMutableSet setWithCapacity:items.count];
+                    for (id obj0 in items) {
+                        if (obj0 != (id)kCFNull) {
+                            id tmp0 = nil;
+                            tmp0 = [User modelObjectWithDictionary:obj0];
+                            if (tmp0 != nil) {
+                                [result0 addObject:tmp0];
+                            }
+                        }
+                    }
+                    self->_contributors = result0;
                 }
-                self->_boardDirtyProperties.BoardDirtyPropertyName = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"id"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_identifier = [value copy];
-                }
-                self->_boardDirtyProperties.BoardDirtyPropertyIdentifier = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"image"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_image = [Image modelObjectWithDictionary:value];
-                }
-                self->_boardDirtyProperties.BoardDirtyPropertyImage = 1;
+                self->_boardDirtyProperties.BoardDirtyPropertyContributors = 1;
             }
         }
         {
@@ -102,35 +95,6 @@ struct BoardDirtyProperties {
             }
         }
         {
-            __unsafe_unretained id value = modelDictionary[@"contributors"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    NSArray *items = value;
-                    NSMutableSet *result0 = [NSMutableSet setWithCapacity:items.count];
-                    for (id obj0 in items) {
-                        if (obj0 != (id)kCFNull) {
-                            id tmp0 = nil;
-                            tmp0 = [User modelObjectWithDictionary:obj0];
-                            if (tmp0 != nil) {
-                                [result0 addObject:tmp0];
-                            }
-                        }
-                    }
-                    self->_contributors = result0;
-                }
-                self->_boardDirtyProperties.BoardDirtyPropertyContributors = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"description"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_descriptionText = [value copy];
-                }
-                self->_boardDirtyProperties.BoardDirtyPropertyDescriptionText = 1;
-            }
-        }
-        {
             __unsafe_unretained id value = modelDictionary[@"creator"]; // Collection will retain.
             if (value != nil) {
                 if (value != (id)kCFNull) {
@@ -144,6 +108,42 @@ struct BoardDirtyProperties {
                     self->_creator = result0;
                 }
                 self->_boardDirtyProperties.BoardDirtyPropertyCreator = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"description"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_descriptionText = [value copy];
+                }
+                self->_boardDirtyProperties.BoardDirtyPropertyDescriptionText = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"id"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_identifier = [value copy];
+                }
+                self->_boardDirtyProperties.BoardDirtyPropertyIdentifier = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"image"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_image = [Image modelObjectWithDictionary:value];
+                }
+                self->_boardDirtyProperties.BoardDirtyPropertyImage = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"name"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_name = [value copy];
+                }
+                self->_boardDirtyProperties.BoardDirtyPropertyName = 1;
             }
         }
         {
@@ -171,14 +171,14 @@ struct BoardDirtyProperties {
     if (!(self = [super init])) {
         return self;
     }
-    _name = builder.name;
-    _identifier = builder.identifier;
-    _image = builder.image;
+    _contributors = builder.contributors;
     _counts = builder.counts;
     _createdAt = builder.createdAt;
-    _contributors = builder.contributors;
-    _descriptionText = builder.descriptionText;
     _creator = builder.creator;
+    _descriptionText = builder.descriptionText;
+    _identifier = builder.identifier;
+    _image = builder.image;
+    _name = builder.name;
     _url = builder.url;
     _boardDirtyProperties = builder.boardDirtyProperties;
     if ([self class] == [Board class]) {
@@ -192,14 +192,8 @@ struct BoardDirtyProperties {
     NSMutableArray *descriptionFields = [NSMutableArray arrayWithCapacity:9];
     [descriptionFields addObject:parentDebugDescription];
     struct BoardDirtyProperties props = _boardDirtyProperties;
-    if (props.BoardDirtyPropertyName) {
-        [descriptionFields addObject:[@"_name = " stringByAppendingFormat:@"%@", _name]];
-    }
-    if (props.BoardDirtyPropertyIdentifier) {
-        [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", _identifier]];
-    }
-    if (props.BoardDirtyPropertyImage) {
-        [descriptionFields addObject:[@"_image = " stringByAppendingFormat:@"%@", _image]];
+    if (props.BoardDirtyPropertyContributors) {
+        [descriptionFields addObject:[@"_contributors = " stringByAppendingFormat:@"%@", _contributors]];
     }
     if (props.BoardDirtyPropertyCounts) {
         [descriptionFields addObject:[@"_counts = " stringByAppendingFormat:@"%@", _counts]];
@@ -207,14 +201,20 @@ struct BoardDirtyProperties {
     if (props.BoardDirtyPropertyCreatedAt) {
         [descriptionFields addObject:[@"_createdAt = " stringByAppendingFormat:@"%@", _createdAt]];
     }
-    if (props.BoardDirtyPropertyContributors) {
-        [descriptionFields addObject:[@"_contributors = " stringByAppendingFormat:@"%@", _contributors]];
+    if (props.BoardDirtyPropertyCreator) {
+        [descriptionFields addObject:[@"_creator = " stringByAppendingFormat:@"%@", _creator]];
     }
     if (props.BoardDirtyPropertyDescriptionText) {
         [descriptionFields addObject:[@"_descriptionText = " stringByAppendingFormat:@"%@", _descriptionText]];
     }
-    if (props.BoardDirtyPropertyCreator) {
-        [descriptionFields addObject:[@"_creator = " stringByAppendingFormat:@"%@", _creator]];
+    if (props.BoardDirtyPropertyIdentifier) {
+        [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", _identifier]];
+    }
+    if (props.BoardDirtyPropertyImage) {
+        [descriptionFields addObject:[@"_image = " stringByAppendingFormat:@"%@", _image]];
+    }
+    if (props.BoardDirtyPropertyName) {
+        [descriptionFields addObject:[@"_name = " stringByAppendingFormat:@"%@", _name]];
     }
     if (props.BoardDirtyPropertyUrl) {
         [descriptionFields addObject:[@"_url = " stringByAppendingFormat:@"%@", _url]];
@@ -242,14 +242,14 @@ struct BoardDirtyProperties {
 {
     return (
         (anObject != nil) &&
-        (_name == anObject.name || [_name isEqualToString:anObject.name]) &&
-        (_identifier == anObject.identifier || [_identifier isEqualToString:anObject.identifier]) &&
-        (_image == anObject.image || [_image isEqual:anObject.image]) &&
+        (_contributors == anObject.contributors || [_contributors isEqualToSet:anObject.contributors]) &&
         (_counts == anObject.counts || [_counts isEqualToDictionary:anObject.counts]) &&
         (_createdAt == anObject.createdAt || [_createdAt isEqualToDate:anObject.createdAt]) &&
-        (_contributors == anObject.contributors || [_contributors isEqualToSet:anObject.contributors]) &&
-        (_descriptionText == anObject.descriptionText || [_descriptionText isEqualToString:anObject.descriptionText]) &&
         (_creator == anObject.creator || [_creator isEqualToDictionary:anObject.creator]) &&
+        (_descriptionText == anObject.descriptionText || [_descriptionText isEqualToString:anObject.descriptionText]) &&
+        (_identifier == anObject.identifier || [_identifier isEqualToString:anObject.identifier]) &&
+        (_image == anObject.image || [_image isEqual:anObject.image]) &&
+        (_name == anObject.name || [_name isEqualToString:anObject.name]) &&
         (_url == anObject.url || [_url isEqual:anObject.url])
     );
 }
@@ -257,14 +257,14 @@ struct BoardDirtyProperties {
 {
     NSUInteger subhashes[] = {
         17,
-        [_name hash],
-        [_identifier hash],
-        [_image hash],
+        [_contributors hash],
         [_counts hash],
         [_createdAt hash],
-        [_contributors hash],
-        [_descriptionText hash],
         [_creator hash],
+        [_descriptionText hash],
+        [_identifier hash],
+        [_image hash],
+        [_name hash],
         [_url hash]
     };
     return PINIntegerArrayHash(subhashes, sizeof(subhashes) / sizeof(subhashes[0]));
@@ -295,23 +295,23 @@ struct BoardDirtyProperties {
     if (!(self = [super init])) {
         return self;
     }
-    _name = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"name"];
-    _identifier = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"id"];
-    _image = [aDecoder decodeObjectOfClass:[Image class] forKey:@"image"];
+    _contributors = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSSet class], [User class]]] forKey:@"contributors"];
     _counts = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSNumber class]]] forKey:@"counts"];
     _createdAt = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"created_at"];
-    _contributors = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSSet class], [User class]]] forKey:@"contributors"];
-    _descriptionText = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"description"];
     _creator = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSString class]]] forKey:@"creator"];
+    _descriptionText = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"description"];
+    _identifier = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"id"];
+    _image = [aDecoder decodeObjectOfClass:[Image class] forKey:@"image"];
+    _name = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"name"];
     _url = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"url"];
-    _boardDirtyProperties.BoardDirtyPropertyName = [aDecoder decodeIntForKey:@"name_dirty_property"] & 0x1;
-    _boardDirtyProperties.BoardDirtyPropertyIdentifier = [aDecoder decodeIntForKey:@"id_dirty_property"] & 0x1;
-    _boardDirtyProperties.BoardDirtyPropertyImage = [aDecoder decodeIntForKey:@"image_dirty_property"] & 0x1;
+    _boardDirtyProperties.BoardDirtyPropertyContributors = [aDecoder decodeIntForKey:@"contributors_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyCounts = [aDecoder decodeIntForKey:@"counts_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyCreatedAt = [aDecoder decodeIntForKey:@"created_at_dirty_property"] & 0x1;
-    _boardDirtyProperties.BoardDirtyPropertyContributors = [aDecoder decodeIntForKey:@"contributors_dirty_property"] & 0x1;
-    _boardDirtyProperties.BoardDirtyPropertyDescriptionText = [aDecoder decodeIntForKey:@"description_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyCreator = [aDecoder decodeIntForKey:@"creator_dirty_property"] & 0x1;
+    _boardDirtyProperties.BoardDirtyPropertyDescriptionText = [aDecoder decodeIntForKey:@"description_dirty_property"] & 0x1;
+    _boardDirtyProperties.BoardDirtyPropertyIdentifier = [aDecoder decodeIntForKey:@"id_dirty_property"] & 0x1;
+    _boardDirtyProperties.BoardDirtyPropertyImage = [aDecoder decodeIntForKey:@"image_dirty_property"] & 0x1;
+    _boardDirtyProperties.BoardDirtyPropertyName = [aDecoder decodeIntForKey:@"name_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyUrl = [aDecoder decodeIntForKey:@"url_dirty_property"] & 0x1;
     if ([self class] == [Board class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(PlankModelInitTypeDefault) }];
@@ -320,23 +320,23 @@ struct BoardDirtyProperties {
 }
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
-    [aCoder encodeObject:self.name forKey:@"name"];
-    [aCoder encodeObject:self.identifier forKey:@"id"];
-    [aCoder encodeObject:self.image forKey:@"image"];
+    [aCoder encodeObject:self.contributors forKey:@"contributors"];
     [aCoder encodeObject:self.counts forKey:@"counts"];
     [aCoder encodeObject:self.createdAt forKey:@"created_at"];
-    [aCoder encodeObject:self.contributors forKey:@"contributors"];
-    [aCoder encodeObject:self.descriptionText forKey:@"description"];
     [aCoder encodeObject:self.creator forKey:@"creator"];
+    [aCoder encodeObject:self.descriptionText forKey:@"description"];
+    [aCoder encodeObject:self.identifier forKey:@"id"];
+    [aCoder encodeObject:self.image forKey:@"image"];
+    [aCoder encodeObject:self.name forKey:@"name"];
     [aCoder encodeObject:self.url forKey:@"url"];
-    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyName forKey:@"name_dirty_property"];
-    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyIdentifier forKey:@"id_dirty_property"];
-    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyImage forKey:@"image_dirty_property"];
+    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyContributors forKey:@"contributors_dirty_property"];
     [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyCounts forKey:@"counts_dirty_property"];
     [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyCreatedAt forKey:@"created_at_dirty_property"];
-    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyContributors forKey:@"contributors_dirty_property"];
-    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyDescriptionText forKey:@"description_dirty_property"];
     [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyCreator forKey:@"creator_dirty_property"];
+    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyDescriptionText forKey:@"description_dirty_property"];
+    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyIdentifier forKey:@"id_dirty_property"];
+    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyImage forKey:@"image_dirty_property"];
+    [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyName forKey:@"name_dirty_property"];
     [aCoder encodeInt:_boardDirtyProperties.BoardDirtyPropertyUrl forKey:@"url_dirty_property"];
 }
 @end
@@ -349,14 +349,8 @@ struct BoardDirtyProperties {
         return self;
     }
     struct BoardDirtyProperties boardDirtyProperties = modelObject.boardDirtyProperties;
-    if (boardDirtyProperties.BoardDirtyPropertyName) {
-        _name = modelObject.name;
-    }
-    if (boardDirtyProperties.BoardDirtyPropertyIdentifier) {
-        _identifier = modelObject.identifier;
-    }
-    if (boardDirtyProperties.BoardDirtyPropertyImage) {
-        _image = modelObject.image;
+    if (boardDirtyProperties.BoardDirtyPropertyContributors) {
+        _contributors = modelObject.contributors;
     }
     if (boardDirtyProperties.BoardDirtyPropertyCounts) {
         _counts = modelObject.counts;
@@ -364,14 +358,20 @@ struct BoardDirtyProperties {
     if (boardDirtyProperties.BoardDirtyPropertyCreatedAt) {
         _createdAt = modelObject.createdAt;
     }
-    if (boardDirtyProperties.BoardDirtyPropertyContributors) {
-        _contributors = modelObject.contributors;
+    if (boardDirtyProperties.BoardDirtyPropertyCreator) {
+        _creator = modelObject.creator;
     }
     if (boardDirtyProperties.BoardDirtyPropertyDescriptionText) {
         _descriptionText = modelObject.descriptionText;
     }
-    if (boardDirtyProperties.BoardDirtyPropertyCreator) {
-        _creator = modelObject.creator;
+    if (boardDirtyProperties.BoardDirtyPropertyIdentifier) {
+        _identifier = modelObject.identifier;
+    }
+    if (boardDirtyProperties.BoardDirtyPropertyImage) {
+        _image = modelObject.image;
+    }
+    if (boardDirtyProperties.BoardDirtyPropertyName) {
+        _name = modelObject.name;
     }
     if (boardDirtyProperties.BoardDirtyPropertyUrl) {
         _url = modelObject.url;
@@ -387,8 +387,20 @@ struct BoardDirtyProperties {
 {
     NSParameterAssert(modelObject);
     BoardBuilder *builder = self;
-    if (modelObject.boardDirtyProperties.BoardDirtyPropertyName) {
-        builder.name = modelObject.name;
+    if (modelObject.boardDirtyProperties.BoardDirtyPropertyContributors) {
+        builder.contributors = modelObject.contributors;
+    }
+    if (modelObject.boardDirtyProperties.BoardDirtyPropertyCounts) {
+        builder.counts = modelObject.counts;
+    }
+    if (modelObject.boardDirtyProperties.BoardDirtyPropertyCreatedAt) {
+        builder.createdAt = modelObject.createdAt;
+    }
+    if (modelObject.boardDirtyProperties.BoardDirtyPropertyCreator) {
+        builder.creator = modelObject.creator;
+    }
+    if (modelObject.boardDirtyProperties.BoardDirtyPropertyDescriptionText) {
+        builder.descriptionText = modelObject.descriptionText;
     }
     if (modelObject.boardDirtyProperties.BoardDirtyPropertyIdentifier) {
         builder.identifier = modelObject.identifier;
@@ -401,39 +413,17 @@ struct BoardDirtyProperties {
             builder.image = value;
         }
     }
-    if (modelObject.boardDirtyProperties.BoardDirtyPropertyCounts) {
-        builder.counts = modelObject.counts;
-    }
-    if (modelObject.boardDirtyProperties.BoardDirtyPropertyCreatedAt) {
-        builder.createdAt = modelObject.createdAt;
-    }
-    if (modelObject.boardDirtyProperties.BoardDirtyPropertyContributors) {
-        builder.contributors = modelObject.contributors;
-    }
-    if (modelObject.boardDirtyProperties.BoardDirtyPropertyDescriptionText) {
-        builder.descriptionText = modelObject.descriptionText;
-    }
-    if (modelObject.boardDirtyProperties.BoardDirtyPropertyCreator) {
-        builder.creator = modelObject.creator;
+    if (modelObject.boardDirtyProperties.BoardDirtyPropertyName) {
+        builder.name = modelObject.name;
     }
     if (modelObject.boardDirtyProperties.BoardDirtyPropertyUrl) {
         builder.url = modelObject.url;
     }
 }
-- (void)setName:(NSString *)name
+- (void)setContributors:(NSSet<User *> *)contributors
 {
-    _name = name;
-    _boardDirtyProperties.BoardDirtyPropertyName = 1;
-}
-- (void)setIdentifier:(NSString *)identifier
-{
-    _identifier = identifier;
-    _boardDirtyProperties.BoardDirtyPropertyIdentifier = 1;
-}
-- (void)setImage:(Image *)image
-{
-    _image = image;
-    _boardDirtyProperties.BoardDirtyPropertyImage = 1;
+    _contributors = contributors;
+    _boardDirtyProperties.BoardDirtyPropertyContributors = 1;
 }
 - (void)setCounts:(NSDictionary<NSString *, NSNumber /* Integer */ *> *)counts
 {
@@ -445,20 +435,30 @@ struct BoardDirtyProperties {
     _createdAt = createdAt;
     _boardDirtyProperties.BoardDirtyPropertyCreatedAt = 1;
 }
-- (void)setContributors:(NSSet<User *> *)contributors
+- (void)setCreator:(NSDictionary<NSString *, NSString *> *)creator
 {
-    _contributors = contributors;
-    _boardDirtyProperties.BoardDirtyPropertyContributors = 1;
+    _creator = creator;
+    _boardDirtyProperties.BoardDirtyPropertyCreator = 1;
 }
 - (void)setDescriptionText:(NSString *)descriptionText
 {
     _descriptionText = descriptionText;
     _boardDirtyProperties.BoardDirtyPropertyDescriptionText = 1;
 }
-- (void)setCreator:(NSDictionary<NSString *, NSString *> *)creator
+- (void)setIdentifier:(NSString *)identifier
 {
-    _creator = creator;
-    _boardDirtyProperties.BoardDirtyPropertyCreator = 1;
+    _identifier = identifier;
+    _boardDirtyProperties.BoardDirtyPropertyIdentifier = 1;
+}
+- (void)setImage:(Image *)image
+{
+    _image = image;
+    _boardDirtyProperties.BoardDirtyPropertyImage = 1;
+}
+- (void)setName:(NSString *)name
+{
+    _name = name;
+    _boardDirtyProperties.BoardDirtyPropertyName = 1;
 }
 - (void)setUrl:(NSURL *)url
 {

--- a/Examples/Cocoa/Sources/Objective_C/Pin.m
+++ b/Examples/Cocoa/Sources/Objective_C/Pin.m
@@ -70,8 +70,8 @@
 {
     NSUInteger subhashes[] = {
         17,
-        [_value0 hash],
         (NSUInteger)_internalType,
+        [_value0 hash],
         [_value1 hash]
     };
     return PINIntegerArrayHash(subhashes, sizeof(subhashes) / sizeof(subhashes[0]));
@@ -91,15 +91,15 @@
     if (!(self = [super init])) {
         return self;
     }
-    _value0 = [aDecoder decodeObjectOfClass:[Board class] forKey:@"value0"];
     _internalType = [aDecoder decodeIntegerForKey:@"internal_type"];
+    _value0 = [aDecoder decodeObjectOfClass:[Board class] forKey:@"value0"];
     _value1 = [aDecoder decodeObjectOfClass:[User class] forKey:@"value1"];
     return self;
 }
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
-    [aCoder encodeObject:self.value0 forKey:@"value0"];
     [aCoder encodeInteger:self.internalType forKey:@"internal_type"];
+    [aCoder encodeObject:self.value0 forKey:@"value0"];
     [aCoder encodeObject:self.value1 forKey:@"value1"];
 }
 @end
@@ -158,85 +158,6 @@ struct PinDirtyProperties {
         return self;
     }
         {
-            __unsafe_unretained id value = modelDictionary[@"note"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_note = [value copy];
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyNote = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"media"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    NSDictionary *items0 = value;
-                    NSMutableDictionary *result0 = [NSMutableDictionary dictionaryWithCapacity:items0.count];
-                    [items0 enumerateKeysAndObjectsUsingBlock:^(NSString *  _Nonnull key0, id  _Nonnull obj0, __unused BOOL * _Nonnull stop0){
-                        if (obj0 != nil && obj0 != (id)kCFNull) {
-                            result0[key0] = [obj0 copy];
-                        }
-                    }];
-                    self->_media = result0;
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyMedia = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"counts"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_counts = value;
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyCounts = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"description"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_descriptionText = [value copy];
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyDescriptionText = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"creator"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    NSDictionary *items0 = value;
-                    NSMutableDictionary *result0 = [NSMutableDictionary dictionaryWithCapacity:items0.count];
-                    [items0 enumerateKeysAndObjectsUsingBlock:^(NSString *  _Nonnull key0, id  _Nonnull obj0, __unused BOOL * _Nonnull stop0){
-                        if (obj0 != nil && obj0 != (id)kCFNull) {
-                            result0[key0] = [User modelObjectWithDictionary:obj0];
-                        }
-                    }];
-                    self->_creator = result0;
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyCreator = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"tags"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    NSArray *items = value;
-                    NSMutableArray *result0 = [NSMutableArray arrayWithCapacity:items.count];
-                    for (id obj0 in items) {
-                        if (obj0 != (id)kCFNull) {
-                            id tmp0 = nil;
-                            tmp0 = obj0;
-                            if (tmp0 != nil) {
-                                [result0 addObject:tmp0];
-                            }
-                        }
-                    }
-                    self->_tags = result0;
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyTags = 1;
-            }
-        }
-        {
             __unsafe_unretained id value = modelDictionary[@"attribution"]; // Collection will retain.
             if (value != nil) {
                 if (value != (id)kCFNull) {
@@ -250,69 +171,6 @@ struct PinDirtyProperties {
                     self->_attribution = result0;
                 }
                 self->_pinDirtyProperties.PinDirtyPropertyAttribution = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"board"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_board = [Board modelObjectWithDictionary:value];
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyBoard = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"visual_search_attrs"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_visualSearchAttrs = value;
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"color"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_color = [value copy];
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyColor = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"link"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_link = [NSURL URLWithString:value];
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyLink = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"id"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_identifier = [value copy];
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyIdentifier = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"image"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_image = [Image modelObjectWithDictionary:value];
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyImage = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"created_at"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_createdAt = [[NSValueTransformer valueTransformerForName:kPlankDateValueTransformerKey] transformedValue:value];
-                }
-                self->_pinDirtyProperties.PinDirtyPropertyCreatedAt = 1;
             }
         }
         {
@@ -341,12 +199,154 @@ struct PinDirtyProperties {
             }
         }
         {
+            __unsafe_unretained id value = modelDictionary[@"board"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_board = [Board modelObjectWithDictionary:value];
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyBoard = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"color"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_color = [value copy];
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyColor = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"counts"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_counts = value;
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyCounts = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"created_at"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_createdAt = [[NSValueTransformer valueTransformerForName:kPlankDateValueTransformerKey] transformedValue:value];
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyCreatedAt = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"creator"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    NSDictionary *items0 = value;
+                    NSMutableDictionary *result0 = [NSMutableDictionary dictionaryWithCapacity:items0.count];
+                    [items0 enumerateKeysAndObjectsUsingBlock:^(NSString *  _Nonnull key0, id  _Nonnull obj0, __unused BOOL * _Nonnull stop0){
+                        if (obj0 != nil && obj0 != (id)kCFNull) {
+                            result0[key0] = [User modelObjectWithDictionary:obj0];
+                        }
+                    }];
+                    self->_creator = result0;
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyCreator = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"description"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_descriptionText = [value copy];
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyDescriptionText = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"id"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_identifier = [value copy];
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyIdentifier = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"image"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_image = [Image modelObjectWithDictionary:value];
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyImage = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"link"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_link = [NSURL URLWithString:value];
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyLink = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"media"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    NSDictionary *items0 = value;
+                    NSMutableDictionary *result0 = [NSMutableDictionary dictionaryWithCapacity:items0.count];
+                    [items0 enumerateKeysAndObjectsUsingBlock:^(NSString *  _Nonnull key0, id  _Nonnull obj0, __unused BOOL * _Nonnull stop0){
+                        if (obj0 != nil && obj0 != (id)kCFNull) {
+                            result0[key0] = [obj0 copy];
+                        }
+                    }];
+                    self->_media = result0;
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyMedia = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"note"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_note = [value copy];
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyNote = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"tags"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    NSArray *items = value;
+                    NSMutableArray *result0 = [NSMutableArray arrayWithCapacity:items.count];
+                    for (id obj0 in items) {
+                        if (obj0 != (id)kCFNull) {
+                            id tmp0 = nil;
+                            tmp0 = obj0;
+                            if (tmp0 != nil) {
+                                [result0 addObject:tmp0];
+                            }
+                        }
+                    }
+                    self->_tags = result0;
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyTags = 1;
+            }
+        }
+        {
             __unsafe_unretained id value = modelDictionary[@"url"]; // Collection will retain.
             if (value != nil) {
                 if (value != (id)kCFNull) {
                     self->_url = [NSURL URLWithString:value];
                 }
                 self->_pinDirtyProperties.PinDirtyPropertyUrl = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"visual_search_attrs"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_visualSearchAttrs = value;
+                }
+                self->_pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs = 1;
             }
         }
     if ([self class] == [Pin class]) {
@@ -365,22 +365,22 @@ struct PinDirtyProperties {
     if (!(self = [super init])) {
         return self;
     }
-    _note = builder.note;
-    _media = builder.media;
-    _counts = builder.counts;
-    _descriptionText = builder.descriptionText;
-    _creator = builder.creator;
-    _tags = builder.tags;
     _attribution = builder.attribution;
+    _attributionObjects = builder.attributionObjects;
     _board = builder.board;
-    _visualSearchAttrs = builder.visualSearchAttrs;
     _color = builder.color;
-    _link = builder.link;
+    _counts = builder.counts;
+    _createdAt = builder.createdAt;
+    _creator = builder.creator;
+    _descriptionText = builder.descriptionText;
     _identifier = builder.identifier;
     _image = builder.image;
-    _createdAt = builder.createdAt;
-    _attributionObjects = builder.attributionObjects;
+    _link = builder.link;
+    _media = builder.media;
+    _note = builder.note;
+    _tags = builder.tags;
     _url = builder.url;
+    _visualSearchAttrs = builder.visualSearchAttrs;
     _pinDirtyProperties = builder.pinDirtyProperties;
     if ([self class] == [Pin class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(initType) }];
@@ -393,38 +393,29 @@ struct PinDirtyProperties {
     NSMutableArray *descriptionFields = [NSMutableArray arrayWithCapacity:16];
     [descriptionFields addObject:parentDebugDescription];
     struct PinDirtyProperties props = _pinDirtyProperties;
-    if (props.PinDirtyPropertyNote) {
-        [descriptionFields addObject:[@"_note = " stringByAppendingFormat:@"%@", _note]];
-    }
-    if (props.PinDirtyPropertyMedia) {
-        [descriptionFields addObject:[@"_media = " stringByAppendingFormat:@"%@", _media]];
-    }
-    if (props.PinDirtyPropertyCounts) {
-        [descriptionFields addObject:[@"_counts = " stringByAppendingFormat:@"%@", _counts]];
-    }
-    if (props.PinDirtyPropertyDescriptionText) {
-        [descriptionFields addObject:[@"_descriptionText = " stringByAppendingFormat:@"%@", _descriptionText]];
-    }
-    if (props.PinDirtyPropertyCreator) {
-        [descriptionFields addObject:[@"_creator = " stringByAppendingFormat:@"%@", _creator]];
-    }
-    if (props.PinDirtyPropertyTags) {
-        [descriptionFields addObject:[@"_tags = " stringByAppendingFormat:@"%@", _tags]];
-    }
     if (props.PinDirtyPropertyAttribution) {
         [descriptionFields addObject:[@"_attribution = " stringByAppendingFormat:@"%@", _attribution]];
+    }
+    if (props.PinDirtyPropertyAttributionObjects) {
+        [descriptionFields addObject:[@"_attributionObjects = " stringByAppendingFormat:@"%@", _attributionObjects]];
     }
     if (props.PinDirtyPropertyBoard) {
         [descriptionFields addObject:[@"_board = " stringByAppendingFormat:@"%@", _board]];
     }
-    if (props.PinDirtyPropertyVisualSearchAttrs) {
-        [descriptionFields addObject:[@"_visualSearchAttrs = " stringByAppendingFormat:@"%@", _visualSearchAttrs]];
-    }
     if (props.PinDirtyPropertyColor) {
         [descriptionFields addObject:[@"_color = " stringByAppendingFormat:@"%@", _color]];
     }
-    if (props.PinDirtyPropertyLink) {
-        [descriptionFields addObject:[@"_link = " stringByAppendingFormat:@"%@", _link]];
+    if (props.PinDirtyPropertyCounts) {
+        [descriptionFields addObject:[@"_counts = " stringByAppendingFormat:@"%@", _counts]];
+    }
+    if (props.PinDirtyPropertyCreatedAt) {
+        [descriptionFields addObject:[@"_createdAt = " stringByAppendingFormat:@"%@", _createdAt]];
+    }
+    if (props.PinDirtyPropertyCreator) {
+        [descriptionFields addObject:[@"_creator = " stringByAppendingFormat:@"%@", _creator]];
+    }
+    if (props.PinDirtyPropertyDescriptionText) {
+        [descriptionFields addObject:[@"_descriptionText = " stringByAppendingFormat:@"%@", _descriptionText]];
     }
     if (props.PinDirtyPropertyIdentifier) {
         [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", _identifier]];
@@ -432,14 +423,23 @@ struct PinDirtyProperties {
     if (props.PinDirtyPropertyImage) {
         [descriptionFields addObject:[@"_image = " stringByAppendingFormat:@"%@", _image]];
     }
-    if (props.PinDirtyPropertyCreatedAt) {
-        [descriptionFields addObject:[@"_createdAt = " stringByAppendingFormat:@"%@", _createdAt]];
+    if (props.PinDirtyPropertyLink) {
+        [descriptionFields addObject:[@"_link = " stringByAppendingFormat:@"%@", _link]];
     }
-    if (props.PinDirtyPropertyAttributionObjects) {
-        [descriptionFields addObject:[@"_attributionObjects = " stringByAppendingFormat:@"%@", _attributionObjects]];
+    if (props.PinDirtyPropertyMedia) {
+        [descriptionFields addObject:[@"_media = " stringByAppendingFormat:@"%@", _media]];
+    }
+    if (props.PinDirtyPropertyNote) {
+        [descriptionFields addObject:[@"_note = " stringByAppendingFormat:@"%@", _note]];
+    }
+    if (props.PinDirtyPropertyTags) {
+        [descriptionFields addObject:[@"_tags = " stringByAppendingFormat:@"%@", _tags]];
     }
     if (props.PinDirtyPropertyUrl) {
         [descriptionFields addObject:[@"_url = " stringByAppendingFormat:@"%@", _url]];
+    }
+    if (props.PinDirtyPropertyVisualSearchAttrs) {
+        [descriptionFields addObject:[@"_visualSearchAttrs = " stringByAppendingFormat:@"%@", _visualSearchAttrs]];
     }
     return [NSString stringWithFormat:@"Pin = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
@@ -464,44 +464,44 @@ struct PinDirtyProperties {
 {
     return (
         (anObject != nil) &&
-        (_note == anObject.note || [_note isEqualToString:anObject.note]) &&
-        (_media == anObject.media || [_media isEqualToDictionary:anObject.media]) &&
-        (_counts == anObject.counts || [_counts isEqualToDictionary:anObject.counts]) &&
-        (_descriptionText == anObject.descriptionText || [_descriptionText isEqualToString:anObject.descriptionText]) &&
-        (_creator == anObject.creator || [_creator isEqualToDictionary:anObject.creator]) &&
-        (_tags == anObject.tags || [_tags isEqualToArray:anObject.tags]) &&
         (_attribution == anObject.attribution || [_attribution isEqualToDictionary:anObject.attribution]) &&
+        (_attributionObjects == anObject.attributionObjects || [_attributionObjects isEqualToArray:anObject.attributionObjects]) &&
         (_board == anObject.board || [_board isEqual:anObject.board]) &&
-        (_visualSearchAttrs == anObject.visualSearchAttrs || [_visualSearchAttrs isEqualToDictionary:anObject.visualSearchAttrs]) &&
         (_color == anObject.color || [_color isEqualToString:anObject.color]) &&
-        (_link == anObject.link || [_link isEqual:anObject.link]) &&
+        (_counts == anObject.counts || [_counts isEqualToDictionary:anObject.counts]) &&
+        (_createdAt == anObject.createdAt || [_createdAt isEqualToDate:anObject.createdAt]) &&
+        (_creator == anObject.creator || [_creator isEqualToDictionary:anObject.creator]) &&
+        (_descriptionText == anObject.descriptionText || [_descriptionText isEqualToString:anObject.descriptionText]) &&
         (_identifier == anObject.identifier || [_identifier isEqualToString:anObject.identifier]) &&
         (_image == anObject.image || [_image isEqual:anObject.image]) &&
-        (_createdAt == anObject.createdAt || [_createdAt isEqualToDate:anObject.createdAt]) &&
-        (_attributionObjects == anObject.attributionObjects || [_attributionObjects isEqualToArray:anObject.attributionObjects]) &&
-        (_url == anObject.url || [_url isEqual:anObject.url])
+        (_link == anObject.link || [_link isEqual:anObject.link]) &&
+        (_media == anObject.media || [_media isEqualToDictionary:anObject.media]) &&
+        (_note == anObject.note || [_note isEqualToString:anObject.note]) &&
+        (_tags == anObject.tags || [_tags isEqualToArray:anObject.tags]) &&
+        (_url == anObject.url || [_url isEqual:anObject.url]) &&
+        (_visualSearchAttrs == anObject.visualSearchAttrs || [_visualSearchAttrs isEqualToDictionary:anObject.visualSearchAttrs])
     );
 }
 - (NSUInteger)hash
 {
     NSUInteger subhashes[] = {
         17,
-        [_note hash],
-        [_media hash],
-        [_counts hash],
-        [_descriptionText hash],
-        [_creator hash],
-        [_tags hash],
         [_attribution hash],
+        [_attributionObjects hash],
         [_board hash],
-        [_visualSearchAttrs hash],
         [_color hash],
-        [_link hash],
+        [_counts hash],
+        [_createdAt hash],
+        [_creator hash],
+        [_descriptionText hash],
         [_identifier hash],
         [_image hash],
-        [_createdAt hash],
-        [_attributionObjects hash],
-        [_url hash]
+        [_link hash],
+        [_media hash],
+        [_note hash],
+        [_tags hash],
+        [_url hash],
+        [_visualSearchAttrs hash]
     };
     return PINIntegerArrayHash(subhashes, sizeof(subhashes) / sizeof(subhashes[0]));
 }
@@ -531,38 +531,38 @@ struct PinDirtyProperties {
     if (!(self = [super init])) {
         return self;
     }
-    _note = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"note"];
-    _media = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSString class]]] forKey:@"media"];
-    _counts = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSNumber class]]] forKey:@"counts"];
-    _descriptionText = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"description"];
-    _creator = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [User class]]] forKey:@"creator"];
-    _tags = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSArray class]]] forKey:@"tags"];
     _attribution = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSString class]]] forKey:@"attribution"];
+    _attributionObjects = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[Board class], [User class], [NSArray class]]] forKey:@"attribution_objects"];
     _board = [aDecoder decodeObjectOfClass:[Board class] forKey:@"board"];
-    _visualSearchAttrs = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"visual_search_attrs"];
     _color = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"color"];
-    _link = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"link"];
+    _counts = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSNumber class]]] forKey:@"counts"];
+    _createdAt = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"created_at"];
+    _creator = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [User class]]] forKey:@"creator"];
+    _descriptionText = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"description"];
     _identifier = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"id"];
     _image = [aDecoder decodeObjectOfClass:[Image class] forKey:@"image"];
-    _createdAt = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"created_at"];
-    _attributionObjects = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[Board class], [User class], [NSArray class]]] forKey:@"attribution_objects"];
+    _link = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"link"];
+    _media = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSString class]]] forKey:@"media"];
+    _note = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"note"];
+    _tags = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSArray class]]] forKey:@"tags"];
     _url = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"url"];
-    _pinDirtyProperties.PinDirtyPropertyNote = [aDecoder decodeIntForKey:@"note_dirty_property"] & 0x1;
-    _pinDirtyProperties.PinDirtyPropertyMedia = [aDecoder decodeIntForKey:@"media_dirty_property"] & 0x1;
-    _pinDirtyProperties.PinDirtyPropertyCounts = [aDecoder decodeIntForKey:@"counts_dirty_property"] & 0x1;
-    _pinDirtyProperties.PinDirtyPropertyDescriptionText = [aDecoder decodeIntForKey:@"description_dirty_property"] & 0x1;
-    _pinDirtyProperties.PinDirtyPropertyCreator = [aDecoder decodeIntForKey:@"creator_dirty_property"] & 0x1;
-    _pinDirtyProperties.PinDirtyPropertyTags = [aDecoder decodeIntForKey:@"tags_dirty_property"] & 0x1;
+    _visualSearchAttrs = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"visual_search_attrs"];
     _pinDirtyProperties.PinDirtyPropertyAttribution = [aDecoder decodeIntForKey:@"attribution_dirty_property"] & 0x1;
+    _pinDirtyProperties.PinDirtyPropertyAttributionObjects = [aDecoder decodeIntForKey:@"attribution_objects_dirty_property"] & 0x1;
     _pinDirtyProperties.PinDirtyPropertyBoard = [aDecoder decodeIntForKey:@"board_dirty_property"] & 0x1;
-    _pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs = [aDecoder decodeIntForKey:@"visual_search_attrs_dirty_property"] & 0x1;
     _pinDirtyProperties.PinDirtyPropertyColor = [aDecoder decodeIntForKey:@"color_dirty_property"] & 0x1;
-    _pinDirtyProperties.PinDirtyPropertyLink = [aDecoder decodeIntForKey:@"link_dirty_property"] & 0x1;
+    _pinDirtyProperties.PinDirtyPropertyCounts = [aDecoder decodeIntForKey:@"counts_dirty_property"] & 0x1;
+    _pinDirtyProperties.PinDirtyPropertyCreatedAt = [aDecoder decodeIntForKey:@"created_at_dirty_property"] & 0x1;
+    _pinDirtyProperties.PinDirtyPropertyCreator = [aDecoder decodeIntForKey:@"creator_dirty_property"] & 0x1;
+    _pinDirtyProperties.PinDirtyPropertyDescriptionText = [aDecoder decodeIntForKey:@"description_dirty_property"] & 0x1;
     _pinDirtyProperties.PinDirtyPropertyIdentifier = [aDecoder decodeIntForKey:@"id_dirty_property"] & 0x1;
     _pinDirtyProperties.PinDirtyPropertyImage = [aDecoder decodeIntForKey:@"image_dirty_property"] & 0x1;
-    _pinDirtyProperties.PinDirtyPropertyCreatedAt = [aDecoder decodeIntForKey:@"created_at_dirty_property"] & 0x1;
-    _pinDirtyProperties.PinDirtyPropertyAttributionObjects = [aDecoder decodeIntForKey:@"attribution_objects_dirty_property"] & 0x1;
+    _pinDirtyProperties.PinDirtyPropertyLink = [aDecoder decodeIntForKey:@"link_dirty_property"] & 0x1;
+    _pinDirtyProperties.PinDirtyPropertyMedia = [aDecoder decodeIntForKey:@"media_dirty_property"] & 0x1;
+    _pinDirtyProperties.PinDirtyPropertyNote = [aDecoder decodeIntForKey:@"note_dirty_property"] & 0x1;
+    _pinDirtyProperties.PinDirtyPropertyTags = [aDecoder decodeIntForKey:@"tags_dirty_property"] & 0x1;
     _pinDirtyProperties.PinDirtyPropertyUrl = [aDecoder decodeIntForKey:@"url_dirty_property"] & 0x1;
+    _pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs = [aDecoder decodeIntForKey:@"visual_search_attrs_dirty_property"] & 0x1;
     if ([self class] == [Pin class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(PlankModelInitTypeDefault) }];
     }
@@ -570,38 +570,38 @@ struct PinDirtyProperties {
 }
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
-    [aCoder encodeObject:self.note forKey:@"note"];
-    [aCoder encodeObject:self.media forKey:@"media"];
-    [aCoder encodeObject:self.counts forKey:@"counts"];
-    [aCoder encodeObject:self.descriptionText forKey:@"description"];
-    [aCoder encodeObject:self.creator forKey:@"creator"];
-    [aCoder encodeObject:self.tags forKey:@"tags"];
     [aCoder encodeObject:self.attribution forKey:@"attribution"];
+    [aCoder encodeObject:self.attributionObjects forKey:@"attribution_objects"];
     [aCoder encodeObject:self.board forKey:@"board"];
-    [aCoder encodeObject:self.visualSearchAttrs forKey:@"visual_search_attrs"];
     [aCoder encodeObject:self.color forKey:@"color"];
-    [aCoder encodeObject:self.link forKey:@"link"];
+    [aCoder encodeObject:self.counts forKey:@"counts"];
+    [aCoder encodeObject:self.createdAt forKey:@"created_at"];
+    [aCoder encodeObject:self.creator forKey:@"creator"];
+    [aCoder encodeObject:self.descriptionText forKey:@"description"];
     [aCoder encodeObject:self.identifier forKey:@"id"];
     [aCoder encodeObject:self.image forKey:@"image"];
-    [aCoder encodeObject:self.createdAt forKey:@"created_at"];
-    [aCoder encodeObject:self.attributionObjects forKey:@"attribution_objects"];
+    [aCoder encodeObject:self.link forKey:@"link"];
+    [aCoder encodeObject:self.media forKey:@"media"];
+    [aCoder encodeObject:self.note forKey:@"note"];
+    [aCoder encodeObject:self.tags forKey:@"tags"];
     [aCoder encodeObject:self.url forKey:@"url"];
-    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyNote forKey:@"note_dirty_property"];
-    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyMedia forKey:@"media_dirty_property"];
-    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyCounts forKey:@"counts_dirty_property"];
-    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyDescriptionText forKey:@"description_dirty_property"];
-    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyCreator forKey:@"creator_dirty_property"];
-    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyTags forKey:@"tags_dirty_property"];
+    [aCoder encodeObject:self.visualSearchAttrs forKey:@"visual_search_attrs"];
     [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyAttribution forKey:@"attribution_dirty_property"];
+    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyAttributionObjects forKey:@"attribution_objects_dirty_property"];
     [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyBoard forKey:@"board_dirty_property"];
-    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs forKey:@"visual_search_attrs_dirty_property"];
     [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyColor forKey:@"color_dirty_property"];
-    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyLink forKey:@"link_dirty_property"];
+    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyCounts forKey:@"counts_dirty_property"];
+    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyCreatedAt forKey:@"created_at_dirty_property"];
+    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyCreator forKey:@"creator_dirty_property"];
+    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyDescriptionText forKey:@"description_dirty_property"];
     [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyIdentifier forKey:@"id_dirty_property"];
     [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyImage forKey:@"image_dirty_property"];
-    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyCreatedAt forKey:@"created_at_dirty_property"];
-    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyAttributionObjects forKey:@"attribution_objects_dirty_property"];
+    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyLink forKey:@"link_dirty_property"];
+    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyMedia forKey:@"media_dirty_property"];
+    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyNote forKey:@"note_dirty_property"];
+    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyTags forKey:@"tags_dirty_property"];
     [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyUrl forKey:@"url_dirty_property"];
+    [aCoder encodeInt:_pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs forKey:@"visual_search_attrs_dirty_property"];
 }
 @end
 
@@ -613,38 +613,29 @@ struct PinDirtyProperties {
         return self;
     }
     struct PinDirtyProperties pinDirtyProperties = modelObject.pinDirtyProperties;
-    if (pinDirtyProperties.PinDirtyPropertyNote) {
-        _note = modelObject.note;
-    }
-    if (pinDirtyProperties.PinDirtyPropertyMedia) {
-        _media = modelObject.media;
-    }
-    if (pinDirtyProperties.PinDirtyPropertyCounts) {
-        _counts = modelObject.counts;
-    }
-    if (pinDirtyProperties.PinDirtyPropertyDescriptionText) {
-        _descriptionText = modelObject.descriptionText;
-    }
-    if (pinDirtyProperties.PinDirtyPropertyCreator) {
-        _creator = modelObject.creator;
-    }
-    if (pinDirtyProperties.PinDirtyPropertyTags) {
-        _tags = modelObject.tags;
-    }
     if (pinDirtyProperties.PinDirtyPropertyAttribution) {
         _attribution = modelObject.attribution;
+    }
+    if (pinDirtyProperties.PinDirtyPropertyAttributionObjects) {
+        _attributionObjects = modelObject.attributionObjects;
     }
     if (pinDirtyProperties.PinDirtyPropertyBoard) {
         _board = modelObject.board;
     }
-    if (pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs) {
-        _visualSearchAttrs = modelObject.visualSearchAttrs;
-    }
     if (pinDirtyProperties.PinDirtyPropertyColor) {
         _color = modelObject.color;
     }
-    if (pinDirtyProperties.PinDirtyPropertyLink) {
-        _link = modelObject.link;
+    if (pinDirtyProperties.PinDirtyPropertyCounts) {
+        _counts = modelObject.counts;
+    }
+    if (pinDirtyProperties.PinDirtyPropertyCreatedAt) {
+        _createdAt = modelObject.createdAt;
+    }
+    if (pinDirtyProperties.PinDirtyPropertyCreator) {
+        _creator = modelObject.creator;
+    }
+    if (pinDirtyProperties.PinDirtyPropertyDescriptionText) {
+        _descriptionText = modelObject.descriptionText;
     }
     if (pinDirtyProperties.PinDirtyPropertyIdentifier) {
         _identifier = modelObject.identifier;
@@ -652,14 +643,23 @@ struct PinDirtyProperties {
     if (pinDirtyProperties.PinDirtyPropertyImage) {
         _image = modelObject.image;
     }
-    if (pinDirtyProperties.PinDirtyPropertyCreatedAt) {
-        _createdAt = modelObject.createdAt;
+    if (pinDirtyProperties.PinDirtyPropertyLink) {
+        _link = modelObject.link;
     }
-    if (pinDirtyProperties.PinDirtyPropertyAttributionObjects) {
-        _attributionObjects = modelObject.attributionObjects;
+    if (pinDirtyProperties.PinDirtyPropertyMedia) {
+        _media = modelObject.media;
+    }
+    if (pinDirtyProperties.PinDirtyPropertyNote) {
+        _note = modelObject.note;
+    }
+    if (pinDirtyProperties.PinDirtyPropertyTags) {
+        _tags = modelObject.tags;
     }
     if (pinDirtyProperties.PinDirtyPropertyUrl) {
         _url = modelObject.url;
+    }
+    if (pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs) {
+        _visualSearchAttrs = modelObject.visualSearchAttrs;
     }
     _pinDirtyProperties = pinDirtyProperties;
     return self;
@@ -672,26 +672,11 @@ struct PinDirtyProperties {
 {
     NSParameterAssert(modelObject);
     PinBuilder *builder = self;
-    if (modelObject.pinDirtyProperties.PinDirtyPropertyNote) {
-        builder.note = modelObject.note;
-    }
-    if (modelObject.pinDirtyProperties.PinDirtyPropertyMedia) {
-        builder.media = modelObject.media;
-    }
-    if (modelObject.pinDirtyProperties.PinDirtyPropertyCounts) {
-        builder.counts = modelObject.counts;
-    }
-    if (modelObject.pinDirtyProperties.PinDirtyPropertyDescriptionText) {
-        builder.descriptionText = modelObject.descriptionText;
-    }
-    if (modelObject.pinDirtyProperties.PinDirtyPropertyCreator) {
-        builder.creator = modelObject.creator;
-    }
-    if (modelObject.pinDirtyProperties.PinDirtyPropertyTags) {
-        builder.tags = modelObject.tags;
-    }
     if (modelObject.pinDirtyProperties.PinDirtyPropertyAttribution) {
         builder.attribution = modelObject.attribution;
+    }
+    if (modelObject.pinDirtyProperties.PinDirtyPropertyAttributionObjects) {
+        builder.attributionObjects = modelObject.attributionObjects;
     }
     if (modelObject.pinDirtyProperties.PinDirtyPropertyBoard) {
         id value = modelObject.board;
@@ -705,14 +690,20 @@ struct PinDirtyProperties {
             builder.board = nil;
         }
     }
-    if (modelObject.pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs) {
-        builder.visualSearchAttrs = modelObject.visualSearchAttrs;
-    }
     if (modelObject.pinDirtyProperties.PinDirtyPropertyColor) {
         builder.color = modelObject.color;
     }
-    if (modelObject.pinDirtyProperties.PinDirtyPropertyLink) {
-        builder.link = modelObject.link;
+    if (modelObject.pinDirtyProperties.PinDirtyPropertyCounts) {
+        builder.counts = modelObject.counts;
+    }
+    if (modelObject.pinDirtyProperties.PinDirtyPropertyCreatedAt) {
+        builder.createdAt = modelObject.createdAt;
+    }
+    if (modelObject.pinDirtyProperties.PinDirtyPropertyCreator) {
+        builder.creator = modelObject.creator;
+    }
+    if (modelObject.pinDirtyProperties.PinDirtyPropertyDescriptionText) {
+        builder.descriptionText = modelObject.descriptionText;
     }
     if (modelObject.pinDirtyProperties.PinDirtyPropertyIdentifier) {
         builder.identifier = modelObject.identifier;
@@ -729,70 +720,64 @@ struct PinDirtyProperties {
             builder.image = nil;
         }
     }
-    if (modelObject.pinDirtyProperties.PinDirtyPropertyCreatedAt) {
-        builder.createdAt = modelObject.createdAt;
+    if (modelObject.pinDirtyProperties.PinDirtyPropertyLink) {
+        builder.link = modelObject.link;
     }
-    if (modelObject.pinDirtyProperties.PinDirtyPropertyAttributionObjects) {
-        builder.attributionObjects = modelObject.attributionObjects;
+    if (modelObject.pinDirtyProperties.PinDirtyPropertyMedia) {
+        builder.media = modelObject.media;
+    }
+    if (modelObject.pinDirtyProperties.PinDirtyPropertyNote) {
+        builder.note = modelObject.note;
+    }
+    if (modelObject.pinDirtyProperties.PinDirtyPropertyTags) {
+        builder.tags = modelObject.tags;
     }
     if (modelObject.pinDirtyProperties.PinDirtyPropertyUrl) {
         builder.url = modelObject.url;
     }
-}
-- (void)setNote:(NSString *)note
-{
-    _note = note;
-    _pinDirtyProperties.PinDirtyPropertyNote = 1;
-}
-- (void)setMedia:(NSDictionary<NSString *, NSString *> *)media
-{
-    _media = media;
-    _pinDirtyProperties.PinDirtyPropertyMedia = 1;
-}
-- (void)setCounts:(NSDictionary<NSString *, NSNumber /* Integer */ *> *)counts
-{
-    _counts = counts;
-    _pinDirtyProperties.PinDirtyPropertyCounts = 1;
-}
-- (void)setDescriptionText:(NSString *)descriptionText
-{
-    _descriptionText = descriptionText;
-    _pinDirtyProperties.PinDirtyPropertyDescriptionText = 1;
-}
-- (void)setCreator:(NSDictionary<NSString *, User *> *)creator
-{
-    _creator = creator;
-    _pinDirtyProperties.PinDirtyPropertyCreator = 1;
-}
-- (void)setTags:(NSArray<NSDictionary *> *)tags
-{
-    _tags = tags;
-    _pinDirtyProperties.PinDirtyPropertyTags = 1;
+    if (modelObject.pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs) {
+        builder.visualSearchAttrs = modelObject.visualSearchAttrs;
+    }
 }
 - (void)setAttribution:(NSDictionary<NSString *, NSString *> *)attribution
 {
     _attribution = attribution;
     _pinDirtyProperties.PinDirtyPropertyAttribution = 1;
 }
+- (void)setAttributionObjects:(NSArray<PinAttributionObjects *> *)attributionObjects
+{
+    _attributionObjects = attributionObjects;
+    _pinDirtyProperties.PinDirtyPropertyAttributionObjects = 1;
+}
 - (void)setBoard:(Board *)board
 {
     _board = board;
     _pinDirtyProperties.PinDirtyPropertyBoard = 1;
-}
-- (void)setVisualSearchAttrs:(NSDictionary *)visualSearchAttrs
-{
-    _visualSearchAttrs = visualSearchAttrs;
-    _pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs = 1;
 }
 - (void)setColor:(NSString *)color
 {
     _color = color;
     _pinDirtyProperties.PinDirtyPropertyColor = 1;
 }
-- (void)setLink:(NSURL *)link
+- (void)setCounts:(NSDictionary<NSString *, NSNumber /* Integer */ *> *)counts
 {
-    _link = link;
-    _pinDirtyProperties.PinDirtyPropertyLink = 1;
+    _counts = counts;
+    _pinDirtyProperties.PinDirtyPropertyCounts = 1;
+}
+- (void)setCreatedAt:(NSDate *)createdAt
+{
+    _createdAt = createdAt;
+    _pinDirtyProperties.PinDirtyPropertyCreatedAt = 1;
+}
+- (void)setCreator:(NSDictionary<NSString *, User *> *)creator
+{
+    _creator = creator;
+    _pinDirtyProperties.PinDirtyPropertyCreator = 1;
+}
+- (void)setDescriptionText:(NSString *)descriptionText
+{
+    _descriptionText = descriptionText;
+    _pinDirtyProperties.PinDirtyPropertyDescriptionText = 1;
 }
 - (void)setIdentifier:(NSString *)identifier
 {
@@ -804,19 +789,34 @@ struct PinDirtyProperties {
     _image = image;
     _pinDirtyProperties.PinDirtyPropertyImage = 1;
 }
-- (void)setCreatedAt:(NSDate *)createdAt
+- (void)setLink:(NSURL *)link
 {
-    _createdAt = createdAt;
-    _pinDirtyProperties.PinDirtyPropertyCreatedAt = 1;
+    _link = link;
+    _pinDirtyProperties.PinDirtyPropertyLink = 1;
 }
-- (void)setAttributionObjects:(NSArray<PinAttributionObjects *> *)attributionObjects
+- (void)setMedia:(NSDictionary<NSString *, NSString *> *)media
 {
-    _attributionObjects = attributionObjects;
-    _pinDirtyProperties.PinDirtyPropertyAttributionObjects = 1;
+    _media = media;
+    _pinDirtyProperties.PinDirtyPropertyMedia = 1;
+}
+- (void)setNote:(NSString *)note
+{
+    _note = note;
+    _pinDirtyProperties.PinDirtyPropertyNote = 1;
+}
+- (void)setTags:(NSArray<NSDictionary *> *)tags
+{
+    _tags = tags;
+    _pinDirtyProperties.PinDirtyPropertyTags = 1;
 }
 - (void)setUrl:(NSURL *)url
 {
     _url = url;
     _pinDirtyProperties.PinDirtyPropertyUrl = 1;
+}
+- (void)setVisualSearchAttrs:(NSDictionary *)visualSearchAttrs
+{
+    _visualSearchAttrs = visualSearchAttrs;
+    _pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs = 1;
 }
 @end

--- a/Examples/Cocoa/Sources/Objective_C/User.m
+++ b/Examples/Cocoa/Sources/Objective_C/User.m
@@ -55,39 +55,12 @@ struct UserDirtyProperties {
         return self;
     }
         {
-            __unsafe_unretained id value = modelDictionary[@"last_name"]; // Collection will retain.
+            __unsafe_unretained id value = modelDictionary[@"bio"]; // Collection will retain.
             if (value != nil) {
                 if (value != (id)kCFNull) {
-                    self->_lastName = [value copy];
+                    self->_bio = [value copy];
                 }
-                self->_userDirtyProperties.UserDirtyPropertyLastName = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"id"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_identifier = [value copy];
-                }
-                self->_userDirtyProperties.UserDirtyPropertyIdentifier = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"first_name"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_firstName = [value copy];
-                }
-                self->_userDirtyProperties.UserDirtyPropertyFirstName = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"image"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_image = [Image modelObjectWithDictionary:value];
-                }
-                self->_userDirtyProperties.UserDirtyPropertyImage = 1;
+                self->_userDirtyProperties.UserDirtyPropertyBio = 1;
             }
         }
         {
@@ -109,21 +82,48 @@ struct UserDirtyProperties {
             }
         }
         {
+            __unsafe_unretained id value = modelDictionary[@"first_name"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_firstName = [value copy];
+                }
+                self->_userDirtyProperties.UserDirtyPropertyFirstName = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"id"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_identifier = [value copy];
+                }
+                self->_userDirtyProperties.UserDirtyPropertyIdentifier = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"image"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_image = [Image modelObjectWithDictionary:value];
+                }
+                self->_userDirtyProperties.UserDirtyPropertyImage = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"last_name"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_lastName = [value copy];
+                }
+                self->_userDirtyProperties.UserDirtyPropertyLastName = 1;
+            }
+        }
+        {
             __unsafe_unretained id value = modelDictionary[@"username"]; // Collection will retain.
             if (value != nil) {
                 if (value != (id)kCFNull) {
                     self->_username = [value copy];
                 }
                 self->_userDirtyProperties.UserDirtyPropertyUsername = 1;
-            }
-        }
-        {
-            __unsafe_unretained id value = modelDictionary[@"bio"]; // Collection will retain.
-            if (value != nil) {
-                if (value != (id)kCFNull) {
-                    self->_bio = [value copy];
-                }
-                self->_userDirtyProperties.UserDirtyPropertyBio = 1;
             }
         }
     if ([self class] == [User class]) {
@@ -142,14 +142,14 @@ struct UserDirtyProperties {
     if (!(self = [super init])) {
         return self;
     }
-    _lastName = builder.lastName;
-    _identifier = builder.identifier;
-    _firstName = builder.firstName;
-    _image = builder.image;
+    _bio = builder.bio;
     _counts = builder.counts;
     _createdAt = builder.createdAt;
+    _firstName = builder.firstName;
+    _identifier = builder.identifier;
+    _image = builder.image;
+    _lastName = builder.lastName;
     _username = builder.username;
-    _bio = builder.bio;
     _userDirtyProperties = builder.userDirtyProperties;
     if ([self class] == [User class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(initType) }];
@@ -162,17 +162,8 @@ struct UserDirtyProperties {
     NSMutableArray *descriptionFields = [NSMutableArray arrayWithCapacity:8];
     [descriptionFields addObject:parentDebugDescription];
     struct UserDirtyProperties props = _userDirtyProperties;
-    if (props.UserDirtyPropertyLastName) {
-        [descriptionFields addObject:[@"_lastName = " stringByAppendingFormat:@"%@", _lastName]];
-    }
-    if (props.UserDirtyPropertyIdentifier) {
-        [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", _identifier]];
-    }
-    if (props.UserDirtyPropertyFirstName) {
-        [descriptionFields addObject:[@"_firstName = " stringByAppendingFormat:@"%@", _firstName]];
-    }
-    if (props.UserDirtyPropertyImage) {
-        [descriptionFields addObject:[@"_image = " stringByAppendingFormat:@"%@", _image]];
+    if (props.UserDirtyPropertyBio) {
+        [descriptionFields addObject:[@"_bio = " stringByAppendingFormat:@"%@", _bio]];
     }
     if (props.UserDirtyPropertyCounts) {
         [descriptionFields addObject:[@"_counts = " stringByAppendingFormat:@"%@", _counts]];
@@ -180,11 +171,20 @@ struct UserDirtyProperties {
     if (props.UserDirtyPropertyCreatedAt) {
         [descriptionFields addObject:[@"_createdAt = " stringByAppendingFormat:@"%@", _createdAt]];
     }
+    if (props.UserDirtyPropertyFirstName) {
+        [descriptionFields addObject:[@"_firstName = " stringByAppendingFormat:@"%@", _firstName]];
+    }
+    if (props.UserDirtyPropertyIdentifier) {
+        [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", _identifier]];
+    }
+    if (props.UserDirtyPropertyImage) {
+        [descriptionFields addObject:[@"_image = " stringByAppendingFormat:@"%@", _image]];
+    }
+    if (props.UserDirtyPropertyLastName) {
+        [descriptionFields addObject:[@"_lastName = " stringByAppendingFormat:@"%@", _lastName]];
+    }
     if (props.UserDirtyPropertyUsername) {
         [descriptionFields addObject:[@"_username = " stringByAppendingFormat:@"%@", _username]];
-    }
-    if (props.UserDirtyPropertyBio) {
-        [descriptionFields addObject:[@"_bio = " stringByAppendingFormat:@"%@", _bio]];
     }
     return [NSString stringWithFormat:@"User = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
@@ -209,28 +209,28 @@ struct UserDirtyProperties {
 {
     return (
         (anObject != nil) &&
-        (_lastName == anObject.lastName || [_lastName isEqualToString:anObject.lastName]) &&
-        (_identifier == anObject.identifier || [_identifier isEqualToString:anObject.identifier]) &&
-        (_firstName == anObject.firstName || [_firstName isEqualToString:anObject.firstName]) &&
-        (_image == anObject.image || [_image isEqual:anObject.image]) &&
+        (_bio == anObject.bio || [_bio isEqualToString:anObject.bio]) &&
         (_counts == anObject.counts || [_counts isEqualToDictionary:anObject.counts]) &&
         (_createdAt == anObject.createdAt || [_createdAt isEqualToDate:anObject.createdAt]) &&
-        (_username == anObject.username || [_username isEqualToString:anObject.username]) &&
-        (_bio == anObject.bio || [_bio isEqualToString:anObject.bio])
+        (_firstName == anObject.firstName || [_firstName isEqualToString:anObject.firstName]) &&
+        (_identifier == anObject.identifier || [_identifier isEqualToString:anObject.identifier]) &&
+        (_image == anObject.image || [_image isEqual:anObject.image]) &&
+        (_lastName == anObject.lastName || [_lastName isEqualToString:anObject.lastName]) &&
+        (_username == anObject.username || [_username isEqualToString:anObject.username])
     );
 }
 - (NSUInteger)hash
 {
     NSUInteger subhashes[] = {
         17,
-        [_lastName hash],
-        [_identifier hash],
-        [_firstName hash],
-        [_image hash],
+        [_bio hash],
         [_counts hash],
         [_createdAt hash],
-        [_username hash],
-        [_bio hash]
+        [_firstName hash],
+        [_identifier hash],
+        [_image hash],
+        [_lastName hash],
+        [_username hash]
     };
     return PINIntegerArrayHash(subhashes, sizeof(subhashes) / sizeof(subhashes[0]));
 }
@@ -260,22 +260,22 @@ struct UserDirtyProperties {
     if (!(self = [super init])) {
         return self;
     }
-    _lastName = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"last_name"];
-    _identifier = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"id"];
-    _firstName = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"first_name"];
-    _image = [aDecoder decodeObjectOfClass:[Image class] forKey:@"image"];
+    _bio = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"bio"];
     _counts = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSNumber class]]] forKey:@"counts"];
     _createdAt = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"created_at"];
+    _firstName = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"first_name"];
+    _identifier = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"id"];
+    _image = [aDecoder decodeObjectOfClass:[Image class] forKey:@"image"];
+    _lastName = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"last_name"];
     _username = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"username"];
-    _bio = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"bio"];
-    _userDirtyProperties.UserDirtyPropertyLastName = [aDecoder decodeIntForKey:@"last_name_dirty_property"] & 0x1;
-    _userDirtyProperties.UserDirtyPropertyIdentifier = [aDecoder decodeIntForKey:@"id_dirty_property"] & 0x1;
-    _userDirtyProperties.UserDirtyPropertyFirstName = [aDecoder decodeIntForKey:@"first_name_dirty_property"] & 0x1;
-    _userDirtyProperties.UserDirtyPropertyImage = [aDecoder decodeIntForKey:@"image_dirty_property"] & 0x1;
+    _userDirtyProperties.UserDirtyPropertyBio = [aDecoder decodeIntForKey:@"bio_dirty_property"] & 0x1;
     _userDirtyProperties.UserDirtyPropertyCounts = [aDecoder decodeIntForKey:@"counts_dirty_property"] & 0x1;
     _userDirtyProperties.UserDirtyPropertyCreatedAt = [aDecoder decodeIntForKey:@"created_at_dirty_property"] & 0x1;
+    _userDirtyProperties.UserDirtyPropertyFirstName = [aDecoder decodeIntForKey:@"first_name_dirty_property"] & 0x1;
+    _userDirtyProperties.UserDirtyPropertyIdentifier = [aDecoder decodeIntForKey:@"id_dirty_property"] & 0x1;
+    _userDirtyProperties.UserDirtyPropertyImage = [aDecoder decodeIntForKey:@"image_dirty_property"] & 0x1;
+    _userDirtyProperties.UserDirtyPropertyLastName = [aDecoder decodeIntForKey:@"last_name_dirty_property"] & 0x1;
     _userDirtyProperties.UserDirtyPropertyUsername = [aDecoder decodeIntForKey:@"username_dirty_property"] & 0x1;
-    _userDirtyProperties.UserDirtyPropertyBio = [aDecoder decodeIntForKey:@"bio_dirty_property"] & 0x1;
     if ([self class] == [User class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(PlankModelInitTypeDefault) }];
     }
@@ -283,22 +283,22 @@ struct UserDirtyProperties {
 }
 - (void)encodeWithCoder:(NSCoder *)aCoder
 {
-    [aCoder encodeObject:self.lastName forKey:@"last_name"];
-    [aCoder encodeObject:self.identifier forKey:@"id"];
-    [aCoder encodeObject:self.firstName forKey:@"first_name"];
-    [aCoder encodeObject:self.image forKey:@"image"];
+    [aCoder encodeObject:self.bio forKey:@"bio"];
     [aCoder encodeObject:self.counts forKey:@"counts"];
     [aCoder encodeObject:self.createdAt forKey:@"created_at"];
+    [aCoder encodeObject:self.firstName forKey:@"first_name"];
+    [aCoder encodeObject:self.identifier forKey:@"id"];
+    [aCoder encodeObject:self.image forKey:@"image"];
+    [aCoder encodeObject:self.lastName forKey:@"last_name"];
     [aCoder encodeObject:self.username forKey:@"username"];
-    [aCoder encodeObject:self.bio forKey:@"bio"];
-    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyLastName forKey:@"last_name_dirty_property"];
-    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyIdentifier forKey:@"id_dirty_property"];
-    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyFirstName forKey:@"first_name_dirty_property"];
-    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyImage forKey:@"image_dirty_property"];
+    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyBio forKey:@"bio_dirty_property"];
     [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyCounts forKey:@"counts_dirty_property"];
     [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyCreatedAt forKey:@"created_at_dirty_property"];
+    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyFirstName forKey:@"first_name_dirty_property"];
+    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyIdentifier forKey:@"id_dirty_property"];
+    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyImage forKey:@"image_dirty_property"];
+    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyLastName forKey:@"last_name_dirty_property"];
     [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyUsername forKey:@"username_dirty_property"];
-    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyBio forKey:@"bio_dirty_property"];
 }
 @end
 
@@ -310,17 +310,8 @@ struct UserDirtyProperties {
         return self;
     }
     struct UserDirtyProperties userDirtyProperties = modelObject.userDirtyProperties;
-    if (userDirtyProperties.UserDirtyPropertyLastName) {
-        _lastName = modelObject.lastName;
-    }
-    if (userDirtyProperties.UserDirtyPropertyIdentifier) {
-        _identifier = modelObject.identifier;
-    }
-    if (userDirtyProperties.UserDirtyPropertyFirstName) {
-        _firstName = modelObject.firstName;
-    }
-    if (userDirtyProperties.UserDirtyPropertyImage) {
-        _image = modelObject.image;
+    if (userDirtyProperties.UserDirtyPropertyBio) {
+        _bio = modelObject.bio;
     }
     if (userDirtyProperties.UserDirtyPropertyCounts) {
         _counts = modelObject.counts;
@@ -328,11 +319,20 @@ struct UserDirtyProperties {
     if (userDirtyProperties.UserDirtyPropertyCreatedAt) {
         _createdAt = modelObject.createdAt;
     }
+    if (userDirtyProperties.UserDirtyPropertyFirstName) {
+        _firstName = modelObject.firstName;
+    }
+    if (userDirtyProperties.UserDirtyPropertyIdentifier) {
+        _identifier = modelObject.identifier;
+    }
+    if (userDirtyProperties.UserDirtyPropertyImage) {
+        _image = modelObject.image;
+    }
+    if (userDirtyProperties.UserDirtyPropertyLastName) {
+        _lastName = modelObject.lastName;
+    }
     if (userDirtyProperties.UserDirtyPropertyUsername) {
         _username = modelObject.username;
-    }
-    if (userDirtyProperties.UserDirtyPropertyBio) {
-        _bio = modelObject.bio;
     }
     _userDirtyProperties = userDirtyProperties;
     return self;
@@ -345,14 +345,20 @@ struct UserDirtyProperties {
 {
     NSParameterAssert(modelObject);
     UserBuilder *builder = self;
-    if (modelObject.userDirtyProperties.UserDirtyPropertyLastName) {
-        builder.lastName = modelObject.lastName;
+    if (modelObject.userDirtyProperties.UserDirtyPropertyBio) {
+        builder.bio = modelObject.bio;
     }
-    if (modelObject.userDirtyProperties.UserDirtyPropertyIdentifier) {
-        builder.identifier = modelObject.identifier;
+    if (modelObject.userDirtyProperties.UserDirtyPropertyCounts) {
+        builder.counts = modelObject.counts;
+    }
+    if (modelObject.userDirtyProperties.UserDirtyPropertyCreatedAt) {
+        builder.createdAt = modelObject.createdAt;
     }
     if (modelObject.userDirtyProperties.UserDirtyPropertyFirstName) {
         builder.firstName = modelObject.firstName;
+    }
+    if (modelObject.userDirtyProperties.UserDirtyPropertyIdentifier) {
+        builder.identifier = modelObject.identifier;
     }
     if (modelObject.userDirtyProperties.UserDirtyPropertyImage) {
         id value = modelObject.image;
@@ -366,38 +372,17 @@ struct UserDirtyProperties {
             builder.image = nil;
         }
     }
-    if (modelObject.userDirtyProperties.UserDirtyPropertyCounts) {
-        builder.counts = modelObject.counts;
-    }
-    if (modelObject.userDirtyProperties.UserDirtyPropertyCreatedAt) {
-        builder.createdAt = modelObject.createdAt;
+    if (modelObject.userDirtyProperties.UserDirtyPropertyLastName) {
+        builder.lastName = modelObject.lastName;
     }
     if (modelObject.userDirtyProperties.UserDirtyPropertyUsername) {
         builder.username = modelObject.username;
     }
-    if (modelObject.userDirtyProperties.UserDirtyPropertyBio) {
-        builder.bio = modelObject.bio;
-    }
 }
-- (void)setLastName:(NSString *)lastName
+- (void)setBio:(NSString *)bio
 {
-    _lastName = lastName;
-    _userDirtyProperties.UserDirtyPropertyLastName = 1;
-}
-- (void)setIdentifier:(NSString *)identifier
-{
-    _identifier = identifier;
-    _userDirtyProperties.UserDirtyPropertyIdentifier = 1;
-}
-- (void)setFirstName:(NSString *)firstName
-{
-    _firstName = firstName;
-    _userDirtyProperties.UserDirtyPropertyFirstName = 1;
-}
-- (void)setImage:(Image *)image
-{
-    _image = image;
-    _userDirtyProperties.UserDirtyPropertyImage = 1;
+    _bio = bio;
+    _userDirtyProperties.UserDirtyPropertyBio = 1;
 }
 - (void)setCounts:(NSDictionary<NSString *, NSNumber /* Integer */ *> *)counts
 {
@@ -409,14 +394,29 @@ struct UserDirtyProperties {
     _createdAt = createdAt;
     _userDirtyProperties.UserDirtyPropertyCreatedAt = 1;
 }
+- (void)setFirstName:(NSString *)firstName
+{
+    _firstName = firstName;
+    _userDirtyProperties.UserDirtyPropertyFirstName = 1;
+}
+- (void)setIdentifier:(NSString *)identifier
+{
+    _identifier = identifier;
+    _userDirtyProperties.UserDirtyPropertyIdentifier = 1;
+}
+- (void)setImage:(Image *)image
+{
+    _image = image;
+    _userDirtyProperties.UserDirtyPropertyImage = 1;
+}
+- (void)setLastName:(NSString *)lastName
+{
+    _lastName = lastName;
+    _userDirtyProperties.UserDirtyPropertyLastName = 1;
+}
 - (void)setUsername:(NSString *)username
 {
     _username = username;
     _userDirtyProperties.UserDirtyPropertyUsername = 1;
-}
-- (void)setBio:(NSString *)bio
-{
-    _bio = bio;
-    _userDirtyProperties.UserDirtyPropertyBio = 1;
 }
 @end

--- a/Examples/JS/flow/BoardType.js
+++ b/Examples/JS/flow/BoardType.js
@@ -12,14 +12,14 @@ import type { ImageType } from './ImageType.js';
 import type { UserType } from './UserType.js';
 
 export type BoardType = $Shape<{|
-  +name: ?string,
-  +id: ?string,
-  +image: ImageType,
+  +contributors: ?Set<UserType>,
   +counts: ?{ +[string]: number } /* Integer */,
   +created_at: ?PlankDate,
-  +contributors: ?Set<UserType>,
-  +description: ?string,
   +creator: ?{ +[string]: string },
+  +description: ?string,
+  +id: ?string,
+  +image: ImageType,
+  +name: ?string,
   +url: ?PlankURI,
 |}> & {
   id: string

--- a/Examples/JS/flow/PinType.js
+++ b/Examples/JS/flow/PinType.js
@@ -15,22 +15,22 @@ import type { UserType } from './UserType.js';
 export type PinAttributionObjectsType = BoardType | UserType;
 
 export type PinType = $Shape<{|
-  +note: ?string,
-  +media: ?{ +[string]: string },
-  +counts: ?{ +[string]: number } /* Integer */,
-  +description: ?string,
-  +creator: { +[string]: UserType },
-  +tags: ?Array<{}>,
   +attribution: ?{ +[string]: string },
+  +attribution_objects: ?Array<PinAttributionObjectsType>,
   +board: ?BoardType,
-  +visual_search_attrs: ?{},
   +color: ?string,
-  +link: ?PlankURI,
+  +counts: ?{ +[string]: number } /* Integer */,
+  +created_at: PlankDate,
+  +creator: { +[string]: UserType },
+  +description: ?string,
   +id: string,
   +image: ?ImageType,
-  +created_at: PlankDate,
-  +attribution_objects: ?Array<PinAttributionObjectsType>,
+  +link: ?PlankURI,
+  +media: ?{ +[string]: string },
+  +note: ?string,
+  +tags: ?Array<{}>,
   +url: ?PlankURI,
+  +visual_search_attrs: ?{},
 |}> & {
   id: string
 };

--- a/Examples/JS/flow/UserType.js
+++ b/Examples/JS/flow/UserType.js
@@ -11,14 +11,14 @@ import type { PlankDate, PlankURI } from './runtime.flow.js';
 import type { ImageType } from './ImageType.js';
 
 export type UserType = $Shape<{|
-  +last_name: ?string,
-  +id: ?string,
-  +first_name: ?string,
-  +image: ?ImageType,
+  +bio: ?string,
   +counts: ?{ +[string]: number } /* Integer */,
   +created_at: ?PlankDate,
+  +first_name: ?string,
+  +id: ?string,
+  +image: ?ImageType,
+  +last_name: ?string,
   +username: ?string,
-  +bio: ?string,
 |}> & {
   id: string
 };

--- a/Sources/Core/JSFileRenderer.swift
+++ b/Sources/Core/JSFileRenderer.swift
@@ -30,7 +30,9 @@ extension JSFileRenderer {
     }
 
     var properties: [(Parameter, SchemaObjectProperty)] {
-        return self.rootSchema.properties.map { $0 }
+        return self.rootSchema.properties.map { $0 }.sorted(by: { (obj1, obj2) -> Bool in
+            return obj1.0 < obj2.0
+        })
     }
 
     var isBaseClass: Bool {

--- a/Sources/Core/ObjCFileRenderer.swift
+++ b/Sources/Core/ObjCFileRenderer.swift
@@ -31,7 +31,9 @@ extension ObjCFileRenderer {
     }
 
     var properties: [(Parameter, SchemaObjectProperty)] {
-        return self.rootSchema.properties.map { $0 }
+        return self.rootSchema.properties.map { $0 }.sorted(by: { (obj1, obj2) -> Bool in
+            return obj1.0 < obj2.0
+        })
     }
 
     var isBaseClass: Bool {


### PR DESCRIPTION
This is necessary to ensure a stable output. 

There were unexpected changes introduced since the properties were modeled as a dictionary vs an array and enumeration does not guarantee any sort of ordering. This would lead to confusion since regeneration might changes lines that shouldn't have been changed.