### PR TITLE
Use fancy string enums and remove unused runtime function

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/PlankModelRuntime.m
+++ b/Examples/Cocoa/Sources/Objective_C/PlankModelRuntime.m
@@ -10,14 +10,6 @@
 
 #import "PlankModelRuntime.h"
 
-id _Nullable valueOrNil(NSDictionary *dict, NSString *key)
-{
-    id value = dict[key];
-    if (value == nil || value == (id)kCFNull) {
-        return nil;
-    }
-    return value;
-}
 NSString *debugDescriptionForFields(NSArray *descriptionFields)
 {
     NSMutableString *stringBuf = [NSMutableString string];

--- a/Examples/Cocoa/Sources/Objective_C/include/PlankModelRuntime.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/PlankModelRuntime.h
@@ -28,8 +28,6 @@ static NSString *const kPlankDidInitializeNotification = @"kPlankDidInitializeNo
 
 static NSString *const kPlankInitTypeKey = @"kPlankInitTypeKey";
 
-id _Nullable valueOrNil(NSDictionary *dict, NSString *key);
-
 NSString *debugDescriptionForFields(NSArray *descriptionFields);
 
 NSUInteger PINIntegerArrayHash(const NSUInteger *subhashes, NSUInteger count);

--- a/Sources/Core/ObjectiveCFileGenerator.swift
+++ b/Sources/Core/ObjectiveCFileGenerator.swift
@@ -101,18 +101,9 @@ struct ObjCRuntimeFile {
             ),
             // TODO Add another root for constant variables instead of using Macro
             ObjCIR.Root.macro("NS_ASSUME_NONNULL_BEGIN"),
-            ObjCIR.Root.macro("static NSString *const kPlankDateValueTransformerKey = @\"kPlankDateValueTransformerKey\";"),
-            ObjCIR.Root.macro("static NSString *const kPlankDidInitializeNotification = @\"kPlankDidInitializeNotification\";"),
+            ObjCIR.Root.macro("static NSValueTransformerName const kPlankDateValueTransformerKey = @\"kPlankDateValueTransformerKey\";"),
+            ObjCIR.Root.macro("static NSNotificationName const kPlankDidInitializeNotification = @\"kPlankDidInitializeNotification\";"),
             ObjCIR.Root.macro("static NSString *const kPlankInitTypeKey = @\"kPlankInitTypeKey\";"),
-            ObjCIR.Root.function(
-                ObjCIR.method("id _Nullable valueOrNil(NSDictionary *dict, NSString *key)") {[
-                    "id value = dict[key];",
-                    ObjCIR.ifStmt("value == nil || value == (id)kCFNull") {
-                        ["return nil;"]
-                    },
-                    "return value;"
-                    ]}
-            ),
             ObjCIR.Root.function(
                 ObjCIR.method("NSString *debugDescriptionForFields(NSArray *descriptionFields)") {[
                     "NSMutableString *stringBuf = [NSMutableString string];",


### PR DESCRIPTION
- The `valueOrNil` runtime function isn't used anymore.
- Use `NSNotificationName` and `NSValueTransformerName`.