### PR TITLE
Create NSURLComponentsExtension that can safely handle illegal fragments

### DIFF
--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -19,6 +19,7 @@ public enum GenerationParameterType {
     case includeRuntime
     case indent
     case packageName
+    case includeUtility
 }
 
 public enum Languages: String {

--- a/Sources/Core/JSFileGenerator.swift
+++ b/Sources/Core/JSFileGenerator.swift
@@ -35,10 +35,10 @@ struct JSModelFile: FileGenerator {
         return 2
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         return (
             [self.renderCommentHeader()] +
-            self.roots.map { $0.renderImplementation().joined(separator: "\n") }
+            self.roots.map { $0.renderImplementation(generationParameters: generationParameters).joined(separator: "\n") }
         )
         .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
         .filter { $0 != "" }

--- a/Sources/Core/JSIR.swift
+++ b/Sources/Core/JSIR.swift
@@ -125,7 +125,11 @@ public struct JSIR {
         )
         case enumDecl(name: String, values: EnumType)
 
-        func renderImplementation() -> [String] {
+        func humanReadableString() -> [String] {
+            return [String(describing: self)]
+        }
+
+        func renderImplementation(generationParameters: GenerationParameters) -> [String] {
             switch self {
             case .structDecl(name: _, fields: _):
                 // Structs are not supported

--- a/Sources/Core/JSRuntimeFile.swift
+++ b/Sources/Core/JSRuntimeFile.swift
@@ -33,7 +33,7 @@ struct JSRuntimeFile: FileGenerator {
         .joined(separator: "\n")
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         let output = (
             [self.renderCommentHeader()] + [self.renderContent()]
         )

--- a/Sources/Core/JavaFileGenerator.swift
+++ b/Sources/Core/JavaFileGenerator.swift
@@ -30,10 +30,10 @@ struct JavaFileGenerator: FileGenerator {
         return "\(className).java"
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         return (
             [self.renderCommentHeader()] +
-                self.roots.map { $0.renderImplementation().joined(separator: "\n") }
+                self.roots.map { $0.renderImplementation(generationParameters: generationParameters).joined(separator: "\n") }
             )
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .map { $0.replacingOccurrences(of: "  ", with: " ") }

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -148,17 +148,29 @@ public struct JavaIR {
         case classDecl(aClass: JavaIR.Class)
         case interfaceDecl(aInterface: JavaIR.Interface)
 
-        func renderImplementation() -> [String] {
+        func humanReadableString() -> [String] {
+            return [String(describing: self)]
+        }
+
+        func renderImplementation(generationParameters: GenerationParameters) -> [String] {
+            var generatedSource = [String]()
+            
+            if let debugString = debugStatement(generationParameters: generationParameters, language: .java) {
+                generatedSource += debugString
+            }
+
             switch self {
             case let .packages(names):
-                return names.sorted().map { "package \($0);" }
+                generatedSource += names.sorted().map { "package \($0);" }
             case let .imports(names):
-                return names.sorted().map { "import \($0);" }
+                generatedSource += names.sorted().map { "import \($0);" }
             case let .classDecl(aClass: cls):
-                return cls.render()
+                generatedSource += cls.render()
             case let .interfaceDecl(aInterface: interface):
-                return interface.render()
+                generatedSource += interface.render()
             }
+
+            return generatedSource
         }
     }
 }

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -136,7 +136,7 @@ public struct JavaIR {
             let extendsStmt = extends.map { "extends \($0) " } ?? ""
             return [
                 "\(modifiers.render()) interface \(name) \(extendsStmt){",
-                -->methods.compactMap { "\($0.signature);" },
+                -->methods.map { "\($0.signature);" },
                 "}"
             ]
         }

--- a/Sources/Core/ObjCADTRenderer.swift
+++ b/Sources/Core/ObjCADTRenderer.swift
@@ -172,10 +172,14 @@ struct ObjCADTRenderer: ObjCFileRenderer {
         return [
             ObjCIR.Root.macro("NS_ASSUME_NONNULL_BEGIN"),
             internalTypeEnum,
-            ObjCIR.Root.category(className: self.className,
+            ObjCIR.Root.categoryDecl(className: self.className,
                                  categoryName: nil,
                                  methods: [],
-                                 properties: props),
+                                 properties: props,
+                                 headerOnly: false),
+            ObjCIR.Root.categoryImpl(className: self.className,
+                                     categoryName: nil,
+                                     methods: []),
             ObjCIR.Root.classDecl(name: name,
                                  extends: nil,
                                  methods:

--- a/Sources/Core/ObjCModelRenderer.swift
+++ b/Sources/Core/ObjCModelRenderer.swift
@@ -114,14 +114,14 @@ public struct ObjCModelRenderer: ObjCFileRenderer {
 
     func renderRoots() -> [ObjCIR.Root] {
         let properties: [(Parameter, SchemaObjectProperty)] = rootSchema.properties.map { $0 } // Convert [String:Schema] -> [(String, Schema)]
-        
+
         let protocols: [String: [ObjCIR.Method]] = [
             "NSSecureCoding": [self.renderSupportsSecureCoding(), self.renderInitWithCoder(), self.renderEncodeWithCoder()],
             "NSCopying": [ObjCIR.method("- (id)copyWithZone:(NSZone *)zone") { ["return self;"] }]
         ]
-        
+
         let parentName = resolveClassName(self.parentDescriptor)
-        
+
         func enumRoot(from prop: Schema, param: String) -> [ObjCIR.Root] {
             switch prop {
             case .enumT(let enumValues):
@@ -135,11 +135,11 @@ public struct ObjCModelRenderer: ObjCFileRenderer {
             default: return []
             }
         }
-        
+
         let enumRoots = self.properties.flatMap { (param, prop) -> [ObjCIR.Root] in
             enumRoot(from: prop.schema, param: param)
         }
-        
+
         // TODO: Synthesize oneOf ADT Classes and Class Extension
         // TODO (rmalik): Clean this up, too much copy / paste here to support oneOf cases
         let adtRoots = self.properties.flatMap { (param, prop) -> [ObjCIR.Root] in
@@ -164,7 +164,7 @@ public struct ObjCModelRenderer: ObjCFileRenderer {
             default: return []
             }
         }
-        
+
         let classDependencies = Set(self.renderReferencedClasses().map {
             // Objective-C types contain "*" if they are a pointer type
             // This information is excessive for import statements so
@@ -174,7 +174,7 @@ public struct ObjCModelRenderer: ObjCFileRenderer {
         var dependencies = Set(classDependencies)
         let utilityDependencies = Set<String>(UtilitySourceIncluder.imports(for: params, language: Languages.objectiveC))
         dependencies.formUnion(utilityDependencies)
-        
+
         return [
             ObjCIR.Root.imports(
                 classNames: dependencies,

--- a/Sources/Core/ObjectiveCFileGenerator.swift
+++ b/Sources/Core/ObjectiveCFileGenerator.swift
@@ -44,10 +44,10 @@ struct ObjCHeaderFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         let output = (
                 [self.renderCommentHeader()] +
-                self.roots.map { $0.renderHeader().joined(separator: "\n") }
+                self.roots.map { $0.renderHeader(generationParameters: generationParameters).joined(separator: "\n") }
             )
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }
@@ -68,10 +68,10 @@ struct ObjCImplementationFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         let output = (
                 [self.renderCommentHeader()] +
-                self.roots.map { $0.renderImplementation().joined(separator: "\n") }
+                self.roots.map { $0.renderImplementation(generationParameters: generationParameters).joined(separator: "\n") }
             )
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }
@@ -161,9 +161,9 @@ struct ObjCRuntimeHeaderFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         let roots: [ObjCIR.Root] = ObjCRuntimeFile.renderRoots()
-        let outputs = roots.map { $0.renderHeader() }.reduce([], +)
+        let outputs = roots.map { $0.renderHeader(generationParameters: generationParameters) }.reduce([], +)
         return ([self.renderCommentHeader(), "", "#import <Foundation/Foundation.h>", ""] + outputs)
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }
@@ -179,9 +179,9 @@ struct ObjCRuntimeImplementationFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         let roots: [ObjCIR.Root] = ObjCRuntimeFile.renderRoots()
-        let outputs = roots.map { $0.renderImplementation() }.reduce([], +)
+        let outputs = roots.map { $0.renderImplementation(generationParameters: generationParameters) }.reduce([], +)
         return ([self.renderCommentHeader(), "", "#import <Foundation/Foundation.h>", "", "#import \"\(ObjCRuntimeHeaderFile().fileName)\"", outputs.joined(separator: "\n")])
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }

--- a/Sources/Core/ObjectiveCFileGenerator.swift
+++ b/Sources/Core/ObjectiveCFileGenerator.swift
@@ -47,7 +47,7 @@ struct ObjCHeaderFile: FileGenerator {
     func renderFile() -> String {
         let output = (
                 [self.renderCommentHeader()] +
-                self.roots.compactMap { $0.renderHeader().joined(separator: "\n") }
+                self.roots.map { $0.renderHeader().joined(separator: "\n") }
             )
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -148,7 +148,7 @@ extension ObjCModelRenderer {
             case .boolean:
                 return ["\(propertyToAssign) = [\(rawObjectName) boolValue];"]
             case .string(format: .some(.uri)):
-                return ["\(propertyToAssign) = [NSURL URLWithString:\(rawObjectName)];"]
+                return ["\(propertyToAssign) = [NSURLComponents URLWithUnsafeString:\(rawObjectName)];"]
             case .string(format: .some(.dateTime)):
                 return ["\(propertyToAssign) = [[NSValueTransformer valueTransformerForName:\(dateValueTransformerKey)] transformedValue:\(rawObjectName)];"]
             case .reference(with: let ref):

--- a/Sources/Core/UtilitySourceIncluder.swift
+++ b/Sources/Core/UtilitySourceIncluder.swift
@@ -1,0 +1,102 @@
+//
+//  UtilitySourceIncluder.swift
+//  plank
+//
+//  Created by Michael Zuccarino on 10/22/18.
+//
+
+import Foundation
+
+public struct UtilitySourceIncluder {
+    
+    let languages: [Languages]
+    let outputDirectory: URL
+    let generationParameters: GenerationParameters
+    
+    public init(languages langs: [Languages],
+                outputDirectory outputDir: URL,
+                generationParameters genParams: GenerationParameters) {
+        languages = langs
+        outputDirectory = outputDir
+        generationParameters = genParams
+    }
+
+    public func write() {
+        var files = [FileGenerator]()
+        languages.forEach({ (language) in
+            switch language {
+            case .objectiveC:
+                files += ObjectiveCCategoryExtensions.generators()
+            default:
+                return
+            }
+        })
+
+        files.forEach { (file) in
+            writeFile(file: file, outputDirectory: outputDirectory, generationParameters: generationParameters)
+        }
+    }
+
+}
+
+// MARK: Objective-C
+
+extension UtilitySourceIncluder {
+    
+    class ObjectiveCCategoryExtensions {
+        
+        // Enlist different generators here i.e. [one list] + NSURLComponents.extensions + ...
+        class func generators() -> [FileGenerator] {
+            return NSURLComponents.extensions()
+        }
+        
+        private class NSURLComponents {
+            
+            class func extensions() -> [FileGenerator] {
+                let classToExtend = "NSURLComponents"
+                let extensionName = "PlankUtility"
+                let fileNameBase = "\(classToExtend)+\(extensionName)"
+
+                let categoryMethods: [ObjCIR.Method] = [
+                    NSURLComponents.NSURLComponentsUnsafeInitializer()
+                ]
+                
+                let categoryRoots = [
+                    ObjCIR.Root.category(className: classToExtend, categoryName: extensionName, methods: categoryMethods, properties: [])
+                ]
+                
+                let files: [FileGenerator] = [
+                    ObjCHeaderFile(roots: categoryRoots, className: fileNameBase),
+                    ObjCImplementationFile(roots: categoryRoots, className: fileNameBase)
+                ]
+                return files
+            }
+            
+            class func NSURLComponentsUnsafeInitializer() -> ObjCIR.Method {
+                return ObjCIR.method("+ (NSURL * _Nullable)URLWithUnsafeString:(NSString * _Nonnull)unsafeString", body: { () -> [String] in
+                    return [
+                        "static NSCharacterSet * const fragmentDefinition = [NSCharacterSet characterSetWithCharactersInString:@\"#\"];",
+                        "NSRange firstFragmentRange = [unsafeString rangeOfCharacterInSet:fragmentDefinition];",
+                        ObjCIR.ifStmt("firstFragmentRange.location != NSNotFound") {
+                            return [
+                                "NSString *baseURL = [unsafeString substringToIndex:firstFragmentRange.location];",
+                                "NSString *fragment = [unsafeString substringFromIndex:firstFragmentRange.location];",
+                                ObjCIR.ifStmt("[unsafeString rangeOfCharacterInSet:fragmentDefinition].location != NSNotFound", body: { () -> [String] in
+                                    return [
+                                        "NSString *encodedFragment = [fragment stringByAddingPercentEncodingWithAllowedCharacters:URLFragmentAllowedCharacterSet];",
+                                        "unsafeString = [NSStringWithFormat:@\"%@#%@\", baseUrl, encodedFragment];"
+                                    ]
+                                })
+                            ]
+                        },
+                        "return [NSURLComponents urlComponentsWithString:unsafeString].URL;"
+                    ]
+                })
+            }
+            
+        }
+    
+        
+    }
+    
+}

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -190,7 +190,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     outputDirectory = URL(fileURLWithPath: outputDirectory.absoluteString, isDirectory: true)
 
     let urls = args.map { URL(string: $0)! }
-    let languages: [Languages] = flags[.lang]?.trimmingCharacters(in: .whitespaces).components(separatedBy: ",").compactMap {
+    let languages: [Languages] = flags[.lang]?.trimmingCharacters(in: .whitespaces).components(separatedBy: ",").map {
         guard let lang = Languages.init(rawValue: $0) else {
             fatalError("Invalid or unsupported language: \($0)")
         }

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -149,21 +149,22 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     let includeRuntime: String? = flags[.onlyRuntime] != nil || (flags[.noRuntime] == nil || flags[.noRecursive] != nil) ? .some("") : .none
     let indent: String? = flags[.indent]
     let packageName: String? = flags[.javaPackageName]
+    let includeUtility: String? = flags[.includeUtility] != nil ? .some("") : .none
 
     let generationParameters: GenerationParameters = [
         (.recursive, recursive),
         (.classPrefix, classPrefix),
         (.includeRuntime, includeRuntime),
         (.indent, indent),
-        (.packageName, packageName)
-    ].reduce([:]) { (dict: GenerationParameters, tuple: (GenerationParameterType, String?)) in
+        (.packageName, packageName),
+        (.includeUtility, includeUtility)
+        ].reduce(GenerationParameters()) { (dict: GenerationParameters, tuple: (GenerationParameterType, String?)) -> GenerationParameters in
             var d = dict
             if let v = tuple.1 {
                 d[tuple.0] = v
             }
             return d
     }
-
     guard !args.isEmpty || flags[.onlyRuntime] != nil else {
         print("Error: Missing or invalid URL to JSONSchema")
         handleHelpCommand()

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -26,6 +26,7 @@ enum FlagOptions: String {
     case help = "help"
     case version = "version"
     case includeUtility = "include_utility"
+    case debugIR = "debug_ir"
 
     func needsArgument() -> Bool {
         switch self {
@@ -41,6 +42,7 @@ enum FlagOptions: String {
         case .version: return false
         case .javaPackageName: return true
         case .includeUtility: return false
+        case .debugIR: return false
         }
     }
 }
@@ -58,6 +60,7 @@ extension FlagOptions: HelpCommandOutput {
             "    --\(FlagOptions.help.rawValue) - Show this text and exit",
             "    --\(FlagOptions.version.rawValue) - Show version number and exit",
             "    --\(FlagOptions.includeUtility.rawValue) - Include utility source for the defined language",
+            "    --\(FlagOptions.debugIR.rawValue) - Includes IR statement above generated source",
             "",
             "    Objective-C:",
             "    --\(FlagOptions.objectiveCClassPrefix.rawValue) - The prefix to add to all generated class names",
@@ -150,6 +153,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     let indent: String? = flags[.indent]
     let packageName: String? = flags[.javaPackageName]
     let includeUtility: String? = flags[.includeUtility] != nil ? .some("") : .none
+    let debugIR: String? = flags[.debugIR] != nil ? .some("") : .none
 
     let generationParameters: GenerationParameters = [
         (.recursive, recursive),
@@ -157,7 +161,8 @@ func handleGenerateCommand(withArguments arguments: [String]) {
         (.includeRuntime, includeRuntime),
         (.indent, indent),
         (.packageName, packageName),
-        (.includeUtility, includeUtility)
+        (.includeUtility, includeUtility),
+        (.debugIR, debugIR)
         ].reduce(GenerationParameters()) { (dict: GenerationParameters, tuple: (GenerationParameterType, String?)) -> GenerationParameters in
             var d = dict
             if let v = tuple.1 {

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -25,6 +25,7 @@ enum FlagOptions: String {
     case lang = "lang"
     case help = "help"
     case version = "version"
+    case includeUtility = "include_utility"
 
     func needsArgument() -> Bool {
         switch self {
@@ -39,6 +40,7 @@ enum FlagOptions: String {
         case .help: return false
         case .version: return false
         case .javaPackageName: return true
+        case .includeUtility: return false
         }
     }
 }
@@ -55,6 +57,7 @@ extension FlagOptions: HelpCommandOutput {
             "    --\(FlagOptions.lang.rawValue) - Comma separated list of target language(s) for generating code. Default: \"objc\"",
             "    --\(FlagOptions.help.rawValue) - Show this text and exit",
             "    --\(FlagOptions.version.rawValue) - Show version number and exit",
+            "    --\(FlagOptions.includeUtility.rawValue) - Include utility source for the defined language",
             "",
             "    Objective-C:",
             "    --\(FlagOptions.objectiveCClassPrefix.rawValue) - The prefix to add to all generated class names",
@@ -209,6 +212,12 @@ func handleGenerateCommand(withArguments arguments: [String]) {
                       generationParameters: generationParameters,
                       forLanguages: languages)
     }
+    
+    if flags[.includeUtility] != nil {
+        UtilitySourceIncluder(languages: languages,
+                              outputDirectory: outputDirectory,
+                              generationParameters: generationParameters).write()
+    }
 }
 
 func handleHelpCommand() {
@@ -227,3 +236,4 @@ func handleHelpCommand() {
 func handleVersionCommand() {
     print(Version.current.value)
 }
+

--- a/plank.xcodeproj/project.pbxproj
+++ b/plank.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
             "en"
          );
          mainGroup = "OBJ_5";
-         productRefGroup = "OBJ_51";
+         productRefGroup = "OBJ_52";
          projectDirPath = ".";
          targets = (
             "plank::Core",
@@ -32,19 +32,29 @@
          sourceTree = "<group>";
       };
       "OBJ_100" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_101"
+         );
+      };
+      "OBJ_101" = {
+         isa = "PBXBuildFile";
+         fileRef = "plank::Core::Product";
+      };
+      "OBJ_102" = {
          isa = "PBXTargetDependency";
          target = "plank::Core";
       };
-      "OBJ_102" = {
+      "OBJ_104" = {
          isa = "XCConfigurationList";
          buildConfigurations = (
-            "OBJ_103",
-            "OBJ_104"
+            "OBJ_105",
+            "OBJ_106"
          );
          defaultConfigurationIsVisible = "0";
          defaultConfigurationName = "Release";
       };
-      "OBJ_103" = {
+      "OBJ_105" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
             FRAMEWORK_SEARCH_PATHS = (
@@ -79,7 +89,7 @@
          };
          name = "Debug";
       };
-      "OBJ_104" = {
+      "OBJ_106" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
             FRAMEWORK_SEARCH_PATHS = (
@@ -114,31 +124,21 @@
          };
          name = "Release";
       };
-      "OBJ_105" = {
+      "OBJ_107" = {
          isa = "PBXSourcesBuildPhase";
          files = (
-            "OBJ_106",
-            "OBJ_107",
-            "OBJ_108"
+            "OBJ_108",
+            "OBJ_109",
+            "OBJ_110"
          );
-      };
-      "OBJ_106" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_36";
-      };
-      "OBJ_107" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_37";
       };
       "OBJ_108" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_38";
+         fileRef = "OBJ_37";
       };
       "OBJ_109" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_110"
-         );
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_38";
       };
       "OBJ_11" = {
          isa = "PBXFileReference";
@@ -147,22 +147,32 @@
       };
       "OBJ_110" = {
          isa = "PBXBuildFile";
-         fileRef = "plank::Core::Product";
+         fileRef = "OBJ_39";
       };
       "OBJ_111" = {
+         isa = "PBXFrameworksBuildPhase";
+         files = (
+            "OBJ_112"
+         );
+      };
+      "OBJ_112" = {
+         isa = "PBXBuildFile";
+         fileRef = "plank::Core::Product";
+      };
+      "OBJ_113" = {
          isa = "PBXTargetDependency";
          target = "plank::Core";
       };
-      "OBJ_113" = {
+      "OBJ_115" = {
          isa = "XCConfigurationList";
          buildConfigurations = (
-            "OBJ_114",
-            "OBJ_115"
+            "OBJ_116",
+            "OBJ_117"
          );
          defaultConfigurationIsVisible = "0";
          defaultConfigurationName = "Release";
       };
-      "OBJ_114" = {
+      "OBJ_116" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
             LD = "/usr/bin/true";
@@ -174,13 +184,13 @@
                "-target",
                "x86_64-apple-macosx10.10",
                "-sdk",
-               "/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
             );
             SWIFT_VERSION = "4.0";
          };
          name = "Debug";
       };
-      "OBJ_115" = {
+      "OBJ_117" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
             LD = "/usr/bin/true";
@@ -192,49 +202,49 @@
                "-target",
                "x86_64-apple-macosx10.10",
                "-sdk",
-               "/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
+               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
             );
             SWIFT_VERSION = "4.0";
          };
          name = "Release";
       };
-      "OBJ_116" = {
+      "OBJ_118" = {
          isa = "PBXSourcesBuildPhase";
          files = (
-            "OBJ_117"
+            "OBJ_119"
          );
-      };
-      "OBJ_117" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_6";
       };
       "OBJ_119" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_120",
-            "OBJ_121"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_6";
       };
       "OBJ_12" = {
          isa = "PBXFileReference";
          path = "JSFileRenderer.swift";
          sourceTree = "<group>";
       };
-      "OBJ_120" = {
+      "OBJ_121" = {
+         isa = "XCConfigurationList";
+         buildConfigurations = (
+            "OBJ_122",
+            "OBJ_123"
+         );
+         defaultConfigurationIsVisible = "0";
+         defaultConfigurationName = "Release";
+      };
+      "OBJ_122" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
          };
          name = "Debug";
       };
-      "OBJ_121" = {
+      "OBJ_123" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
          };
          name = "Release";
       };
-      "OBJ_122" = {
+      "OBJ_124" = {
          isa = "PBXTargetDependency";
          target = "plank::CoreTests";
       };
@@ -397,39 +407,35 @@
          sourceTree = "<group>";
       };
       "OBJ_35" = {
+         isa = "PBXFileReference";
+         path = "UtilitySourceIncluder.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_36" = {
          isa = "PBXGroup";
          children = (
-            "OBJ_36",
             "OBJ_37",
-            "OBJ_38"
+            "OBJ_38",
+            "OBJ_39"
          );
          name = "plank";
          path = "Sources/plank";
          sourceTree = "SOURCE_ROOT";
       };
-      "OBJ_36" = {
+      "OBJ_37" = {
          isa = "PBXFileReference";
          path = "Cli.swift";
          sourceTree = "<group>";
       };
-      "OBJ_37" = {
+      "OBJ_38" = {
          isa = "PBXFileReference";
          path = "Version.swift";
          sourceTree = "<group>";
       };
-      "OBJ_38" = {
+      "OBJ_39" = {
          isa = "PBXFileReference";
          path = "main.swift";
          sourceTree = "<group>";
-      };
-      "OBJ_39" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_40"
-         );
-         name = "Tests";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
       };
       "OBJ_4" = {
          isa = "XCBuildConfiguration";
@@ -466,60 +472,64 @@
       "OBJ_40" = {
          isa = "PBXGroup";
          children = (
-            "OBJ_41",
+            "OBJ_41"
+         );
+         name = "Tests";
+         path = "";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_41" = {
+         isa = "PBXGroup";
+         children = (
             "OBJ_42",
             "OBJ_43",
             "OBJ_44",
             "OBJ_45",
-            "OBJ_46"
+            "OBJ_46",
+            "OBJ_47"
          );
          name = "CoreTests";
          path = "Tests/CoreTests";
          sourceTree = "SOURCE_ROOT";
       };
-      "OBJ_41" = {
+      "OBJ_42" = {
          isa = "PBXFileReference";
          path = "LinuxTestIndex.swift";
          sourceTree = "<group>";
       };
-      "OBJ_42" = {
+      "OBJ_43" = {
          isa = "PBXFileReference";
          path = "MockSchemaLoader.swift";
          sourceTree = "<group>";
       };
-      "OBJ_43" = {
+      "OBJ_44" = {
          isa = "PBXFileReference";
          path = "ObjectiveCIRTests.swift";
          sourceTree = "<group>";
       };
-      "OBJ_44" = {
+      "OBJ_45" = {
          isa = "PBXFileReference";
          path = "ObjectiveCInitTests.swift";
          sourceTree = "<group>";
       };
-      "OBJ_45" = {
+      "OBJ_46" = {
          isa = "PBXFileReference";
          path = "PlankTestExtension.swift";
          sourceTree = "<group>";
       };
-      "OBJ_46" = {
+      "OBJ_47" = {
          isa = "PBXFileReference";
          path = "StringExtensionsTests.swift";
          sourceTree = "<group>";
       };
-      "OBJ_47" = {
+      "OBJ_48" = {
          isa = "PBXFileReference";
          path = "CI";
          sourceTree = "SOURCE_ROOT";
       };
-      "OBJ_48" = {
-         isa = "PBXFileReference";
-         path = "docs";
-         sourceTree = "SOURCE_ROOT";
-      };
       "OBJ_49" = {
          isa = "PBXFileReference";
-         path = "Examples";
+         path = "docs";
          sourceTree = "SOURCE_ROOT";
       };
       "OBJ_5" = {
@@ -527,77 +537,45 @@
          children = (
             "OBJ_6",
             "OBJ_7",
-            "OBJ_39",
-            "OBJ_47",
+            "OBJ_40",
             "OBJ_48",
             "OBJ_49",
             "OBJ_50",
-            "OBJ_51"
+            "OBJ_51",
+            "OBJ_52"
          );
          path = "";
          sourceTree = "<group>";
       };
       "OBJ_50" = {
          isa = "PBXFileReference";
-         path = "Utility";
+         path = "Examples";
          sourceTree = "SOURCE_ROOT";
       };
       "OBJ_51" = {
+         isa = "PBXFileReference";
+         path = "Utility";
+         sourceTree = "SOURCE_ROOT";
+      };
+      "OBJ_52" = {
          isa = "PBXGroup";
          children = (
-            "plank::CoreTests::Product",
             "plank::plank::Product",
+            "plank::CoreTests::Product",
             "plank::Core::Product"
          );
          name = "Products";
          path = "";
          sourceTree = "BUILT_PRODUCTS_DIR";
       };
-      "OBJ_56" = {
+      "OBJ_57" = {
          isa = "XCConfigurationList";
          buildConfigurations = (
-            "OBJ_57",
-            "OBJ_58"
+            "OBJ_58",
+            "OBJ_59"
          );
          defaultConfigurationIsVisible = "0";
          defaultConfigurationName = "Release";
-      };
-      "OBJ_57" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "plank.xcodeproj/Core_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Core";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "Core";
-         };
-         name = "Debug";
       };
       "OBJ_58" = {
          isa = "XCBuildConfiguration";
@@ -634,12 +612,54 @@
             SWIFT_VERSION = "4.0";
             TARGET_NAME = "Core";
          };
-         name = "Release";
+         name = "Debug";
       };
       "OBJ_59" = {
+         isa = "XCBuildConfiguration";
+         buildSettings = {
+            ENABLE_TESTABILITY = "YES";
+            FRAMEWORK_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
+            );
+            HEADER_SEARCH_PATHS = (
+               "$(inherited)"
+            );
+            INFOPLIST_FILE = "plank.xcodeproj/Core_Info.plist";
+            LD_RUNPATH_SEARCH_PATHS = (
+               "$(inherited)",
+               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+            );
+            OTHER_CFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_LDFLAGS = (
+               "$(inherited)"
+            );
+            OTHER_SWIFT_FLAGS = (
+               "$(inherited)"
+            );
+            PRODUCT_BUNDLE_IDENTIFIER = "Core";
+            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+            SKIP_INSTALL = "YES";
+            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
+               "$(inherited)"
+            );
+            SWIFT_VERSION = "4.0";
+            TARGET_NAME = "Core";
+         };
+         name = "Release";
+      };
+      "OBJ_6" = {
+         isa = "PBXFileReference";
+         explicitFileType = "sourcecode.swift";
+         path = "Package.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_60" = {
          isa = "PBXSourcesBuildPhase";
          files = (
-            "OBJ_60",
             "OBJ_61",
             "OBJ_62",
             "OBJ_63",
@@ -664,60 +684,52 @@
             "OBJ_82",
             "OBJ_83",
             "OBJ_84",
-            "OBJ_85"
+            "OBJ_85",
+            "OBJ_86",
+            "OBJ_87"
          );
-      };
-      "OBJ_6" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         path = "Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_60" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_9";
       };
       "OBJ_61" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_10";
+         fileRef = "OBJ_9";
       };
       "OBJ_62" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_11";
+         fileRef = "OBJ_10";
       };
       "OBJ_63" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_12";
+         fileRef = "OBJ_11";
       };
       "OBJ_64" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_13";
+         fileRef = "OBJ_12";
       };
       "OBJ_65" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_14";
+         fileRef = "OBJ_13";
       };
       "OBJ_66" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_15";
+         fileRef = "OBJ_14";
       };
       "OBJ_67" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_16";
+         fileRef = "OBJ_15";
       };
       "OBJ_68" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_17";
+         fileRef = "OBJ_16";
       };
       "OBJ_69" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_18";
+         fileRef = "OBJ_17";
       };
       "OBJ_7" = {
          isa = "PBXGroup";
          children = (
             "OBJ_8",
-            "OBJ_35"
+            "OBJ_36"
          );
          name = "Sources";
          path = "";
@@ -725,43 +737,43 @@
       };
       "OBJ_70" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_19";
+         fileRef = "OBJ_18";
       };
       "OBJ_71" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_20";
+         fileRef = "OBJ_19";
       };
       "OBJ_72" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_21";
+         fileRef = "OBJ_20";
       };
       "OBJ_73" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_22";
+         fileRef = "OBJ_21";
       };
       "OBJ_74" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_23";
+         fileRef = "OBJ_22";
       };
       "OBJ_75" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_24";
+         fileRef = "OBJ_23";
       };
       "OBJ_76" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_25";
+         fileRef = "OBJ_24";
       };
       "OBJ_77" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_26";
+         fileRef = "OBJ_25";
       };
       "OBJ_78" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_27";
+         fileRef = "OBJ_26";
       };
       "OBJ_79" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_28";
+         fileRef = "OBJ_27";
       };
       "OBJ_8" = {
          isa = "PBXGroup";
@@ -791,7 +803,8 @@
             "OBJ_31",
             "OBJ_32",
             "OBJ_33",
-            "OBJ_34"
+            "OBJ_34",
+            "OBJ_35"
          );
          name = "Core";
          path = "Sources/Core";
@@ -799,43 +812,56 @@
       };
       "OBJ_80" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_29";
+         fileRef = "OBJ_28";
       };
       "OBJ_81" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_30";
