### PR TITLE
Add basic Objective-C and JS bridging test

### DIFF
--- a/Examples/Cocoa/Tests/Objective_CTests/ObjcJSBridgingTests.swift
+++ b/Examples/Cocoa/Tests/Objective_CTests/ObjcJSBridgingTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import JavaScriptCore
+import XCTest
+
+@testable import Objective_C
+
+class ObjcJavaScriptCoreBridgingTestSuite: XCTestCase {
+    
+    static let _context: JSContext = JSContext()!
+    
+    override class func setUp() {
+        super.setUp();
+        injectJSFileIntoContext(fileName: "bundle", context: _context);
+    }
+    
+    // Inject a js file located in plank/Examples/Shared/
+    class func injectJSFileIntoContext(fileName: String, context: JSContext) {
+        let jsFileName = "\(fileName).js"
+        // The currentDirectoryPath is: plank/Examples/Cocoa/
+        let currentPath = FileManager.default.currentDirectoryPath
+        
+        let pathURL = URL(fileURLWithPath: currentPath)
+        let finalPathURL = pathURL.appendingPathComponent("..")
+            .appendingPathComponent("Shared")
+            .appendingPathComponent(jsFileName)
+        do {
+            let bundleContents = try String(contentsOf: finalPathURL, encoding: .utf8)
+            context.evaluateScript(bundleContents)
+        } catch {
+            print("Couldn't inject \(jsFileName) into JSContext")
+        }
+    }
+    
+    var context: JSContext {
+        return ObjcJavaScriptCoreBridgingTestSuite._context
+    }
+    
+    func testImageModelBridgingGetImage() {
+        // Expected modelc dictionary
+        let imageModelDictionary: JSONDict = [
+            "height": 300,
+            "width": 200,
+            "url": "https://picsum.photos/200/300"
+        ]
+        let expectedImage = Image(modelDictionary: imageModelDictionary);
+        let expectedImageDictionaryRepresentation = expectedImage.dictionaryObjectRepresentation()
+        
+        // Get image from js context
+        let getTestImageModelJSONFunction = context.objectForKeyedSubscript("getTestImageModelJSON")!
+        let jsImageModel = getTestImageModelJSONFunction.call(withArguments:[]).toObject() as! JSONDict
+        
+        XCTAssert(expectedImage.isEqual(to: Image(modelDictionary:jsImageModel)))
+        XCTAssert(jsImageModel == expectedImageDictionaryRepresentation)
+    }
+    
+    func testImageModelBridgingSendImage() {
+        // Expected model dictionary
+        let imageModelDictionary: JSONDict = [
+            "height": 300,
+            "width": 200,
+            "url": "https://picsum.photos/200/300"
+        ]
+        let imageModel = Image(modelDictionary: imageModelDictionary);
+        let imageModelDictionaryRepresentation = imageModel.dictionaryObjectRepresentation()
+        
+        let testImageModelJSON = context.objectForKeyedSubscript("sendTestImageModelJSON")!
+        XCTAssert(testImageModelJSON.call(withArguments:[imageModelDictionaryRepresentation]).toBool())
+    }
+}

--- a/Examples/Cocoa/Tests/Objective_CTests/ObjcTests.swift
+++ b/Examples/Cocoa/Tests/Objective_CTests/ObjcTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JavaScriptCore
 import XCTest
 
 @testable import Objective_C
@@ -396,5 +397,57 @@ class ObjcDictionaryRepresentationTestSuite: XCTestCase {
             ]
         ]
         assertDictionaryRepresentation(dict)
