### PR TITLE
Align naming logic between Flow and ObjC for enums. Fix naming collis…

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/User.m
+++ b/Examples/Cocoa/Sources/Objective_C/User.m
@@ -13,6 +13,7 @@ struct UserDirtyProperties {
     unsigned int UserDirtyPropertyBio:1;
     unsigned int UserDirtyPropertyCounts:1;
     unsigned int UserDirtyPropertyCreatedAt:1;
+    unsigned int UserDirtyPropertyEmailFrequency:1;
     unsigned int UserDirtyPropertyFirstName:1;
     unsigned int UserDirtyPropertyIdentifier:1;
     unsigned int UserDirtyPropertyImage:1;
@@ -27,6 +28,35 @@ struct UserDirtyProperties {
 @interface UserBuilder ()
 @property (nonatomic, assign, readwrite) struct UserDirtyProperties userDirtyProperties;
 @end
+
+extern NSString * _Nonnull UserEmailFrequencyToString(UserEmailFrequency enumType)
+{
+    switch (enumType) {
+    case UserEmailFrequencyUnset:
+        return @"unset";
+        break;
+    case UserEmailFrequencyImmediate:
+        return @"immediate";
+        break;
+    case UserEmailFrequencyDaily:
+        return @"daily";
+        break;
+    }
+}
+
+extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
+{
+    if ([str isEqualToString:@"unset"]) {
+        return UserEmailFrequencyUnset;
+    }
+    if ([str isEqualToString:@"immediate"]) {
+        return UserEmailFrequencyImmediate;
+    }
+    if ([str isEqualToString:@"daily"]) {
+        return UserEmailFrequencyDaily;
+    }
+    return UserEmailFrequencyUnset;
+}
 
 @implementation User
 + (NSString *)className
@@ -79,6 +109,15 @@ struct UserDirtyProperties {
                     self->_createdAt = [[NSValueTransformer valueTransformerForName:kPlankDateValueTransformerKey] transformedValue:value];
                 }
                 self->_userDirtyProperties.UserDirtyPropertyCreatedAt = 1;
+            }
+        }
+        {
+            __unsafe_unretained id value = modelDictionary[@"email_frequency"]; // Collection will retain.
+            if (value != nil) {
+                if (value != (id)kCFNull) {
+                    self->_emailFrequency = UserEmailFrequencyFromString(value);
+                }
+                self->_userDirtyProperties.UserDirtyPropertyEmailFrequency = 1;
             }
         }
         {
@@ -145,6 +184,7 @@ struct UserDirtyProperties {
     _bio = builder.bio;
     _counts = builder.counts;
     _createdAt = builder.createdAt;
+    _emailFrequency = builder.emailFrequency;
     _firstName = builder.firstName;
     _identifier = builder.identifier;
     _image = builder.image;
@@ -159,7 +199,7 @@ struct UserDirtyProperties {
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
-    NSMutableArray *descriptionFields = [NSMutableArray arrayWithCapacity:8];
+    NSMutableArray *descriptionFields = [NSMutableArray arrayWithCapacity:9];
     [descriptionFields addObject:parentDebugDescription];
     struct UserDirtyProperties props = _userDirtyProperties;
     if (props.UserDirtyPropertyBio) {
@@ -170,6 +210,9 @@ struct UserDirtyProperties {
     }
     if (props.UserDirtyPropertyCreatedAt) {
         [descriptionFields addObject:[@"_createdAt = " stringByAppendingFormat:@"%@", _createdAt]];
+    }
+    if (props.UserDirtyPropertyEmailFrequency) {
+        [descriptionFields addObject:[@"_emailFrequency = " stringByAppendingFormat:@"%@", UserEmailFrequencyToString(_emailFrequency)]];
     }
     if (props.UserDirtyPropertyFirstName) {
         [descriptionFields addObject:[@"_firstName = " stringByAppendingFormat:@"%@", _firstName]];
@@ -209,6 +252,7 @@ struct UserDirtyProperties {
 {
     return (
         (anObject != nil) &&
+        (_emailFrequency == anObject.emailFrequency) &&
         (_bio == anObject.bio || [_bio isEqualToString:anObject.bio]) &&
         (_counts == anObject.counts || [_counts isEqualToDictionary:anObject.counts]) &&
         (_createdAt == anObject.createdAt || [_createdAt isEqualToDate:anObject.createdAt]) &&
@@ -226,6 +270,7 @@ struct UserDirtyProperties {
         [_bio hash],
         [_counts hash],
         [_createdAt hash],
+        (NSUInteger)_emailFrequency,
         [_firstName hash],
         [_identifier hash],
         [_image hash],
@@ -263,6 +308,7 @@ struct UserDirtyProperties {
     _bio = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"bio"];
     _counts = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSNumber class]]] forKey:@"counts"];
     _createdAt = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"created_at"];
+    _emailFrequency = [aDecoder decodeIntegerForKey:@"email_frequency"];
     _firstName = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"first_name"];
     _identifier = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"id"];
     _image = [aDecoder decodeObjectOfClass:[Image class] forKey:@"image"];
@@ -271,6 +317,7 @@ struct UserDirtyProperties {
     _userDirtyProperties.UserDirtyPropertyBio = [aDecoder decodeIntForKey:@"bio_dirty_property"] & 0x1;
     _userDirtyProperties.UserDirtyPropertyCounts = [aDecoder decodeIntForKey:@"counts_dirty_property"] & 0x1;
     _userDirtyProperties.UserDirtyPropertyCreatedAt = [aDecoder decodeIntForKey:@"created_at_dirty_property"] & 0x1;
+    _userDirtyProperties.UserDirtyPropertyEmailFrequency = [aDecoder decodeIntForKey:@"email_frequency_dirty_property"] & 0x1;
     _userDirtyProperties.UserDirtyPropertyFirstName = [aDecoder decodeIntForKey:@"first_name_dirty_property"] & 0x1;
     _userDirtyProperties.UserDirtyPropertyIdentifier = [aDecoder decodeIntForKey:@"id_dirty_property"] & 0x1;
     _userDirtyProperties.UserDirtyPropertyImage = [aDecoder decodeIntForKey:@"image_dirty_property"] & 0x1;
@@ -286,6 +333,7 @@ struct UserDirtyProperties {
     [aCoder encodeObject:self.bio forKey:@"bio"];
     [aCoder encodeObject:self.counts forKey:@"counts"];
     [aCoder encodeObject:self.createdAt forKey:@"created_at"];
+    [aCoder encodeInteger:self.emailFrequency forKey:@"email_frequency"];
     [aCoder encodeObject:self.firstName forKey:@"first_name"];
     [aCoder encodeObject:self.identifier forKey:@"id"];
     [aCoder encodeObject:self.image forKey:@"image"];
@@ -294,6 +342,7 @@ struct UserDirtyProperties {
     [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyBio forKey:@"bio_dirty_property"];
     [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyCounts forKey:@"counts_dirty_property"];
     [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyCreatedAt forKey:@"created_at_dirty_property"];
+    [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyEmailFrequency forKey:@"email_frequency_dirty_property"];
     [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyFirstName forKey:@"first_name_dirty_property"];
     [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyIdentifier forKey:@"id_dirty_property"];
     [aCoder encodeInt:_userDirtyProperties.UserDirtyPropertyImage forKey:@"image_dirty_property"];
@@ -318,6 +367,9 @@ struct UserDirtyProperties {
     }
     if (userDirtyProperties.UserDirtyPropertyCreatedAt) {
         _createdAt = modelObject.createdAt;
+    }
+    if (userDirtyProperties.UserDirtyPropertyEmailFrequency) {
+        _emailFrequency = modelObject.emailFrequency;
     }
     if (userDirtyProperties.UserDirtyPropertyFirstName) {
         _firstName = modelObject.firstName;
@@ -353,6 +405,9 @@ struct UserDirtyProperties {
     }
     if (modelObject.userDirtyProperties.UserDirtyPropertyCreatedAt) {
         builder.createdAt = modelObject.createdAt;
+    }
+    if (modelObject.userDirtyProperties.UserDirtyPropertyEmailFrequency) {
+        builder.emailFrequency = modelObject.emailFrequency;
     }
     if (modelObject.userDirtyProperties.UserDirtyPropertyFirstName) {
         builder.firstName = modelObject.firstName;
@@ -393,6 +448,11 @@ struct UserDirtyProperties {
 {
     _createdAt = [createdAt copy];
     _userDirtyProperties.UserDirtyPropertyCreatedAt = 1;
+}
+- (void)setEmailFrequency:(UserEmailFrequency)emailFrequency
+{
+    _emailFrequency = emailFrequency;
+    _userDirtyProperties.UserDirtyPropertyEmailFrequency = 1;
 }
 - (void)setFirstName:(NSString *)firstName
 {

--- a/Examples/Cocoa/Sources/Objective_C/include/User.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/User.h
@@ -11,17 +11,28 @@
 @class Image;
 @class UserBuilder;
 
+typedef NS_ENUM(NSInteger, UserEmailFrequency) {
+    UserEmailFrequencyUnset /* unset */,
+    UserEmailFrequencyImmediate /* immediate */,
+    UserEmailFrequencyDaily /* daily */
+};
+
+extern NSString * _Nonnull UserEmailFrequencyToString(UserEmailFrequency enumType);
+
+extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str);
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface User : NSObject<NSCopying, NSSecureCoding>
+@property (nullable, nonatomic, copy, readonly) NSString * username;
 @property (nullable, nonatomic, copy, readonly) NSString * lastName;
 @property (nullable, nonatomic, copy, readonly) NSString * identifier;
-@property (nullable, nonatomic, copy, readonly) NSString * firstName;
 @property (nullable, nonatomic, strong, readonly) Image * image;
 @property (nullable, nonatomic, strong, readonly) NSDictionary<NSString *, NSNumber /* Integer */ *> * counts;
 @property (nullable, nonatomic, copy, readonly) NSDate * createdAt;
-@property (nullable, nonatomic, copy, readonly) NSString * username;
+@property (nullable, nonatomic, copy, readonly) NSString * firstName;
 @property (nullable, nonatomic, copy, readonly) NSString * bio;
+@property (nonatomic, assign, readonly) UserEmailFrequency emailFrequency;
 + (NSString *)className;
 + (NSString *)polymorphicTypeIdentifier;
 + (instancetype)modelObjectWithDictionary:(NSDictionary *)dictionary;
@@ -35,14 +46,15 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface UserBuilder : NSObject
+@property (nullable, nonatomic, copy, readwrite) NSString * username;
 @property (nullable, nonatomic, copy, readwrite) NSString * lastName;
 @property (nullable, nonatomic, copy, readwrite) NSString * identifier;
-@property (nullable, nonatomic, copy, readwrite) NSString * firstName;
 @property (nullable, nonatomic, strong, readwrite) Image * image;
 @property (nullable, nonatomic, strong, readwrite) NSDictionary<NSString *, NSNumber /* Integer */ *> * counts;
 @property (nullable, nonatomic, copy, readwrite) NSDate * createdAt;
-@property (nullable, nonatomic, copy, readwrite) NSString * username;
+@property (nullable, nonatomic, copy, readwrite) NSString * firstName;
 @property (nullable, nonatomic, copy, readwrite) NSString * bio;
+@property (nonatomic, assign, readwrite) UserEmailFrequency emailFrequency;
 - (instancetype)initWithModel:(User *)modelObject;
 - (User *)build;
 - (void)mergeWithModel:(User *)modelObject;

--- a/Examples/JS/flow/UserType.js
+++ b/Examples/JS/flow/UserType.js
@@ -10,10 +10,17 @@
 import type { PlankDate, PlankURI } from './runtime.flow.js';
 import type { ImageType } from './ImageType.js';
 
+export type UserEmailFrequency = 
+  | 'unset'
+  | 'immediate'
+  | 'daily'
+;
+
 export type UserType = $Shape<{|
   +bio: ?string,
   +counts: ?{ +[string]: number } /* Integer */,
   +created_at: ?PlankDate,
+  +email_frequency: UserEmailFrequency,
   +first_name: ?string,
   +id: ?string,
   +image: ?ImageType,

--- a/Examples/PDK/user.json
+++ b/Examples/PDK/user.json
@@ -18,6 +18,15 @@
 			"type": "object",
 			"additionalProperties": { "type": "integer" }
 		},
+    "email_frequency" : {
+        "type" : "string",
+        "enum": [
+            { "default" : "unset", "description" : "unset" },
+            { "default" : "immediate", "description" : "immediate" },
+            { "default" : "daily", "description" : "daily" }
+        ],
+        "default" : "unset"
+    },
 		"image": { "$ref": "image.json" }
 	}
 }

--- a/Sources/Core/JSModelRenderer.swift
+++ b/Sources/Core/JSModelRenderer.swift
@@ -42,7 +42,7 @@ public struct JSModelRenderer: JSFileRenderer {
     }
 
     static func enumTypeName(className: String, propertyName: String) -> String {
-        return "\(className)\(propertyName.snakeCaseToCamelCase())Type"
+        return "\(className)\(propertyName.snakeCaseToCamelCase())"
     }
 
     func renderEnumRoots() -> [JSIR.Root] {

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -76,12 +76,7 @@ func enumToStringMethodName(propertyName: String, className: String) -> String {
 }
 
 func enumTypeName(propertyName: String, className: String) -> String {
-    let typeName = "\(className)\(propertyName.snakeCaseToCamelCase())"
-    if typeName.hasSuffix("Type") {
-        return typeName
-    } else {
-        return typeName + "Type"
-    }
+    return "\(className)\(propertyName.snakeCaseToCamelCase())"
 }
 
 extension SchemaObjectRoot {

--- a/Tests/CoreTests/LinuxTestIndex.swift
+++ b/Tests/CoreTests/LinuxTestIndex.swift
@@ -2,10 +2,16 @@
 import XCTest
 
 #if os(Linux)
-// Generated Test Extension for ObjectiveCInitTests
-extension ObjectiveCInitTests {
+// Generated Test Extension for StringExtensionsTests
+extension StringExtensionsTests {
    static var allTests = [
-       ("testOneOfInit", testOneOfInit)
+       ("testUppercaseFirst", testUppercaseFirst),
+       ("testLowercaseFirst", testLowercaseFirst),
+       ("testSuffixSubstring", testSuffixSubstring),
+       ("testSnakeCaseToCamelCase", testSnakeCaseToCamelCase),
+       ("testSnakeCaseToPropertyName", testSnakeCaseToPropertyName),
+       ("testSnakeCaseToCapitalizedPropertyName", testSnakeCaseToCapitalizedPropertyName),
+       ("testReservedKeywordSubstitution", testReservedKeywordSubstitution)
    ]
 }
 // Generated Test Extension for ObjectiveCIRTests
@@ -27,16 +33,10 @@ extension ObjectiveCIRTests {
        ("testIfElseStmt", testIfElseStmt)
    ]
 }
-// Generated Test Extension for StringExtensionsTests
-extension StringExtensionsTests {
+// Generated Test Extension for ObjectiveCInitTests
+extension ObjectiveCInitTests {
    static var allTests = [
-       ("testUppercaseFirst", testUppercaseFirst),
-       ("testLowercaseFirst", testLowercaseFirst),
-       ("testSuffixSubstring", testSuffixSubstring),
-       ("testSnakeCaseToCamelCase", testSnakeCaseToCamelCase),
-       ("testSnakeCaseToPropertyName", testSnakeCaseToPropertyName),
-       ("testSnakeCaseToCapitalizedPropertyName", testSnakeCaseToCapitalizedPropertyName),
-       ("testReservedKeywordSubstitution", testReservedKeywordSubstitution)
+       ("testOneOfInit", testOneOfInit)
    ]
 }
 #endif

--- a/Tests/CoreTests/ObjectiveCIRTests.swift
+++ b/Tests/CoreTests/ObjectiveCIRTests.swift
@@ -22,15 +22,15 @@ class ObjectiveCIRTests: XCTestCase {
     }
 
     func testEnumTypeName() {
-        XCTAssertEqual(enumTypeName(propertyName: "some_prop", className: "class"), "classSomePropType")
+        XCTAssertEqual(enumTypeName(propertyName: "some_prop_type", className: "class"), "classSomePropType")
     }
 
     func testEnumToStringName() {
-        XCTAssertEqual(enumToStringMethodName(propertyName: "some_prop", className: "class"), "classSomePropTypeToString")
+        XCTAssertEqual(enumToStringMethodName(propertyName: "some_prop_type", className: "class"), "classSomePropTypeToString")
     }
 
     func testEnumFromStringName() {
-        XCTAssertEqual(enumFromStringMethodName(propertyName: "some_prop", className: "class"), "classSomePropTypeFromString")
+        XCTAssertEqual(enumFromStringMethodName(propertyName: "some_prop_type", className: "class"), "classSomePropTypeFromString")
     }
 
     func testStatementSyntax() {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -3,8 +3,8 @@ import XCTest
 @testable import CoreTests
 
 var tests = [XCTestCaseEntry]()
-   tests += [testCase(ObjectiveCInitTests.allTests)]
-   tests += [testCase(ObjectiveCIRTests.allTests)]
    tests += [testCase(StringExtensionsTests.allTests)]
+   tests += [testCase(ObjectiveCIRTests.allTests)]
+   tests += [testCase(ObjectiveCInitTests.allTests)]
 
 XCTMain(tests)


### PR DESCRIPTION
…ion issue with ObjC enums.


Currently for ObjC, we tried to add some logic if an enum property ended with "type" to avoid scenarios where the derived enum type would be "ModelPropertyTypeType".

This actually is an issue if you have two enum properties on a model where the only difference in their names is the suffix `_type`. There isn't a great reason to actually keep this logic so I'm removing it to address this issue.

However - This is a breaking change which will likely require any current user of Plank that uses enums to fix-up their codebase.