+         fileRef = "OBJ_29";
       };
       "OBJ_82" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_31";
+         fileRef = "OBJ_30";
       };
       "OBJ_83" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_32";
+         fileRef = "OBJ_31";
       };
       "OBJ_84" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_33";
+         fileRef = "OBJ_32";
       };
       "OBJ_85" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_34";
+         fileRef = "OBJ_33";
       };
       "OBJ_86" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_34";
+      };
+      "OBJ_87" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_35";
+      };
+      "OBJ_88" = {
          isa = "PBXFrameworksBuildPhase";
          files = (
          );
       };
-      "OBJ_88" = {
+      "OBJ_9" = {
+         isa = "PBXFileReference";
+         path = "FileGenerator.swift";
+         sourceTree = "<group>";
+      };
+      "OBJ_90" = {
          isa = "XCConfigurationList";
          buildConfigurations = (
-            "OBJ_89",
-            "OBJ_90"
+            "OBJ_91",
+            "OBJ_92"
          );
          defaultConfigurationIsVisible = "0";
          defaultConfigurationName = "Release";
       };
-      "OBJ_89" = {
+      "OBJ_91" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
             CLANG_ENABLE_MODULES = "YES";
@@ -870,12 +896,7 @@
          };
          name = "Debug";
       };
-      "OBJ_9" = {
-         isa = "PBXFileReference";
-         path = "FileGenerator.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_90" = {
+      "OBJ_92" = {
          isa = "XCBuildConfiguration";
          buildSettings = {
             CLANG_ENABLE_MODULES = "YES";
@@ -910,57 +931,47 @@
          };
          name = "Release";
       };
-      "OBJ_91" = {
+      "OBJ_93" = {
          isa = "PBXSourcesBuildPhase";
          files = (
-            "OBJ_92",
-            "OBJ_93",
             "OBJ_94",
             "OBJ_95",
             "OBJ_96",
-            "OBJ_97"
-         );
-      };
-      "OBJ_92" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_41";
-      };
-      "OBJ_93" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_42";
-      };
-      "OBJ_94" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_43";
-      };
-      "OBJ_95" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_44";
-      };
-      "OBJ_96" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_45";
-      };
-      "OBJ_97" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_46";
-      };
-      "OBJ_98" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
+            "OBJ_97",
+            "OBJ_98",
             "OBJ_99"
          );
       };