+    }
+    
+}
+
+class ObjcJavaScriptCoreBridgingTestSuite: XCTestCase {
+    
+    static let _context: JSContext = JSContext()!
+
+    override class func setUp() {
+        super.setUp();
+        
+        injectJSFileIntoContext(fileName: "bundle", context: _context);
+    }
+
+    // Inject a js file located in plank/Examples/Shared/
+    class func injectJSFileIntoContext(fileName: String, context: JSContext) {
+        let jsFileName = "\(fileName).js"
+        // The currentDirectoryPath is: plank/Examples/Cocoa/
+        let currentPath = FileManager.default.currentDirectoryPath
+        
+        let pathURL = URL(fileURLWithPath: currentPath)
+        let finalPathURL = pathURL.appendingPathComponent("..")
+                                  .appendingPathComponent("Shared")
+                                  .appendingPathComponent(jsFileName)
+        do {
+            let bundleContents = try String(contentsOf: finalPathURL, encoding: .utf8)
+            context.evaluateScript(bundleContents)
+        } catch {
+            print("Couldn't inject \(jsFileName) into JSContext")
+        }
+    }
+    
+    var context: JSContext {
+        return ObjcJavaScriptCoreBridgingTestSuite._context
+    }
+
+    func testImageModelBridging() {
+        // Expected model dictionary
+        let imageModelDictionary: JSONDict = [
+            "height": 300,
+            "width": 200,
+            "url": "https://picsum.photos/200/300"
+        ]
+        let expectedImage = Image(modelDictionary: imageModelDictionary);
+        let expectedImageDictionaryRepresentation = expectedImage.dictionaryObjectRepresentation()
+       
+        // Get image from js context
+        let getTestImageModelJSONFunction = context.objectForKeyedSubscript("getTestImageModelJSON")!
+        let jsImageModel = getTestImageModelJSONFunction.call(withArguments:[]).toObject() as! JSONDict
+        
+        XCTAssert(expectedImage.isEqual(to: Image(modelDictionary:jsImageModel)))
+        XCTAssert(jsImageModel == expectedImageDictionaryRepresentation)
     }
 }

--- a/Examples/Cocoa/Tests/Objective_CTests/ObjcTests.swift
+++ b/Examples/Cocoa/Tests/Objective_CTests/ObjcTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import JavaScriptCore
 import XCTest
 
 @testable import Objective_C
@@ -397,73 +396,5 @@ class ObjcDictionaryRepresentationTestSuite: XCTestCase {
             ]
         ]
         assertDictionaryRepresentation(dict)
-    }
-    
-}
-
-class ObjcJavaScriptCoreBridgingTestSuite: XCTestCase {
-    
-    static let _context: JSContext = JSContext()!
-
-    override class func setUp() {
-        super.setUp();
-        
-        injectJSFileIntoContext(fileName: "bundle", context: _context);
-    }
-
-    // Inject a js file located in plank/Examples/Shared/
-    class func injectJSFileIntoContext(fileName: String, context: JSContext) {
-        let jsFileName = "\(fileName).js"
-        // The currentDirectoryPath is: plank/Examples/Cocoa/
-        let currentPath = FileManager.default.currentDirectoryPath
-        
-        let pathURL = URL(fileURLWithPath: currentPath)
-        let finalPathURL = pathURL.appendingPathComponent("..")
-                                  .appendingPathComponent("Shared")
-                                  .appendingPathComponent(jsFileName)
-        do {
-            let bundleContents = try String(contentsOf: finalPathURL, encoding: .utf8)
-            context.evaluateScript(bundleContents)
-        } catch {
-            print("Couldn't inject \(jsFileName) into JSContext")
-        }
-    }
-    
-    var context: JSContext {
-        return ObjcJavaScriptCoreBridgingTestSuite._context
-    }
-
-    func testImageModelBridgingGetImage() {
-        // Expected modelc dictionary
-        let imageModelDictionary: JSONDict = [
-            "height": 300,
-            "width": 200,
-            "url": "https://picsum.photos/200/300"
-        ]
-        let expectedImage = Image(modelDictionary: imageModelDictionary);
-        let expectedImageDictionaryRepresentation = expectedImage.dictionaryObjectRepresentation()
-       
-        // Get image from js context
-        let getTestImageModelJSONFunction = context.objectForKeyedSubscript("getTestImageModelJSON")!
-        let jsImageModel = getTestImageModelJSONFunction.call(withArguments:[]).toObject() as! JSONDict
-        
-        XCTAssert(expectedImage.isEqual(to: Image(modelDictionary:jsImageModel)))
-        XCTAssert(jsImageModel == expectedImageDictionaryRepresentation)
-    }
-
-    func testImageModelBridgingSendImage() {
-        // Expected model dictionary
-        let imageModelDictionary: JSONDict = [
-            "height": 300,
-            "width": 200,
-            "url": "https://picsum.photos/200/300"
-        ]
-        let imageModel = Image(modelDictionary: imageModelDictionary);
-        let imageModelDictionaryRepresentation = imageModel.dictionaryObjectRepresentation()
-
-        let testImageModelJSON = context.objectForKeyedSubscript("sendTestImageModelJSON")!
-        let result = testImageModelJSON.call(withArguments:[imageModelDictionaryRepresentation]).toBool()
-
-        XCTAssert(result)
     }
 }