+      "OBJ_94" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_42";
+      };
+      "OBJ_95" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_43";
+      };
+      "OBJ_96" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_44";
+      };
+      "OBJ_97" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_45";
+      };
+      "OBJ_98" = {
+         isa = "PBXBuildFile";
+         fileRef = "OBJ_46";
+      };
       "OBJ_99" = {
          isa = "PBXBuildFile";
-         fileRef = "plank::Core::Product";
+         fileRef = "OBJ_47";
       };
       "plank::Core" = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_56";
+         buildConfigurationList = "OBJ_57";
          buildPhases = (
-            "OBJ_59",
-            "OBJ_86"
+            "OBJ_60",
+            "OBJ_88"
          );
          dependencies = (
          );
@@ -976,13 +987,13 @@
       };
       "plank::CoreTests" = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_88";
+         buildConfigurationList = "OBJ_90";
          buildPhases = (
-            "OBJ_91",
-            "OBJ_98"
+            "OBJ_93",
+            "OBJ_100"
          );
          dependencies = (
-            "OBJ_100"
+            "OBJ_102"
          );
          name = "CoreTests";
          productName = "CoreTests";
@@ -996,9 +1007,9 @@
       };
       "plank::SwiftPMPackageDescription" = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_113";
+         buildConfigurationList = "OBJ_115";
          buildPhases = (
-            "OBJ_116"
+            "OBJ_118"
          );
          dependencies = (
          );
@@ -1008,13 +1019,13 @@
       };
       "plank::plank" = {
          isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_102";
+         buildConfigurationList = "OBJ_104";
          buildPhases = (
-            "OBJ_105",
-            "OBJ_109"
+            "OBJ_107",
+            "OBJ_111"
          );
          dependencies = (
-            "OBJ_111"
+            "OBJ_113"
          );
          name = "plank";
          productName = "plank";
@@ -1028,11 +1039,11 @@
       };
       "plank::plankPackageTests::ProductTarget" = {
          isa = "PBXAggregateTarget";
-         buildConfigurationList = "OBJ_119";
+         buildConfigurationList = "OBJ_121";
          buildPhases = (
          );
          dependencies = (
-            "OBJ_122"
+            "OBJ_124"
          );
          name = "plankPackageTests";
          productName = "plankPackageTests";

--- a/plank.xcodeproj/project.pbxproj
+++ b/plank.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
       };
       "OBJ_10" = {
          isa = "PBXFileReference";
-         path = "JSADTExtension.swift";
+         path = "Version.swift";
          sourceTree = "<group>";
       };
       "OBJ_100" = {
@@ -134,20 +134,20 @@
       };
       "OBJ_108" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_37";
+         fileRef = "OBJ_9";
       };
       "OBJ_109" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_38";
+         fileRef = "OBJ_10";
       };
       "OBJ_11" = {
          isa = "PBXFileReference";
-         path = "JSFileGenerator.swift";
+         path = "main.swift";
          sourceTree = "<group>";
       };
       "OBJ_110" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_39";
+         fileRef = "OBJ_11";
       };
       "OBJ_111" = {
          isa = "PBXFrameworksBuildPhase";
@@ -219,9 +219,39 @@
          fileRef = "OBJ_6";
       };
       "OBJ_12" = {
-         isa = "PBXFileReference";
-         path = "JSFileRenderer.swift";
-         sourceTree = "<group>";
+         isa = "PBXGroup";
+         children = (
+            "OBJ_13",
+            "OBJ_14",
+            "OBJ_15",
+            "OBJ_16",
+            "OBJ_17",
+            "OBJ_18",
+            "OBJ_19",
+            "OBJ_20",
+            "OBJ_21",
+            "OBJ_22",
+            "OBJ_23",
+            "OBJ_24",
+            "OBJ_25",
+            "OBJ_26",
+            "OBJ_27",
+            "OBJ_28",
+            "OBJ_29",
+            "OBJ_30",
+            "OBJ_31",
+            "OBJ_32",
+            "OBJ_33",
+            "OBJ_34",
+            "OBJ_35",
+            "OBJ_36",
+            "OBJ_37",
+            "OBJ_38",
+            "OBJ_39"
+         );
+         name = "Core";
+         path = "Sources/Core";
+         sourceTree = "SOURCE_ROOT";
       };
       "OBJ_121" = {
          isa = "XCConfigurationList";
@@ -250,37 +280,37 @@
       };
       "OBJ_13" = {
          isa = "PBXFileReference";
-         path = "JSIR.swift";
+         path = "FileGenerator.swift";
          sourceTree = "<group>";
       };
       "OBJ_14" = {
          isa = "PBXFileReference";
-         path = "JSModelRenderer.swift";
+         path = "JSADTExtension.swift";
          sourceTree = "<group>";
       };
       "OBJ_15" = {
          isa = "PBXFileReference";
-         path = "JSRuntimeFile.swift";
+         path = "JSFileGenerator.swift";
          sourceTree = "<group>";
       };
       "OBJ_16" = {
          isa = "PBXFileReference";
-         path = "JavaADTRenderer.swift";
+         path = "JSFileRenderer.swift";
          sourceTree = "<group>";
       };
       "OBJ_17" = {
          isa = "PBXFileReference";
-         path = "JavaFileGenerator.swift";
+         path = "JSIR.swift";
          sourceTree = "<group>";
       };
       "OBJ_18" = {
          isa = "PBXFileReference";
-         path = "JavaFileRenderer.swift";
+         path = "JSModelRenderer.swift";
          sourceTree = "<group>";
       };
       "OBJ_19" = {
          isa = "PBXFileReference";
-         path = "JavaIR.swift";
+         path = "JSRuntimeFile.swift";
          sourceTree = "<group>";
       };
       "OBJ_2" = {
@@ -294,52 +324,52 @@
       };
       "OBJ_20" = {
          isa = "PBXFileReference";
-         path = "JavaModelRenderer.swift";
+         path = "JavaADTRenderer.swift";
          sourceTree = "<group>";
       };
       "OBJ_21" = {
          isa = "PBXFileReference";
-         path = "ObjCADTRenderer.swift";
+         path = "JavaFileGenerator.swift";
          sourceTree = "<group>";
       };
       "OBJ_22" = {
          isa = "PBXFileReference";
-         path = "ObjCFileRenderer.swift";
+         path = "JavaFileRenderer.swift";
          sourceTree = "<group>";
       };
       "OBJ_23" = {
          isa = "PBXFileReference";
-         path = "ObjCModelRenderer.swift";
+         path = "JavaIR.swift";
          sourceTree = "<group>";
       };
       "OBJ_24" = {
          isa = "PBXFileReference";
-         path = "ObjectiveCBuilderExtension.swift";
+         path = "JavaModelRenderer.swift";
          sourceTree = "<group>";
       };
       "OBJ_25" = {
          isa = "PBXFileReference";
-         path = "ObjectiveCDebugExtension.swift";
+         path = "ObjCADTRenderer.swift";
          sourceTree = "<group>";
       };
       "OBJ_26" = {
          isa = "PBXFileReference";
-         path = "ObjectiveCDictionaryExtension.swift";
+         path = "ObjCFileRenderer.swift";
          sourceTree = "<group>";
       };
       "OBJ_27" = {
          isa = "PBXFileReference";
-         path = "ObjectiveCEqualityExtension.swift";
+         path = "ObjCModelRenderer.swift";
          sourceTree = "<group>";
       };
       "OBJ_28" = {
          isa = "PBXFileReference";
-         path = "ObjectiveCFileGenerator.swift";
+         path = "ObjectiveCBuilderExtension.swift";
          sourceTree = "<group>";
       };
       "OBJ_29" = {
          isa = "PBXFileReference";
-         path = "ObjectiveCIR.swift";
+         path = "ObjectiveCDebugExtension.swift";
          sourceTree = "<group>";
       };
       "OBJ_3" = {
@@ -383,58 +413,52 @@
       };
       "OBJ_30" = {
          isa = "PBXFileReference";
-         path = "ObjectiveCInitExtension.swift";
+         path = "ObjectiveCDictionaryExtension.swift";
          sourceTree = "<group>";
       };
       "OBJ_31" = {
          isa = "PBXFileReference";
-         path = "ObjectiveCNSCodingExtension.swift";
+         path = "ObjectiveCEqualityExtension.swift";
          sourceTree = "<group>";
       };
       "OBJ_32" = {
          isa = "PBXFileReference";
-         path = "Schema.swift";
+         path = "ObjectiveCFileGenerator.swift";
          sourceTree = "<group>";
       };
       "OBJ_33" = {
          isa = "PBXFileReference";
-         path = "SchemaLoader.swift";
+         path = "ObjectiveCIR.swift";
          sourceTree = "<group>";
       };
       "OBJ_34" = {
          isa = "PBXFileReference";
-         path = "StringExtensions.swift";
+         path = "ObjectiveCInitExtension.swift";
          sourceTree = "<group>";
       };
       "OBJ_35" = {
          isa = "PBXFileReference";
-         path = "UtilitySourceIncluder.swift";
+         path = "ObjectiveCNSCodingExtension.swift";
          sourceTree = "<group>";
       };
       "OBJ_36" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_37",