--- a/Examples/Cocoa/Tests/Objective_CTests/ObjcTests.swift
+++ b/Examples/Cocoa/Tests/Objective_CTests/ObjcTests.swift
@@ -433,8 +433,8 @@ class ObjcJavaScriptCoreBridgingTestSuite: XCTestCase {
         return ObjcJavaScriptCoreBridgingTestSuite._context
     }
 
-    func testImageModelBridging() {
-        // Expected model dictionary
+    func testImageModelBridgingGetImage() {
+        // Expected modelc dictionary
         let imageModelDictionary: JSONDict = [
             "height": 300,
             "width": 200,
@@ -449,5 +449,21 @@ class ObjcJavaScriptCoreBridgingTestSuite: XCTestCase {
         
         XCTAssert(expectedImage.isEqual(to: Image(modelDictionary:jsImageModel)))
         XCTAssert(jsImageModel == expectedImageDictionaryRepresentation)
+    }
+
+    func testImageModelBridgingSendImage() {
+        // Expected model dictionary
+        let imageModelDictionary: JSONDict = [
+            "height": 300,
+            "width": 200,
+            "url": "https://picsum.photos/200/300"
+        ]
+        let imageModel = Image(modelDictionary: imageModelDictionary);
+        let imageModelDictionaryRepresentation = imageModel.dictionaryObjectRepresentation()
+
+        let testImageModelJSON = context.objectForKeyedSubscript("sendTestImageModelJSON")!
+        let result = testImageModelJSON.call(withArguments:[imageModelDictionaryRepresentation]).toBool()
+
+        XCTAssert(result)
     }
 }

--- a/Examples/Shared/bundle.js
+++ b/Examples/Shared/bundle.js
@@ -1,7 +1,33 @@
+'use strict';
+
+// Some helper to throw exceptions within JS
+
+function assert(condition, message) {
+  if (!condition) {
+    message = message || 'Assertion failed';
+    if (typeof Error !== 'undefined') {
+      throw new Error(message);
+    }
+    throw message; // Fallback
+  }
+}
+
+// Testing funtions
+
 function getTestImageModelJSON() {
   return {
     height: 300,
     width: 200,
     url: 'https://picsum.photos/200/300',
   };
+}
+
+function sendTestImageModelJSON(passed) {
+  const expected = getTestImageModelJSON();
+
+  return (
+    expected.height === passed.height &&
+    expected.width === passed.width &&
+    expected.height === passed.height
+  );
 }

--- a/Examples/Shared/bundle.js
+++ b/Examples/Shared/bundle.js
@@ -1,0 +1,7 @@
+function getTestImageModelJSON() {
+  return {
+    height: 300,
+    width: 200,
+    url: 'https://picsum.photos/200/300',
+  };
+}

--- a/Examples/Shared/bundle.js
+++ b/Examples/Shared/bundle.js
@@ -28,6 +28,6 @@ function sendTestImageModelJSON(passed) {
   return (
     expected.height === passed.height &&
     expected.width === passed.width &&
-    expected.height === passed.height
+    expected.url === passed.url
   );
 }


### PR DESCRIPTION
Let's leverage JavaScriptCore to test bridging between Objective-C and JS.