-            "OBJ_38",
-            "OBJ_39"
-         );
-         name = "plank";
-         path = "Sources/plank";
-         sourceTree = "SOURCE_ROOT";
+         isa = "PBXFileReference";
+         path = "Schema.swift";
+         sourceTree = "<group>";
       };
       "OBJ_37" = {
          isa = "PBXFileReference";
-         path = "Cli.swift";
+         path = "SchemaLoader.swift";
          sourceTree = "<group>";
       };
       "OBJ_38" = {
          isa = "PBXFileReference";
-         path = "Version.swift";
+         path = "StringExtensions.swift";
          sourceTree = "<group>";
       };
       "OBJ_39" = {
          isa = "PBXFileReference";
-         path = "main.swift";
+         path = "UtilitySourceIncluder.swift";
          sourceTree = "<group>";
       };
       "OBJ_4" = {
@@ -560,9 +584,9 @@
       "OBJ_52" = {
          isa = "PBXGroup";
          children = (
-            "plank::plank::Product",
+            "plank::Core::Product",
             "plank::CoreTests::Product",
-            "plank::Core::Product"
+            "plank::plank::Product"
          );
          name = "Products";
          path = "";
@@ -691,45 +715,45 @@
       };
       "OBJ_61" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_9";
+         fileRef = "OBJ_13";
       };
       "OBJ_62" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_10";
+         fileRef = "OBJ_14";
       };
       "OBJ_63" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_11";
+         fileRef = "OBJ_15";
       };
       "OBJ_64" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_12";
+         fileRef = "OBJ_16";
       };
       "OBJ_65" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_13";
+         fileRef = "OBJ_17";
       };
       "OBJ_66" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_14";
+         fileRef = "OBJ_18";
       };
       "OBJ_67" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_15";
+         fileRef = "OBJ_19";
       };
       "OBJ_68" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_16";
+         fileRef = "OBJ_20";
       };
       "OBJ_69" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_17";
+         fileRef = "OBJ_21";
       };
       "OBJ_7" = {
          isa = "PBXGroup";
          children = (
             "OBJ_8",
-            "OBJ_36"
+            "OBJ_12"
          );
          name = "Sources";
          path = "";
@@ -737,110 +761,86 @@
       };
       "OBJ_70" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_18";
+         fileRef = "OBJ_22";
       };
       "OBJ_71" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_19";
+         fileRef = "OBJ_23";
       };
       "OBJ_72" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_20";
+         fileRef = "OBJ_24";
       };
       "OBJ_73" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_21";
+         fileRef = "OBJ_25";
       };
       "OBJ_74" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_22";
+         fileRef = "OBJ_26";
       };
       "OBJ_75" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_23";
+         fileRef = "OBJ_27";
       };
       "OBJ_76" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_24";
+         fileRef = "OBJ_28";
       };
       "OBJ_77" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_25";
+         fileRef = "OBJ_29";
       };
       "OBJ_78" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_26";
+         fileRef = "OBJ_30";
       };
       "OBJ_79" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_27";
+         fileRef = "OBJ_31";
       };
       "OBJ_8" = {
          isa = "PBXGroup";
          children = (
             "OBJ_9",
             "OBJ_10",
-            "OBJ_11",
-            "OBJ_12",
-            "OBJ_13",
-            "OBJ_14",
-            "OBJ_15",
-            "OBJ_16",
-            "OBJ_17",
-            "OBJ_18",
-            "OBJ_19",
-            "OBJ_20",
-            "OBJ_21",
-            "OBJ_22",
-            "OBJ_23",
-            "OBJ_24",
-            "OBJ_25",
-            "OBJ_26",
-            "OBJ_27",
-            "OBJ_28",
-            "OBJ_29",
-            "OBJ_30",
-            "OBJ_31",
-            "OBJ_32",
-            "OBJ_33",
-            "OBJ_34",
-            "OBJ_35"
+            "OBJ_11"
          );
-         name = "Core";
-         path = "Sources/Core";
+         name = "plank";
+         path = "Sources/plank";
          sourceTree = "SOURCE_ROOT";
       };
       "OBJ_80" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_28";
+         fileRef = "OBJ_32";
       };
       "OBJ_81" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_29";
+         fileRef = "OBJ_33";
       };
       "OBJ_82" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_30";
+         fileRef = "OBJ_34";
       };
       "OBJ_83" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_31";
+         fileRef = "OBJ_35";
       };
       "OBJ_84" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_32";
+         fileRef = "OBJ_36";
       };
       "OBJ_85" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_33";
+         fileRef = "OBJ_37";
       };
       "OBJ_86" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_34";
+         fileRef = "OBJ_38";
       };
       "OBJ_87" = {
          isa = "PBXBuildFile";
-         fileRef = "OBJ_35";
+         fileRef = "OBJ_39";
       };
       "OBJ_88" = {
          isa = "PBXFrameworksBuildPhase";
@@ -849,7 +849,7 @@
       };
       "OBJ_9" = {
          isa = "PBXFileReference";
-         path = "FileGenerator.swift";
+         path = "Cli.swift";
          sourceTree = "<group>";
       };
       "OBJ_90" = {

--- a/plank.xcodeproj/project.pbxproj
+++ b/plank.xcodeproj/project.pbxproj
@@ -1,1053 +1,716 @@
 // !$*UTF8*$!
 {
-   archiveVersion = "1";
-   objectVersion = "46";
-   objects = {
-      "OBJ_1" = {
-         isa = "PBXProject";
-         attributes = {
-            LastUpgradeCheck = "9999";
-         };
-         buildConfigurationList = "OBJ_2";
-         compatibilityVersion = "Xcode 3.2";
-         developmentRegion = "English";
-         hasScannedForEncodings = "0";
-         knownRegions = (
-            "en"
-         );
-         mainGroup = "OBJ_5";
-         productRefGroup = "OBJ_52";
-         projectDirPath = ".";
-         targets = (
-            "plank::Core",
-            "plank::CoreTests",
-            "plank::plank",
-            "plank::SwiftPMPackageDescription",
-            "plank::plankPackageTests::ProductTarget"
-         );
-      };
-      "OBJ_10" = {
-         isa = "PBXFileReference";
-         path = "Version.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_100" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_101"
-         );
-      };
-      "OBJ_101" = {
-         isa = "PBXBuildFile";
-         fileRef = "plank::Core::Product";
-      };
-      "OBJ_102" = {
-         isa = "PBXTargetDependency";
-         target = "plank::Core";
-      };
-      "OBJ_104" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_105",
-            "OBJ_106"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_105" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "plank.xcodeproj/plank_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-               "@executable_path"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_FORCE_DYNAMIC_LINK_STDLIB = "YES";
-            SWIFT_FORCE_STATIC_LINK_STDLIB = "NO";
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "plank";
-         };
-         name = "Debug";
-      };
-      "OBJ_106" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "plank.xcodeproj/plank_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
-               "@executable_path"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_FORCE_DYNAMIC_LINK_STDLIB = "YES";
-            SWIFT_FORCE_STATIC_LINK_STDLIB = "NO";
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "plank";
-         };
-         name = "Release";
-      };
-      "OBJ_107" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_108",
-            "OBJ_109",
-            "OBJ_110"
-         );
-      };
-      "OBJ_108" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_9";
-      };
-      "OBJ_109" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_10";
-      };
-      "OBJ_11" = {
-         isa = "PBXFileReference";
-         path = "main.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_110" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_11";
-      };
-      "OBJ_111" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_112"
-         );
-      };
-      "OBJ_112" = {
-         isa = "PBXBuildFile";
-         fileRef = "plank::Core::Product";
-      };
-      "OBJ_113" = {
-         isa = "PBXTargetDependency";
-         target = "plank::Core";
-      };
-      "OBJ_115" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_116",
-            "OBJ_117"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_116" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_117" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk"
-            );
-            SWIFT_VERSION = "4.0";
-         };
-         name = "Release";
-      };
-      "OBJ_118" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_119"
-         );
-      };
-      "OBJ_119" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_6";
-      };
-      "OBJ_12" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_13",
-            "OBJ_14",
-            "OBJ_15",
-            "OBJ_16",
-            "OBJ_17",
-            "OBJ_18",
-            "OBJ_19",
-            "OBJ_20",
-            "OBJ_21",
-            "OBJ_22",
-            "OBJ_23",
-            "OBJ_24",
-            "OBJ_25",
-            "OBJ_26",
-            "OBJ_27",
-            "OBJ_28",
-            "OBJ_29",
-            "OBJ_30",
-            "OBJ_31",
-            "OBJ_32",
-            "OBJ_33",
-            "OBJ_34",
-            "OBJ_35",
-            "OBJ_36",
-            "OBJ_37",
-            "OBJ_38",
-            "OBJ_39"
-         );
-         name = "Core";
-         path = "Sources/Core";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_121" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_122",
-            "OBJ_123"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_122" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Debug";
-      };
-      "OBJ_123" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Release";
-      };
-      "OBJ_124" = {
-         isa = "PBXTargetDependency";
-         target = "plank::CoreTests";
-      };
-      "OBJ_13" = {
-         isa = "PBXFileReference";
-         path = "FileGenerator.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_14" = {
-         isa = "PBXFileReference";
-         path = "JSADTExtension.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_15" = {
-         isa = "PBXFileReference";
-         path = "JSFileGenerator.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_16" = {
-         isa = "PBXFileReference";
-         path = "JSFileRenderer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_17" = {
-         isa = "PBXFileReference";
-         path = "JSIR.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_18" = {
-         isa = "PBXFileReference";
-         path = "JSModelRenderer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_19" = {
-         isa = "PBXFileReference";
-         path = "JSRuntimeFile.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_2" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_3",
-            "OBJ_4"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_20" = {
-         isa = "PBXFileReference";
-         path = "JavaADTRenderer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_21" = {
-         isa = "PBXFileReference";
-         path = "JavaFileGenerator.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_22" = {
-         isa = "PBXFileReference";
-         path = "JavaFileRenderer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_23" = {
-         isa = "PBXFileReference";
-         path = "JavaIR.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_24" = {
-         isa = "PBXFileReference";
-         path = "JavaModelRenderer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_25" = {
-         isa = "PBXFileReference";
-         path = "ObjCADTRenderer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_26" = {
-         isa = "PBXFileReference";
-         path = "ObjCFileRenderer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_27" = {
-         isa = "PBXFileReference";
-         path = "ObjCModelRenderer.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_28" = {
-         isa = "PBXFileReference";
-         path = "ObjectiveCBuilderExtension.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_29" = {
-         isa = "PBXFileReference";
-         path = "ObjectiveCDebugExtension.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_3" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "NO";
-            DEBUG_INFORMATION_FORMAT = "dwarf";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            ENABLE_NS_ASSERTIONS = "YES";
-            GCC_OPTIMIZATION_LEVEL = "0";
-            GCC_PREPROCESSOR_DEFINITIONS = (
-               "DEBUG=1",
-               "$(inherited)"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            ONLY_ACTIVE_ARCH = "YES";
-            OTHER_SWIFT_FLAGS = (
-               "-DXcode"
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "SWIFT_PACKAGE",
-               "DEBUG"
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Debug";
-      };
-      "OBJ_30" = {
-         isa = "PBXFileReference";
-         path = "ObjectiveCDictionaryExtension.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_31" = {
-         isa = "PBXFileReference";
-         path = "ObjectiveCEqualityExtension.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_32" = {
-         isa = "PBXFileReference";
-         path = "ObjectiveCFileGenerator.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_33" = {
-         isa = "PBXFileReference";
-         path = "ObjectiveCIR.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_34" = {
-         isa = "PBXFileReference";
-         path = "ObjectiveCInitExtension.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_35" = {
-         isa = "PBXFileReference";
-         path = "ObjectiveCNSCodingExtension.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_36" = {
-         isa = "PBXFileReference";
-         path = "Schema.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_37" = {
-         isa = "PBXFileReference";
-         path = "SchemaLoader.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_38" = {
-         isa = "PBXFileReference";
-         path = "StringExtensions.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_39" = {
-         isa = "PBXFileReference";
-         path = "UtilitySourceIncluder.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_4" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "YES";
-            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            GCC_OPTIMIZATION_LEVEL = "s";
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_SWIFT_FLAGS = (
-               "-DXcode"
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "SWIFT_PACKAGE"
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Release";
-      };
-      "OBJ_40" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_41"
-         );
-         name = "Tests";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_41" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_42",
-            "OBJ_43",
-            "OBJ_44",
-            "OBJ_45",
-            "OBJ_46",
-            "OBJ_47"
-         );
-         name = "CoreTests";
-         path = "Tests/CoreTests";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_42" = {
-         isa = "PBXFileReference";
-         path = "LinuxTestIndex.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_43" = {
-         isa = "PBXFileReference";
-         path = "MockSchemaLoader.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_44" = {
-         isa = "PBXFileReference";
-         path = "ObjectiveCIRTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_45" = {
-         isa = "PBXFileReference";
-         path = "ObjectiveCInitTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_46" = {
-         isa = "PBXFileReference";
-         path = "PlankTestExtension.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_47" = {
-         isa = "PBXFileReference";
-         path = "StringExtensionsTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_48" = {
-         isa = "PBXFileReference";
-         path = "CI";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_49" = {
-         isa = "PBXFileReference";
-         path = "docs";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_5" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_6",
-            "OBJ_7",
-            "OBJ_40",
-            "OBJ_48",
-            "OBJ_49",
-            "OBJ_50",
-            "OBJ_51",
-            "OBJ_52"
-         );
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_50" = {
-         isa = "PBXFileReference";
-         path = "Examples";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_51" = {
-         isa = "PBXFileReference";
-         path = "Utility";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_52" = {
-         isa = "PBXGroup";
-         children = (
-            "plank::Core::Product",
-            "plank::CoreTests::Product",
-            "plank::plank::Product"
-         );
-         name = "Products";
-         path = "";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "OBJ_57" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_58",
-            "OBJ_59"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_58" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "plank.xcodeproj/Core_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Core";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "Core";
-         };
-         name = "Debug";
-      };
-      "OBJ_59" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "plank.xcodeproj/Core_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Core";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "Core";
-         };
-         name = "Release";
-      };
-      "OBJ_6" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         path = "Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_60" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_61",
-            "OBJ_62",
-            "OBJ_63",
-            "OBJ_64",
-            "OBJ_65",
-            "OBJ_66",
-            "OBJ_67",
-            "OBJ_68",
-            "OBJ_69",
-            "OBJ_70",
-            "OBJ_71",
-            "OBJ_72",
-            "OBJ_73",
-            "OBJ_74",
-            "OBJ_75",
-            "OBJ_76",
-            "OBJ_77",
-            "OBJ_78",
-            "OBJ_79",
-            "OBJ_80",
-            "OBJ_81",
-            "OBJ_82",
-            "OBJ_83",
-            "OBJ_84",
-            "OBJ_85",
-            "OBJ_86",
-            "OBJ_87"
-         );
-      };
-      "OBJ_61" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_13";
-      };
-      "OBJ_62" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_14";
-      };
-      "OBJ_63" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_15";
-      };
-      "OBJ_64" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_16";
-      };
-      "OBJ_65" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_17";
-      };
-      "OBJ_66" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_18";
-      };
-      "OBJ_67" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_19";
-      };
-      "OBJ_68" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_20";
-      };
-      "OBJ_69" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_21";
-      };
-      "OBJ_7" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_8",
-            "OBJ_12"
-         );
-         name = "Sources";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_70" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_22";
-      };
-      "OBJ_71" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_23";
-      };
-      "OBJ_72" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_24";
-      };
-      "OBJ_73" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_25";
-      };
-      "OBJ_74" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_26";
-      };
-      "OBJ_75" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_27";
-      };
-      "OBJ_76" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_28";
-      };
-      "OBJ_77" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_29";
-      };
-      "OBJ_78" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_30";
-      };
-      "OBJ_79" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_31";
-      };
-      "OBJ_8" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_9",
-            "OBJ_10",
-            "OBJ_11"
-         );
-         name = "plank";
-         path = "Sources/plank";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_80" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_32";
-      };
-      "OBJ_81" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_33";
-      };
-      "OBJ_82" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_34";
-      };
-      "OBJ_83" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_35";
-      };
-      "OBJ_84" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_36";
-      };
-      "OBJ_85" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_37";
-      };
-      "OBJ_86" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_38";
-      };
-      "OBJ_87" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_39";
-      };
-      "OBJ_88" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_9" = {
-         isa = "PBXFileReference";
-         path = "Cli.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_90" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_91",
-            "OBJ_92"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_91" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "plank.xcodeproj/CoreTests_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "CoreTests";
-         };
-         name = "Debug";
-      };
-      "OBJ_92" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "plank.xcodeproj/CoreTests_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.0";
-            TARGET_NAME = "CoreTests";
-         };
-         name = "Release";
-      };
-      "OBJ_93" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_94",
-            "OBJ_95",
-            "OBJ_96",
-            "OBJ_97",
-            "OBJ_98",
-            "OBJ_99"
-         );
-      };
-      "OBJ_94" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_42";
-      };
-      "OBJ_95" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_43";
-      };
-      "OBJ_96" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_44";
-      };
-      "OBJ_97" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_45";
-      };
-      "OBJ_98" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_46";
-      };
-      "OBJ_99" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_47";
-      };
-      "plank::Core" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_57";
-         buildPhases = (
-            "OBJ_60",
-            "OBJ_88"
-         );
-         dependencies = (
-         );
-         name = "Core";
-         productName = "Core";
-         productReference = "plank::Core::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "plank::Core::Product" = {
-         isa = "PBXFileReference";
-         path = "Core.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "plank::CoreTests" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_90";
-         buildPhases = (
-            "OBJ_93",
-            "OBJ_100"
-         );
-         dependencies = (
-            "OBJ_102"
-         );
-         name = "CoreTests";
-         productName = "CoreTests";
-         productReference = "plank::CoreTests::Product";
-         productType = "com.apple.product-type.bundle.unit-test";
-      };
-      "plank::CoreTests::Product" = {
-         isa = "PBXFileReference";
-         path = "CoreTests.xctest";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "plank::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_115";
-         buildPhases = (
-            "OBJ_118"
-         );
-         dependencies = (
-         );
-         name = "plankPackageDescription";
-         productName = "plankPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "plank::plank" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_104";
-         buildPhases = (
-            "OBJ_107",
-            "OBJ_111"
-         );
-         dependencies = (
-            "OBJ_113"
-         );
-         name = "plank";
-         productName = "plank";
-         productReference = "plank::plank::Product";
-         productType = "com.apple.product-type.tool";
-      };
-      "plank::plank::Product" = {
-         isa = "PBXFileReference";
-         path = "plank";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "plank::plankPackageTests::ProductTarget" = {
-         isa = "PBXAggregateTarget";
-         buildConfigurationList = "OBJ_121";
-         buildPhases = (
-         );
-         dependencies = (
-            "OBJ_124"
-         );
-         name = "plankPackageTests";
-         productName = "plankPackageTests";
-      };
-   };
-   rootObject = "OBJ_1";
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		"plank::plankPackageTests::ProductTarget" /* plankPackageTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_121 /* Build configuration list for PBXAggregateTarget "plankPackageTests" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_124 /* PBXTargetDependency */,
+			);
+			name = plankPackageTests;
+			productName = plankPackageTests;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		OBJ_101 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "plank::Core::Product" /* Core.framework */; };
+		OBJ_108 /* Cli.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Cli.swift */; };
+		OBJ_109 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Version.swift */; };
+		OBJ_110 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* main.swift */; };
+		OBJ_112 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "plank::Core::Product" /* Core.framework */; };
+		OBJ_119 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_61 /* FileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* FileGenerator.swift */; };
+		OBJ_62 /* JSADTExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* JSADTExtension.swift */; };
+		OBJ_63 /* JSFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* JSFileGenerator.swift */; };
+		OBJ_64 /* JSFileRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* JSFileRenderer.swift */; };
+		OBJ_65 /* JSIR.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* JSIR.swift */; };
+		OBJ_66 /* JSModelRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* JSModelRenderer.swift */; };
+		OBJ_67 /* JSRuntimeFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* JSRuntimeFile.swift */; };
+		OBJ_68 /* JavaADTRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* JavaADTRenderer.swift */; };
+		OBJ_69 /* JavaFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* JavaFileGenerator.swift */; };
+		OBJ_70 /* JavaFileRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* JavaFileRenderer.swift */; };
+		OBJ_71 /* JavaIR.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* JavaIR.swift */; };
+		OBJ_72 /* JavaModelRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* JavaModelRenderer.swift */; };
+		OBJ_73 /* ObjCADTRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* ObjCADTRenderer.swift */; };
+		OBJ_74 /* ObjCFileRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* ObjCFileRenderer.swift */; };
+		OBJ_75 /* ObjCModelRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* ObjCModelRenderer.swift */; };
+		OBJ_76 /* ObjectiveCBuilderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* ObjectiveCBuilderExtension.swift */; };
+		OBJ_77 /* ObjectiveCDebugExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* ObjectiveCDebugExtension.swift */; };
+		OBJ_78 /* ObjectiveCDictionaryExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* ObjectiveCDictionaryExtension.swift */; };
+		OBJ_79 /* ObjectiveCEqualityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* ObjectiveCEqualityExtension.swift */; };
+		OBJ_80 /* ObjectiveCFileGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* ObjectiveCFileGenerator.swift */; };
+		OBJ_81 /* ObjectiveCIR.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* ObjectiveCIR.swift */; };
+		OBJ_82 /* ObjectiveCInitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* ObjectiveCInitExtension.swift */; };
+		OBJ_83 /* ObjectiveCNSCodingExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* ObjectiveCNSCodingExtension.swift */; };
+		OBJ_84 /* Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_36 /* Schema.swift */; };
+		OBJ_85 /* SchemaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* SchemaLoader.swift */; };
+		OBJ_86 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* StringExtensions.swift */; };
+		OBJ_87 /* UtilitySourceIncluder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* UtilitySourceIncluder.swift */; };
+		OBJ_94 /* LinuxTestIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* LinuxTestIndex.swift */; };
+		OBJ_95 /* MockSchemaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* MockSchemaLoader.swift */; };
+		OBJ_96 /* ObjectiveCIRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* ObjectiveCIRTests.swift */; };
+		OBJ_97 /* ObjectiveCInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* ObjectiveCInitTests.swift */; };
+		OBJ_98 /* PlankTestExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* PlankTestExtension.swift */; };
+		OBJ_99 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_47 /* StringExtensionsTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		96670E7E217FE1AC000BA8C6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "plank::Core";
+			remoteInfo = Core;
+		};
+		96670E7F217FE1AC000BA8C6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "plank::Core";
+			remoteInfo = Core;
+		};
+		96670E80217FE1AE000BA8C6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "plank::CoreTests";
+			remoteInfo = CoreTests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		OBJ_10 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		OBJ_11 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		OBJ_13 /* FileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileGenerator.swift; sourceTree = "<group>"; };
+		OBJ_14 /* JSADTExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSADTExtension.swift; sourceTree = "<group>"; };
+		OBJ_15 /* JSFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSFileGenerator.swift; sourceTree = "<group>"; };
+		OBJ_16 /* JSFileRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSFileRenderer.swift; sourceTree = "<group>"; };
+		OBJ_17 /* JSIR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSIR.swift; sourceTree = "<group>"; };
+		OBJ_18 /* JSModelRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSModelRenderer.swift; sourceTree = "<group>"; };
+		OBJ_19 /* JSRuntimeFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSRuntimeFile.swift; sourceTree = "<group>"; };
+		OBJ_20 /* JavaADTRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaADTRenderer.swift; sourceTree = "<group>"; };
+		OBJ_21 /* JavaFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaFileGenerator.swift; sourceTree = "<group>"; };
+		OBJ_22 /* JavaFileRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaFileRenderer.swift; sourceTree = "<group>"; };
+		OBJ_23 /* JavaIR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaIR.swift; sourceTree = "<group>"; };
+		OBJ_24 /* JavaModelRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaModelRenderer.swift; sourceTree = "<group>"; };
+		OBJ_25 /* ObjCADTRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCADTRenderer.swift; sourceTree = "<group>"; };
+		OBJ_26 /* ObjCFileRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCFileRenderer.swift; sourceTree = "<group>"; };
+		OBJ_27 /* ObjCModelRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCModelRenderer.swift; sourceTree = "<group>"; };
+		OBJ_28 /* ObjectiveCBuilderExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCBuilderExtension.swift; sourceTree = "<group>"; };
+		OBJ_29 /* ObjectiveCDebugExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCDebugExtension.swift; sourceTree = "<group>"; };
+		OBJ_30 /* ObjectiveCDictionaryExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCDictionaryExtension.swift; sourceTree = "<group>"; };
+		OBJ_31 /* ObjectiveCEqualityExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCEqualityExtension.swift; sourceTree = "<group>"; };
+		OBJ_32 /* ObjectiveCFileGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCFileGenerator.swift; sourceTree = "<group>"; };
+		OBJ_33 /* ObjectiveCIR.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCIR.swift; sourceTree = "<group>"; };
+		OBJ_34 /* ObjectiveCInitExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCInitExtension.swift; sourceTree = "<group>"; };
+		OBJ_35 /* ObjectiveCNSCodingExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCNSCodingExtension.swift; sourceTree = "<group>"; };
+		OBJ_36 /* Schema.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Schema.swift; sourceTree = "<group>"; };
+		OBJ_37 /* SchemaLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchemaLoader.swift; sourceTree = "<group>"; };
+		OBJ_38 /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
+		OBJ_39 /* UtilitySourceIncluder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilitySourceIncluder.swift; sourceTree = "<group>"; };
+		OBJ_42 /* LinuxTestIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinuxTestIndex.swift; sourceTree = "<group>"; };
+		OBJ_43 /* MockSchemaLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSchemaLoader.swift; sourceTree = "<group>"; };
+		OBJ_44 /* ObjectiveCIRTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCIRTests.swift; sourceTree = "<group>"; };
+		OBJ_45 /* ObjectiveCInitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectiveCInitTests.swift; sourceTree = "<group>"; };
+		OBJ_46 /* PlankTestExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlankTestExtension.swift; sourceTree = "<group>"; };
+		OBJ_47 /* StringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
+		OBJ_48 /* CI */ = {isa = PBXFileReference; lastKnownFileType = folder; path = CI; sourceTree = SOURCE_ROOT; };
+		OBJ_49 /* docs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = docs; sourceTree = SOURCE_ROOT; };
+		OBJ_50 /* Examples */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Examples; sourceTree = SOURCE_ROOT; };
+		OBJ_51 /* Utility */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Utility; sourceTree = SOURCE_ROOT; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_9 /* Cli.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cli.swift; sourceTree = "<group>"; };
+		"plank::Core::Product" /* Core.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"plank::CoreTests::Product" /* CoreTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = CoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"plank::plank::Product" /* plank */ = {isa = PBXFileReference; lastKnownFileType = text; path = plank; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_100 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_101 /* Core.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_111 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_112 /* Core.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_88 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_12 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_13 /* FileGenerator.swift */,
+				OBJ_14 /* JSADTExtension.swift */,
+				OBJ_15 /* JSFileGenerator.swift */,
+				OBJ_16 /* JSFileRenderer.swift */,
+				OBJ_17 /* JSIR.swift */,
+				OBJ_18 /* JSModelRenderer.swift */,
+				OBJ_19 /* JSRuntimeFile.swift */,
+				OBJ_20 /* JavaADTRenderer.swift */,
+				OBJ_21 /* JavaFileGenerator.swift */,
+				OBJ_22 /* JavaFileRenderer.swift */,
+				OBJ_23 /* JavaIR.swift */,
+				OBJ_24 /* JavaModelRenderer.swift */,
+				OBJ_25 /* ObjCADTRenderer.swift */,
+				OBJ_26 /* ObjCFileRenderer.swift */,
+				OBJ_27 /* ObjCModelRenderer.swift */,
+				OBJ_28 /* ObjectiveCBuilderExtension.swift */,
+				OBJ_29 /* ObjectiveCDebugExtension.swift */,
+				OBJ_30 /* ObjectiveCDictionaryExtension.swift */,
+				OBJ_31 /* ObjectiveCEqualityExtension.swift */,
+				OBJ_32 /* ObjectiveCFileGenerator.swift */,
+				OBJ_33 /* ObjectiveCIR.swift */,
+				OBJ_34 /* ObjectiveCInitExtension.swift */,
+				OBJ_35 /* ObjectiveCNSCodingExtension.swift */,
+				OBJ_36 /* Schema.swift */,
+				OBJ_37 /* SchemaLoader.swift */,
+				OBJ_38 /* StringExtensions.swift */,
+				OBJ_39 /* UtilitySourceIncluder.swift */,
+			);
+			name = Core;
+			path = Sources/Core;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_40 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_41 /* CoreTests */,
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_41 /* CoreTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_42 /* LinuxTestIndex.swift */,
+				OBJ_43 /* MockSchemaLoader.swift */,
+				OBJ_44 /* ObjectiveCIRTests.swift */,
+				OBJ_45 /* ObjectiveCInitTests.swift */,
+				OBJ_46 /* PlankTestExtension.swift */,
+				OBJ_47 /* StringExtensionsTests.swift */,
+			);
+			name = CoreTests;
+			path = Tests/CoreTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_5 /*  */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_40 /* Tests */,
+				OBJ_48 /* CI */,
+				OBJ_49 /* docs */,
+				OBJ_50 /* Examples */,
+				OBJ_51 /* Utility */,
+				OBJ_52 /* Products */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_52 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"plank::Core::Product" /* Core.framework */,
+				"plank::CoreTests::Product" /* CoreTests.xctest */,
+				"plank::plank::Product" /* plank */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* plank */,
+				OBJ_12 /* Core */,
+			);
+			name = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_8 /* plank */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* Cli.swift */,
+				OBJ_10 /* Version.swift */,
+				OBJ_11 /* main.swift */,
+			);
+			name = plank;
+			path = Sources/plank;
+			sourceTree = SOURCE_ROOT;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"plank::Core" /* Core */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_57 /* Build configuration list for PBXNativeTarget "Core" */;
+			buildPhases = (
+				OBJ_60 /* Sources */,
+				OBJ_88 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Core;
+			productName = Core;
+			productReference = "plank::Core::Product" /* Core.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"plank::CoreTests" /* CoreTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_90 /* Build configuration list for PBXNativeTarget "CoreTests" */;
+			buildPhases = (
+				OBJ_93 /* Sources */,
+				OBJ_100 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_102 /* PBXTargetDependency */,
+			);
+			name = CoreTests;
+			productName = CoreTests;
+			productReference = "plank::CoreTests::Product" /* CoreTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		"plank::SwiftPMPackageDescription" /* plankPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_115 /* Build configuration list for PBXNativeTarget "plankPackageDescription" */;
+			buildPhases = (
+				OBJ_118 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = plankPackageDescription;
+			productName = plankPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"plank::plank" /* plank */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_104 /* Build configuration list for PBXNativeTarget "plank" */;
+			buildPhases = (
+				OBJ_107 /* Sources */,
+				OBJ_111 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_113 /* PBXTargetDependency */,
+			);
+			name = plank;
+			productName = plank;
+			productReference = "plank::plank::Product" /* plank */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "plank" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_52 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"plank::Core" /* Core */,
+				"plank::CoreTests" /* CoreTests */,
+				"plank::plank" /* plank */,
+				"plank::SwiftPMPackageDescription" /* plankPackageDescription */,
+				"plank::plankPackageTests::ProductTarget" /* plankPackageTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_107 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_108 /* Cli.swift in Sources */,
+				OBJ_109 /* Version.swift in Sources */,
+				OBJ_110 /* main.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_118 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_119 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_60 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_61 /* FileGenerator.swift in Sources */,
+				OBJ_62 /* JSADTExtension.swift in Sources */,
+				OBJ_63 /* JSFileGenerator.swift in Sources */,
+				OBJ_64 /* JSFileRenderer.swift in Sources */,
+				OBJ_65 /* JSIR.swift in Sources */,
+				OBJ_66 /* JSModelRenderer.swift in Sources */,
+				OBJ_67 /* JSRuntimeFile.swift in Sources */,
+				OBJ_68 /* JavaADTRenderer.swift in Sources */,
+				OBJ_69 /* JavaFileGenerator.swift in Sources */,
+				OBJ_70 /* JavaFileRenderer.swift in Sources */,
+				OBJ_71 /* JavaIR.swift in Sources */,
+				OBJ_72 /* JavaModelRenderer.swift in Sources */,
+				OBJ_73 /* ObjCADTRenderer.swift in Sources */,
+				OBJ_74 /* ObjCFileRenderer.swift in Sources */,
+				OBJ_75 /* ObjCModelRenderer.swift in Sources */,
+				OBJ_76 /* ObjectiveCBuilderExtension.swift in Sources */,
+				OBJ_77 /* ObjectiveCDebugExtension.swift in Sources */,
+				OBJ_78 /* ObjectiveCDictionaryExtension.swift in Sources */,
+				OBJ_79 /* ObjectiveCEqualityExtension.swift in Sources */,
+				OBJ_80 /* ObjectiveCFileGenerator.swift in Sources */,
+				OBJ_81 /* ObjectiveCIR.swift in Sources */,
+				OBJ_82 /* ObjectiveCInitExtension.swift in Sources */,
+				OBJ_83 /* ObjectiveCNSCodingExtension.swift in Sources */,
+				OBJ_84 /* Schema.swift in Sources */,
+				OBJ_85 /* SchemaLoader.swift in Sources */,
+				OBJ_86 /* StringExtensions.swift in Sources */,
+				OBJ_87 /* UtilitySourceIncluder.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_93 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_94 /* LinuxTestIndex.swift in Sources */,
+				OBJ_95 /* MockSchemaLoader.swift in Sources */,
+				OBJ_96 /* ObjectiveCIRTests.swift in Sources */,
+				OBJ_97 /* ObjectiveCInitTests.swift in Sources */,
+				OBJ_98 /* PlankTestExtension.swift in Sources */,
+				OBJ_99 /* StringExtensionsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_102 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "plank::Core" /* Core */;
+			targetProxy = 96670E7F217FE1AC000BA8C6 /* PBXContainerItemProxy */;
+		};
+		OBJ_113 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "plank::Core" /* Core */;
+			targetProxy = 96670E7E217FE1AC000BA8C6 /* PBXContainerItemProxy */;
+		};
+		OBJ_124 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "plank::CoreTests" /* CoreTests */;
+			targetProxy = 96670E80217FE1AE000BA8C6 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_105 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = plank.xcodeproj/plank_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = plank;
+			};
+			name = Debug;
+		};
+		OBJ_106 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = plank.xcodeproj/plank_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_FORCE_DYNAMIC_LINK_STDLIB = YES;
+				SWIFT_FORCE_STATIC_LINK_STDLIB = NO;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = plank;
+			};
+			name = Release;
+		};
+		OBJ_116 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		OBJ_117 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		OBJ_122 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_123 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SWIFT_PACKAGE DEBUG";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_58 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = plank.xcodeproj/Core_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Core;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Core;
+			};
+			name = Debug;
+		};
+		OBJ_59 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = plank.xcodeproj/Core_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Core;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Core;
+			};
+			name = Release;
+		};
+		OBJ_91 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = plank.xcodeproj/CoreTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = CoreTests;
+			};
+			name = Debug;
+		};
+		OBJ_92 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = plank.xcodeproj/CoreTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = CoreTests;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_104 /* Build configuration list for PBXNativeTarget "plank" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_105 /* Debug */,
+				OBJ_106 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_115 /* Build configuration list for PBXNativeTarget "plankPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_116 /* Debug */,
+				OBJ_117 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_121 /* Build configuration list for PBXAggregateTarget "plankPackageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_122 /* Debug */,
+				OBJ_123 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2 /* Build configuration list for PBXProject "plank" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_57 /* Build configuration list for PBXNativeTarget "Core" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_58 /* Debug */,
+				OBJ_59 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_90 /* Build configuration list for PBXNativeTarget "CoreTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_91 /* Debug */,
+				OBJ_92 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
 }

--- a/plank.xcodeproj/xcshareddata/xcschemes/plank-Package.xcscheme
+++ b/plank.xcodeproj/xcshareddata/xcschemes/plank-Package.xcscheme
@@ -1,41 +1,95 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Scheme LastUpgradeVersion = "9999" version = "1.3">
-  <BuildAction parallelizeBuildables = "YES" buildImplicitDependencies = "YES">
-    <BuildActionEntries>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "Core"
-          ReferencedContainer = "container:plank.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'$(TARGET_NAME)'"
-          BlueprintName = "plank"
-          ReferencedContainer = "container:plank.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-    </BuildActionEntries>
-  </BuildAction>
-  <TestAction
-    buildConfiguration = "Debug"
-    selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-    selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-    shouldUseLaunchSchemeArgsEnv = "YES"
-    codeCoverageEnabled = "NO">
-    <Testables>
-        <TestableReference
-          skipped = "NO">
-          <BuildableReference
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "plank::plank"
+               BuildableName = "plank"
+               BlueprintName = "plank"
+               ReferencedContainer = "container:plank.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "plank::Core"
+               BuildableName = "Core.framework"
+               BlueprintName = "Core"
+               ReferencedContainer = "container:plank.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "plank::CoreTests"
+               BuildableName = "CoreTests.xctest"
+               BlueprintName = "CoreTests"
+               ReferencedContainer = "container:plank.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
             BuildableIdentifier = "primary"
-            BuildableName = "'$(TARGET_NAME)'"
-            BlueprintName = "CoreTests"
+            BlueprintIdentifier = "plank::plank"
+            BuildableName = "plank"
+            BlueprintName = "plank"
             ReferencedContainer = "container:plank.xcodeproj">
-          </BuildableReference>
-        </TestableReference>
-    </Testables>
-  </TestAction>
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>

--- a/plank.xcodeproj/xcshareddata/xcschemes/plank-Package.xcscheme
+++ b/plank.xcodeproj/xcshareddata/xcschemes/plank-Package.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "plank::plank"
-               BuildableName = "plank"
-               BlueprintName = "plank"
+               BlueprintIdentifier = "plank::Core"
+               BuildableName = "Core.framework"
+               BlueprintName = "Core"
                ReferencedContainer = "container:plank.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,9 +28,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "plank::Core"
-               BuildableName = "Core.framework"
-               BlueprintName = "Core"
+               BlueprintIdentifier = "plank::plank"
+               BuildableName = "plank"
+               BlueprintName = "plank"
                ReferencedContainer = "container:plank.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -69,9 +69,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "plank::plank"
-            BuildableName = "plank"
-            BlueprintName = "plank"
+            BlueprintIdentifier = "plank::Core"
+            BuildableName = "Core.framework"
+            BlueprintName = "Core"
             ReferencedContainer = "container:plank.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/plank.xcodeproj/xcshareddata/xcschemes/plank.xcscheme
+++ b/plank.xcodeproj/xcshareddata/xcschemes/plank.xcscheme
@@ -46,7 +46,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "1"
+      launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"

--- a/plank.xcodeproj/xcshareddata/xcschemes/plank.xcscheme
+++ b/plank.xcodeproj/xcshareddata/xcschemes/plank.xcscheme
@@ -1,55 +1,82 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Scheme LastUpgradeVersion = "9999" version = "1.3">
-  <BuildAction parallelizeBuildables = "YES" buildImplicitDependencies = "YES">
-    <BuildActionEntries>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'$(TARGET_NAME)'"
-          BlueprintName = "plank"
-          ReferencedContainer = "container:plank.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-    </BuildActionEntries>
-  </BuildAction>
-  <TestAction
-    buildConfiguration = "Debug"
-    selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-    selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-    shouldUseLaunchSchemeArgsEnv = "YES"
-    codeCoverageEnabled = "NO">
-    <Testables>
-        <TestableReference
-          skipped = "NO">
-          <BuildableReference
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "plank::plank"
+               BuildableName = "plank"
+               BlueprintName = "plank"
+               ReferencedContainer = "container:plank.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "plank::CoreTests"
+               BuildableName = "CoreTests.xctest"
+               BlueprintName = "CoreTests"
+               ReferencedContainer = "container:plank.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "1"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
             BuildableIdentifier = "primary"
-            BuildableName = "'$(TARGET_NAME)'"
-            BlueprintName = "CoreTests"
+            BlueprintIdentifier = "plank::plank"
+            BuildableName = "plank"
+            BlueprintName = "plank"
             ReferencedContainer = "container:plank.xcodeproj">
-          </BuildableReference>
-        </TestableReference>
-    </Testables>
-  </TestAction>
-<LaunchAction
-   buildConfiguration = "Debug"
-   selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-   selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-   launchStyle = "0"
-   useCustomWorkingDirectory = "NO"
-   ignoresPersistentStateOnLaunch = "NO"
-   debugDocumentVersioning = "YES"
-   debugServiceExtension = "internal"
-   allowLocationSimulation = "YES">
-   <BuildableProductRunnable
-      runnableDebuggingMode = "0">
-      <BuildableReference
-         BuildableIdentifier = "primary"
-         BuildableName = "'$(TARGET_NAME)'"
-         BlueprintName = "plank"
-         ReferencedContainer = "container:plank.xcodeproj">
-      </BuildableReference>
-   </BuildableProductRunnable>
-   <AdditionalOptions>
-   </AdditionalOptions>
-</LaunchAction>
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
A quick test solution 1:
```
(lldb) p NSURLComponents * $solution1 = [NSURLComponents componentsWithString:@"http://www.elle.fr/Deco/News-tendances/collection-Noel-H-M-Home#Banc-en-bois-Madam-Stoltz"]
(lldb) p ((NSURLComponents *)($solution1)).fragment
(__NSCFString *) $13 = 0x0000600003c8fba0 @"Banc-en-bois-Madam-Stoltz"
(lldb) p ((NSURLComponents *)($solution1)).URL
(NSURL *) $14 = 0x0000600001da7a00 @"http://www.elle.fr/Deco/News-tendances/collection-Noel-H-M-Home#Banc-en-bois-Madam-Stoltz"
```

A quick test solution 2:
```
(lldb) e NSURL * $solution2url = [NSURL URLWithString:@"#Banc-en-bois-Madam-Stoltz" relativeToURL:[NSURL URLWithString:@"http://www.elle.fr/Deco/News-tendances/collection-Noel-H-M-Home#L-idee-qu-on-pique-a-la-collection-Noel-H-M-Home-distiller-des-bouquets-de-branches-et-des-elements-dores-partout"]]
(lldb) p ((NSURL *)($solution2url)).absoluteString
(__NSCFString *) $9 = 0x00006000018b63e0 @"http://www.elle.fr/Deco/News-tendances/collection-Noel-H-M-Home#Banc-en-bois-Madam-Stoltz"
(lldb) p ((NSURL *)($solution2url)).absoluteURL
(NSURL *) $10 = 0x0000600001db9680 @"http://www.elle.fr/Deco/News-tendances/collection-Noel-H-M-Home#Banc-en-bois-Madam-Stoltz"
(lldb) p ((NSURL *)($solution2url)).fragment
(__NSCFString *) $11 = 0x0000600003c92280 @"Banc-en-bois-Madam-Stoltz"
```
 

However both solutions fail if there are multiple `#` in the fragment, so we will have to introduce some extra manual labor
```
(lldb) p NSURLComponents * $bads = [NSURLComponents componentsWithString:@"http://www.elle.fr/Deco/News-tendances/collection-Noel-H-M-Home#Banc-en-bois-Madam-Stoltz#dont-dothis-webpeople=yes"]
(lldb) p $bads
(NSURLComponents *) $bads = nil
```


Proposed solution:
```
if fragment exist
    (base_url, fragment) = split by first fragment
    if subfragments exist in fragment
        fragment = urlencode(fragment)
    return NSURLComponent(string: base_url + fragment)
```

that should be 100% nonnull and grant enough clemency to the integrity of the original fragment that we say thats as best as we can do in light of apple API strict RFC enforcement

 # the meat of the PR

This PR introduces the concept of a UtilitySourceIncluder which creates RendererRoots for various languages. Only one category for ObjC was written. The Roots contain any non-model source that is necessary. The only use case implemented is to create a category that extends NSURLComponents to provide a convenience interface for safely parsing string URLs that may contain malformed fragments.