### PR TITLE
Create NSURLComponents fragment processor for Objective-C, add debug parameter to print IR inside generated source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.mode1v3
 xcuserdata
 Snapshots
+plank.xcodeproj
 
 # OS X
 *.DS_Store

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -19,7 +19,6 @@ public enum GenerationParameterType {
     case includeRuntime
     case indent
     case packageName
-    case includeUtility
     case debugIR
 }
 

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -19,6 +19,8 @@ public enum GenerationParameterType {
     case includeRuntime
     case indent
     case packageName
+    case includeUtility
+    case debugIR
 }
 
 public enum Languages: String {
@@ -33,13 +35,43 @@ public protocol FileGeneratorManager {
 }
 
 public protocol FileGenerator {
-    func renderFile() -> String
+    func renderFile(generationParameters: GenerationParameters) -> String
     var fileName: String { mutating get }
     var indent: Int { get }
 }
 
 protocol RootRenderer {
-    func renderImplementation() -> [String]
+    func renderImplementation(generationParameters: GenerationParameters) -> [String]
+    func humanReadableString() -> [String]
+}
+
+extension RootRenderer {
+    func debugStatement(generationParameters: GenerationParameters, language: Languages) -> [String]? {
+        guard generationParameters[.debugIR] != nil else {
+            return nil
+        }
+        var debugInfo: [String] = ["// vv PlankDebug ON vv"]
+        switch language {
+        default:
+             debugInfo += ["/*"] + humanReadableString() + ["*/"]
+        }
+        debugInfo += ["// ^^ PlankDebug ON ^^"]
+        
+        return debugInfo
+    }
+
+    var label: String {
+        let mirror = Mirror(reflecting: self)
+        if let label = mirror.children.first?.label {
+            return label
+        } else {
+            var debugDescription = String(describing:self)
+            if let firstParenthesesLocation = debugDescription.range(of: "(") {
+                debugDescription = String(debugDescription.prefix(upTo: firstParenthesesLocation.lowerBound))
+            }
+            return debugDescription
+        }
+    }
 }
 
 protocol FileRenderer {
@@ -210,7 +242,7 @@ public func writeFile(file: FileGenerator, outputDirectory: URL, generationParam
     var file = file
     let indent = generationParameters.indent(file: file)
     let indentSpaces = String(repeating: " ", count: indent)
-    let fileContents = file.renderFile()
+    let fileContents = file.renderFile(generationParameters: generationParameters)
                            .replacingOccurrences(of: "\t", with: indentSpaces)
                            .appending("\n") // Ensure there is exactly one new line a the end of the file
     do {

--- a/Sources/Core/JSFileGenerator.swift
+++ b/Sources/Core/JSFileGenerator.swift
@@ -35,10 +35,10 @@ struct JSModelFile: FileGenerator {
         return 2
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         return (
             [self.renderCommentHeader()] +
-            self.roots.map { $0.renderImplementation().joined(separator: "\n") }
+            self.roots.map { $0.renderImplementation(generationParameters: generationParameters).joined(separator: "\n") }
         )
         .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
         .filter { $0 != "" }

--- a/Sources/Core/JSIR.swift
+++ b/Sources/Core/JSIR.swift
@@ -125,7 +125,11 @@ public struct JSIR {
         )
         case enumDecl(name: String, values: EnumType)
 
-        func renderImplementation() -> [String] {
+        func humanReadableString() -> [String] {
+            return [String(describing: self)]
+        }
+
+        func renderImplementation(generationParameters: GenerationParameters) -> [String] {
             switch self {
             case .structDecl(name: _, fields: _):
                 // Structs are not supported

--- a/Sources/Core/JSRuntimeFile.swift
+++ b/Sources/Core/JSRuntimeFile.swift
@@ -33,7 +33,7 @@ struct JSRuntimeFile: FileGenerator {
         .joined(separator: "\n")
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         let output = (
             [self.renderCommentHeader()] + [self.renderContent()]
         )

--- a/Sources/Core/JavaFileGenerator.swift
+++ b/Sources/Core/JavaFileGenerator.swift
@@ -30,10 +30,10 @@ struct JavaFileGenerator: FileGenerator {
         return "\(className).java"
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         return (
             [self.renderCommentHeader()] +
-                self.roots.map { $0.renderImplementation().joined(separator: "\n") }
+                self.roots.map { $0.renderImplementation(generationParameters: generationParameters).joined(separator: "\n") }
             )
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .map { $0.replacingOccurrences(of: "  ", with: " ") }

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -136,7 +136,7 @@ public struct JavaIR {
             let extendsStmt = extends.map { "extends \($0) " } ?? ""
             return [
                 "\(modifiers.render()) interface \(name) \(extendsStmt){",
-                -->methods.compactMap { "\($0.signature);" },
+                -->methods.map { "\($0.signature);" },
                 "}"
             ]
         }
@@ -148,17 +148,29 @@ public struct JavaIR {
         case classDecl(aClass: JavaIR.Class)
         case interfaceDecl(aInterface: JavaIR.Interface)
 
-        func renderImplementation() -> [String] {
+        func humanReadableString() -> [String] {
+            return [String(describing: self)]
+        }
+
+        func renderImplementation(generationParameters: GenerationParameters) -> [String] {
+            var generatedSource = [String]()
+            
+            if let debugString = debugStatement(generationParameters: generationParameters, language: .java) {
+                generatedSource += debugString
+            }
+
             switch self {
             case let .packages(names):
-                return names.sorted().map { "package \($0);" }
+                generatedSource += names.sorted().map { "package \($0);" }
             case let .imports(names):
-                return names.sorted().map { "import \($0);" }
+                generatedSource += names.sorted().map { "import \($0);" }
             case let .classDecl(aClass: cls):
-                return cls.render()
+                generatedSource += cls.render()
             case let .interfaceDecl(aInterface: interface):
-                return interface.render()
+                generatedSource += interface.render()
             }
+
+            return generatedSource
         }
     }
 }

--- a/Sources/Core/ObjCADTRenderer.swift
+++ b/Sources/Core/ObjCADTRenderer.swift
@@ -172,10 +172,14 @@ struct ObjCADTRenderer: ObjCFileRenderer {
         return [
             ObjCIR.Root.macro("NS_ASSUME_NONNULL_BEGIN"),
             internalTypeEnum,
-            ObjCIR.Root.category(className: self.className,
+            ObjCIR.Root.categoryDecl(className: self.className,
                                  categoryName: nil,
                                  methods: [],
-                                 properties: props),
+                                 properties: props,
+                                 headerOnly: false),
+            ObjCIR.Root.categoryImpl(className: self.className,
+                                     categoryName: nil,
+                                     methods: []),
             ObjCIR.Root.classDecl(name: name,
                                  extends: nil,
                                  methods:

--- a/Sources/Core/ObjCModelRenderer.swift
+++ b/Sources/Core/ObjCModelRenderer.swift
@@ -165,71 +165,82 @@ public struct ObjCModelRenderer: ObjCFileRenderer {
             }
         }
 
+        let classDependencies = Set(self.renderReferencedClasses().map {
+            // Objective-C types contain "*" if they are a pointer type
+            // This information is excessive for import statements so
+            // we're removing it here.
+            $0.replacingOccurrences(of: "*", with: "")
+        })
+        var dependencies = Set(classDependencies)
+        let utilityDependencies = Set<String>(UtilitySourceIncluder.imports(for: params, language: Languages.objectiveC))
+        dependencies.formUnion(utilityDependencies)
+
         return [
             ObjCIR.Root.imports(
-                classNames: Set(self.renderReferencedClasses().map {
-                    // Objective-C types contain "*" if they are a pointer type
-                    // This information is excessive for import statements so
-                    // we're removing it here.
-                    $0.replacingOccurrences(of: "*", with: "")
-                }),
+                classNames: dependencies,
                 myName: self.className,
                 parentName: parentName)
-        ] + adtRoots + enumRoots + [
-            ObjCIR.Root.structDecl(name: self.dirtyPropertyOptionName,
-                               fields: rootSchema.properties.keys
-                                .map { "unsigned int \(dirtyPropertyOption(propertyName: $0, className: self.className)):1;" }
-            ),
-            ObjCIR.Root.category(className: self.className,
-                                 categoryName: nil,
-                                 methods: [],
-                                 properties: [(self.dirtyPropertiesIVarName, "struct \(self.dirtyPropertyOptionName)",
-                                    SchemaObjectProperty(schema: .integer, nullability: nil),
-                                    .readwrite)]),
-            ObjCIR.Root.category(className: self.builderClassName,
-                                 categoryName: nil,
-                                 methods: [],
-                                 properties: [(self.dirtyPropertiesIVarName, "struct \(self.dirtyPropertyOptionName)",
-                                    SchemaObjectProperty(schema: .integer, nullability: nil),
-                                    .readwrite)])
-        ] + self.renderStringEnumerationMethods().map { ObjCIR.Root.function($0) } + [
-            ObjCIR.Root.macro("NS_ASSUME_NONNULL_BEGIN"),
-            ObjCIR.Root.classDecl(
-                name: self.className,
-                extends: parentName,
-                methods: [
-                    (self.isBaseClass ? .publicM : .privateM, self.renderClassName()),
-                    (self.isBaseClass ? .publicM : .privateM, self.renderPolymorphicTypeIdentifier()),
-                    (self.isBaseClass ? .publicM : .privateM, self.renderModelObjectWithDictionary()),
-                    (.privateM, self.renderDesignatedInit()),
-                    (self.isBaseClass ? .publicM : .privateM, self.renderInitWithModelDictionary()),
-                    (.publicM, self.renderInitWithBuilder()),
-                    (self.isBaseClass ? .publicM : .privateM, self.renderInitWithBuilderWithInitType()),
-                    (.privateM, self.renderDebugDescription()),
-                    (.publicM, self.renderCopyWithBlock()),
-                    (.privateM, self.renderIsEqual()),
-                    (.publicM, self.renderIsEqualToClass()),
-                    (.privateM, self.renderHash()),
-                    (.publicM, self.renderMergeWithModel()),
-                    (.publicM, self.renderMergeWithModelWithInitType()),
-                    (self.isBaseClass ? .publicM : .privateM, self.renderGenerateDictionary())
-                ],
-                properties: properties.map { param, prop in (param, typeFromSchema(param, prop), prop, .readonly) },
-                protocols: protocols
-            ),
-            ObjCIR.Root.classDecl(
-                name: self.builderClassName,
-                extends: resolveClassName(self.parentDescriptor).map { "\($0)Builder"},
-                methods: [
-                    (.publicM, self.renderBuilderInitWithModel()),
-                    (.publicM, ObjCIR.method("- (\(self.className) *)build") {
-                        ["return [[\(self.className) alloc] initWithBuilder:self];"]
-                    }),
-                    (.publicM, self.renderBuilderMergeWithModel())
-                    ] + self.renderBuilderPropertySetters().map { (.privateM, $0) },
-                properties: properties.map { param, prop in (param, typeFromSchema(param, prop), prop, .readwrite) },
-                protocols: [:]),
-            ObjCIR.Root.macro("NS_ASSUME_NONNULL_END")
+            ] + [
+                ObjCIR.Root.forwardDeclarations(classNames: classDependencies, myName: self.className)
+            ] + adtRoots
+            + enumRoots
+            + [
+                ObjCIR.Root.structDecl(name: self.dirtyPropertyOptionName,
+                                       fields: rootSchema.properties.keys
+                                        .map { "unsigned int \(dirtyPropertyOption(propertyName: $0, className: self.className)):1;" }
+                ),
+                ObjCIR.Root.categoryDecl(className: self.className,
+                                     categoryName: nil,
+                                     methods: [],
+                                     properties: [(self.dirtyPropertiesIVarName, "struct \(self.dirtyPropertyOptionName)",
+                                        SchemaObjectProperty(schema: .integer, nullability: nil),
+                                        .readwrite)],
+                                     headerOnly: false),
+                ObjCIR.Root.categoryDecl(className: self.builderClassName,
+                                         categoryName: nil,
+                                         methods: [],
+                                         properties: [(self.dirtyPropertiesIVarName, "struct \(self.dirtyPropertyOptionName)",
+                                            SchemaObjectProperty(schema: .integer, nullability: nil),
+                                            .readwrite)],
+                                         headerOnly: false),
+            ] + self.renderStringEnumerationMethods().map { ObjCIR.Root.function($0) } + [
+                ObjCIR.Root.macro("NS_ASSUME_NONNULL_BEGIN"),
+                ObjCIR.Root.classDecl(
+                    name: self.className,
+                    extends: parentName,
+                    methods: [
+                        (self.isBaseClass ? .publicM : .privateM, self.renderClassName()),
+                        (self.isBaseClass ? .publicM : .privateM, self.renderPolymorphicTypeIdentifier()),
+                        (self.isBaseClass ? .publicM : .privateM, self.renderModelObjectWithDictionary()),
+                        (.privateM, self.renderDesignatedInit()),
+                        (self.isBaseClass ? .publicM : .privateM, self.renderInitWithModelDictionary()),
+                        (.publicM, self.renderInitWithBuilder()),
+                        (self.isBaseClass ? .publicM : .privateM, self.renderInitWithBuilderWithInitType()),
+                        (.privateM, self.renderDebugDescription()),
+                        (.publicM, self.renderCopyWithBlock()),
+                        (.privateM, self.renderIsEqual()),
+                        (.publicM, self.renderIsEqualToClass()),
+                        (.privateM, self.renderHash()),
+                        (.publicM, self.renderMergeWithModel()),
+                        (.publicM, self.renderMergeWithModelWithInitType()),
+                        (self.isBaseClass ? .publicM : .privateM, self.renderGenerateDictionary())
+                    ],
+                    properties: properties.map { param, prop in (param, typeFromSchema(param, prop), prop, .readonly) },
+                    protocols: protocols
+                ),
+                ObjCIR.Root.classDecl(
+                    name: self.builderClassName,
+                    extends: resolveClassName(self.parentDescriptor).map { "\($0)Builder"},
+                    methods: [
+                        (.publicM, self.renderBuilderInitWithModel()),
+                        (.publicM, ObjCIR.method("- (\(self.className) *)build") {
+                            ["return [[\(self.className) alloc] initWithBuilder:self];"]
+                        }),
+                        (.publicM, self.renderBuilderMergeWithModel())
+                        ] + self.renderBuilderPropertySetters().map { (.privateM, $0) },
+                    properties: properties.map { param, prop in (param, typeFromSchema(param, prop), prop, .readwrite) },
+                    protocols: [:]),
+                ObjCIR.Root.macro("NS_ASSUME_NONNULL_END")
         ]
     }
 }

--- a/Sources/Core/ObjectiveCFileGenerator.swift
+++ b/Sources/Core/ObjectiveCFileGenerator.swift
@@ -44,10 +44,10 @@ struct ObjCHeaderFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         let output = (
                 [self.renderCommentHeader()] +
-                self.roots.compactMap { $0.renderHeader().joined(separator: "\n") }
+                self.roots.map { $0.renderHeader(generationParameters: generationParameters).joined(separator: "\n") }
             )
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }
@@ -68,10 +68,10 @@ struct ObjCImplementationFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         let output = (
                 [self.renderCommentHeader()] +
-                self.roots.map { $0.renderImplementation().joined(separator: "\n") }
+                self.roots.map { $0.renderImplementation(generationParameters: generationParameters).joined(separator: "\n") }
             )
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }
@@ -161,9 +161,9 @@ struct ObjCRuntimeHeaderFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         let roots: [ObjCIR.Root] = ObjCRuntimeFile.renderRoots()
-        let outputs = roots.map { $0.renderHeader() }.reduce([], +)
+        let outputs = roots.map { $0.renderHeader(generationParameters: generationParameters) }.reduce([], +)
         return ([self.renderCommentHeader(), "", "#import <Foundation/Foundation.h>", ""] + outputs)
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }
@@ -179,9 +179,9 @@ struct ObjCRuntimeImplementationFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(generationParameters: GenerationParameters) -> String {
         let roots: [ObjCIR.Root] = ObjCRuntimeFile.renderRoots()
-        let outputs = roots.map { $0.renderImplementation() }.reduce([], +)
+        let outputs = roots.map { $0.renderImplementation(generationParameters: generationParameters) }.reduce([], +)
         return ([self.renderCommentHeader(), "", "#import <Foundation/Foundation.h>", "", "#import \"\(ObjCRuntimeHeaderFile().fileName)\"", outputs.joined(separator: "\n")])
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -150,15 +150,15 @@ public struct ObjCIR {
         return
             "[\(variable) " +
                 messages.map { (param, arg) in "\(param):\(arg)" }.joined(separator: " ") +
-            "]"
+        "]"
     }
 
     static func block(_ params: [Parameter], body: () -> [String]) -> String {
         return [
             "^" + (params.count == 0 ? "" : "(\(params.joined(separator: ", ")))") + "{",
-              -->body,
+            -->body,
             "}"
-        ].joined(separator: "\n")
+            ].joined(separator: "\n")
     }
 
     static func scope(body: () -> [String]) -> String {
@@ -166,7 +166,7 @@ public struct ObjCIR {
             "{",
             -->body,
             "}"
-        ].joined(separator: "\n")
+            ].joined(separator: "\n")
     }
 
     enum SwitchCase {
@@ -179,12 +179,12 @@ public struct ObjCIR {
                 return [ "case \(condition):",
                     -->body,
                     -->[ObjCIR.stmt("break")]
-                ].joined(separator: "\n")
+                    ].joined(separator: "\n")
             case .defaultStmt(let body):
                 return [ "default:",
-                    -->body,
-                    -->[ObjCIR.stmt("break")]
-                ].joined(separator: "\n")
+                         -->body,
+                         -->[ObjCIR.stmt("break")]
+                    ].joined(separator: "\n")
             }
         }
     }
@@ -202,45 +202,45 @@ public struct ObjCIR {
             "switch (\(switchVariable)) {",
             body().map { $0.render() }.joined(separator: "\n"),
             "}"
-        ].joined(separator: "\n")
+            ].joined(separator: "\n")
     }
     static func ifStmt(_ condition: String, body: () -> [String]) -> String {
         return [
             "if (\(condition)) {",
-                -->body,
+            -->body,
             "}"
-        ].joined(separator: "\n")
+            ].joined(separator: "\n")
     }
 
     static func elseIfStmt(_ condition: String, _ body:() -> [String]) -> String {
         return [
             " else if (\(condition)) {",
-                -->body,
+            -->body,
             "}"
-        ].joined(separator: "\n")
+            ].joined(separator: "\n")
     }
 
     static func elseStmt(_ body: () -> [String]) -> String {
         return [
             " else {",
-                -->body,
+            -->body,
             "}"
-        ].joined(separator: "\n")
+            ].joined(separator: "\n")
     }
 
     static func ifElseStmt(_ condition: String, body: @escaping () -> [String]) -> (() -> [String]) -> String {
         return { elseBody in [
             ObjCIR.ifStmt(condition, body: body) +
-            ObjCIR.elseStmt(elseBody)
-        ].joined(separator: "\n") }
+                ObjCIR.elseStmt(elseBody)
+            ].joined(separator: "\n") }
     }
 
     static func forStmt(_ condition: String, body: () -> [String]) -> String {
         return [
             "for (\(condition)) {",
-              -->body,
+            -->body,
             "}"
-        ].joined(separator: "\n")
+            ].joined(separator: "\n")
     }
 
     static func fileImportStmt(_ filename: String) -> String {
@@ -250,9 +250,9 @@ public struct ObjCIR {
     static func enumStmt(_ enumName: String, body: () -> [String]) -> String {
         return [
             "typedef NS_ENUM(NSInteger, \(enumName)) {",
-              -->[body().joined(separator: ",\n")],
+            -->[body().joined(separator: ",\n")],
             "};"
-        ].joined(separator: "\n")
+            ].joined(separator: "\n")
     }
 
     static func optionEnumStmt(_ enumName: String, body: () -> [String]) -> String {
@@ -260,7 +260,7 @@ public struct ObjCIR {
             "typedef NS_OPTIONS(NSUInteger, \(enumName)) {",
             -->[body().joined(separator: ",\n")],
             "};"
-        ].joined(separator: "\n")
+            ].joined(separator: "\n")
     }
 
     public struct Method {
@@ -271,7 +271,7 @@ public struct ObjCIR {
             return [
                 signature,
                 "{",
-                  -->body,
+                -->body,
                 "}"
             ]
         }
@@ -280,8 +280,8 @@ public struct ObjCIR {
     enum Root: RootRenderer {
         case structDecl(name: String, fields: [String])
         case imports(classNames: Set<String>, myName: String, parentName: String?)
-        case category(className: String, categoryName: String?, methods: [ObjCIR.Method],
-            properties: [SimpleProperty])
+        case categoryDecl(className: String, categoryName: String?, methods: [ObjCIR.Method], properties: [SimpleProperty], headerOnly: Bool)
+        case categoryImpl(className: String, categoryName: String?, methods: [ObjCIR.Method])
         case macro(String)
         case function(ObjCIR.Method)
         case classDecl(
@@ -293,21 +293,32 @@ public struct ObjCIR {
         )
         case enumDecl(name: String, values: EnumType)
         case optionSetEnum(name: String, values: [EnumValue<Int>])
+        case literalImport(name: String)
+        case forwardDeclarations(classNames: Set<String>, myName: String)
 
-        func renderHeader() -> [String] {
+        func renderHeader(generationParameters: GenerationParameters) -> [String] {
+            var generatedSource = [String]()
+
+            if let debugString = debugStatement(generationParameters: generationParameters, language: .objectiveC) {
+                generatedSource += debugString
+            }
+
             switch self {
             case .structDecl:
                 // skip structs in header
-                return []
+                generatedSource += []
             case .macro(let macro):
-                return [macro]
-            case .imports(let classNames, let myName, let parentName):
-                return [
+                generatedSource += [macro]
+            case .imports(classNames: _, myName: _, let parentName):
+                generatedSource += [
                     "#import <Foundation/Foundation.h>",
                     parentName.map(ObjCIR.fileImportStmt) ?? "",
                     "#import \"\(ObjCRuntimeHeaderFile().fileName)\""
-                ].filter { $0 != "" }  + (["\(myName)Builder"] + classNames)
-                    .sorted().map { "@class \($0.trimmingCharacters(in: .whitespaces));" }
+                    ].filter { $0 != "" }
+            case .forwardDeclarations(let classNames, let myName):
+                generatedSource += (["\(myName)Builder"] + classNames)
+                    .sorted()
+                    .map { "@class \($0.trimmingCharacters(in: .whitespaces));" }
             case .classDecl(let className, let extends, let methods, let properties, let protocols):
                 let protocolList = protocols.keys.sorted().joined(separator: ", ")
                 let protocolDeclarations = protocols.count > 0 ? "<\(protocolList)>" : ""
@@ -317,80 +328,201 @@ public struct ObjCIR {
                     prop.nullability.map { "\($0), " } ?? ""
                 }
 
-                return [
+                generatedSource += [
                     "@interface \(className) : \(superClass)",
                     properties.map { (param, typeName, propSchema, access) in
                         "@property (\(nullability(propSchema))nonatomic, \(propSchema.schema.memoryAssignmentType().rawValue), \(access.rawValue)) \(typeName) \(param.snakeCaseToPropertyName());"
-                    }.joined(separator: "\n"),
+                        }.joined(separator: "\n"),
                     methods.filter { visibility, _ in visibility == .publicM }
-                            .map { $1 }.map { $0.signature + ";" }.joined(separator: "\n"),
+                        .map { $1 }.map { $0.signature + ";" }.joined(separator: "\n"),
                     "@end"
                 ]
-            case .category(className: _, categoryName: _, methods: _, properties: _):
-                // skip categories in header
-                return []
+            case .categoryDecl(let className, let categoryName, let methods, let properties, headerOnly: _):
+                guard categoryName != nil else {
+                    break
+                }
+
+                let nullability = { (prop: SchemaObjectProperty) in
+                    prop.nullability.map { "\($0), " } ?? ""
+                }
+
+                generatedSource += [
+                    "@interface \(className) (\(categoryName ?? ""))",
+                    properties.map { (param, typeName, propSchema, access) in
+                        "@property (\(nullability(propSchema))nonatomic, \(propSchema.schema.memoryAssignmentType().rawValue), \(access.rawValue)) \(typeName) \(param.snakeCaseToPropertyName());"
+                        }.joined(separator: "\n"),
+                    methods.map { $0.signature + ";" }.joined(separator: "\n"),
+                    "@end"
+                ]
+            case .categoryImpl(className: _, categoryName: _, methods: _):
+                generatedSource += []
             case .function(let method):
-                return ["\(method.signature);"]
+                generatedSource += ["\(method.signature);"]
             case .enumDecl(let name, let values):
-                return [ObjCIR.enumStmt(name) {
+                generatedSource += [ObjCIR.enumStmt(name) {
                     switch values {
                     case .integer(let options):
                         return options.map { "\(name + $0.camelCaseDescription) = \($0.defaultValue)" }
                     case .string(let options, _):
                         return options.map { "\(name + $0.camelCaseDescription) /* \($0.defaultValue) */" }
                     }
-                }]
+                    }]
             case .optionSetEnum(let name, let values):
-                return [ObjCIR.optionEnumStmt(name) {
+                generatedSource += [ObjCIR.optionEnumStmt(name) {
                     values.map { "\(name + $0.camelCaseDescription) = 1 << \($0.defaultValue)" }
-                }]
+                    }]
+            case .literalImport(name: _):
+                generatedSource += []
             }
+
+            return generatedSource
         }
 
-        func renderImplementation() -> [String] {
+        func renderImplementation(generationParameters: GenerationParameters) -> [String] {
+            var generatedSource = [String]()
+
+            if let debugString = debugStatement(generationParameters: generationParameters, language: .objectiveC) {
+                generatedSource += debugString
+            }
+
             switch self {
             case .structDecl(name: let name, fields: let fields):
-                return [
+                generatedSource += [
                     "struct \(name) {",
-                        fields.sorted().map { $0.indent() }.joined(separator: "\n"),
+                    fields.sorted().map { $0.indent() }.joined(separator: "\n"),
                     "};"
                 ]
             case .macro:
                 // skip macro in impl
-                return []
+                generatedSource += []
             case .imports(let classNames, let myName, _):
-                return [classNames.union(Set([myName]))
+                generatedSource += [classNames.union(Set([myName]))
                     .sorted()
                     .map { $0.trimmingCharacters(in: .whitespaces) }
                     .map(ObjCIR.fileImportStmt)
                     .joined(separator: "\n")]
+            case .forwardDeclarations( classNames: _, myName: _):
+                generatedSource += []
             case .classDecl(name: let className, extends: _, methods: let methods, properties: _, protocols: let protocols):
-                return [
+                generatedSource += [
                     "@implementation \(className)",
                     methods.flatMap {$1.render()}.joined(separator: "\n"),
                     protocols.flatMap({ (protocolName, methods) -> [String] in
                         return ["#pragma mark - \(protocolName)"] + methods.flatMap {$0.render()}
                     }).joined(separator: "\n"),
                     "@end"
-                ].map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }.filter { $0 != "" }
-            case .category(className: let className, categoryName: let categoryName, methods: let methods, properties: let properties):
-                // Only render anonymous categories in the implementation
-                guard categoryName == nil else { return [] }
-                return [
-                    "@interface \(className) ()",
+                    ].map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }.filter { $0 != "" }
+            case .categoryDecl(let className, let categoryName, let methods, let properties, let headerOnly):
+                generatedSource += headerOnly ? [] : [
+                    "@interface \(className) (\(categoryName ?? ""))",
                     properties.map { (param, typeName, prop, access) in
                         "@property (nonatomic, \(prop.schema.memoryAssignmentType().rawValue), \(access.rawValue)) \(typeName) \(param.snakeCaseToPropertyName());"
-                    }.joined(separator: "\n"),
-                    methods.map { $0.signature + ";" }.joined(separator: "\n"),
+                        }.joined(separator: "\n"),
+                    methods.map {$0.signature + ";"}.joined(separator: "\n"),
                     "@end"
-                ].map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }.filter { $0 != "" }
+                    ].map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }.filter { $0 != "" }
+            case .categoryImpl(className: let className, categoryName: let categoryName, methods: let methods):
+                guard let categoryName = categoryName else {
+                    generatedSource += []
+                    break
+                }
+
+                generatedSource += [
+                    "@implementation \(className) (\(categoryName))",
+                    methods.flatMap {$0.render()}.joined(separator: "\n"),
+                    "@end"
+                    ].map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }.filter { $0 != "" }
             case .function(let method):
-                return method.render()
+                generatedSource += method.render()
             case .enumDecl:
-                return []
+                generatedSource += []
             case .optionSetEnum:
-                return []
+                generatedSource += []
+            case .literalImport(let name):
+                generatedSource += [ObjCIR.fileImportStmt(name)]
+            }
+
+            return generatedSource
+        }
+
+        func humanReadableString() -> [String] {
+            switch self {
+            case .structDecl:
+                return [label + ": \(self)"]
+            case .macro(macro: _):
+                return [label + ": \(self)"]
+            case .imports(let classNames, let myName, let parentName):
+                return [label + ": className:"] + classNames.map({$0})
+                    + ["myName: \(myName), parentName: \(parentName ?? "none")"]
+            case .forwardDeclarations(let classNames, let myName):
+                return [label + ": className:"]
+                    + classNames.map({$0})
+                    + ["myName: \(myName)"]
+            case .classDecl(let className, let extends, let methods, let properties, let protocols):
+                return ([label + ": className: \(className), extends: \(extends ?? "none"), methods: "] as [String])
+                    + methods.humanReadableDescription()
+                    + ["properties: "] + properties.map({"\($0)"}) + ["\tprotocols: "]
+                    + protocols.humanReadableDescription()
+            case .categoryDecl(let className, let categoryName, let methods, let properties, let headerOnly):
+                return ([label + ": className: \(className), categpryName: \(categoryName ?? "none"), methods: "]) as [String]
+                    + methods.humanReadableDescription()
+                    + ([" properties: "] + properties.map({"\($0)"}) + ["headerOnly: \(headerOnly ? "y" : "n")"] as [String])
+            case .categoryImpl(let className, let categoryName, let methods):
+                return ([label + ": className: \(className), categpryName: \(categoryName ?? "none"), methods:"] as [String])
+                    + methods.humanReadableDescription()
+            case .function(let method):
+                return method.humanReadableDescription()
+            case .enumDecl(let name, let values):
+                return [label + ": name: \(name), values: \(values)"]
+            case .optionSetEnum(let name, let values):
+                return [label + ": name: \(name), values: \(values)"]
+            case .literalImport(let name):
+                return [label + ": name: \(name)"]
             }
         }
     }
+}
+
+// MARK: Collection extensions
+
+extension Collection where Element == (MethodVisibility, ObjCIR.Method) {
+
+    func humanReadableDescription() -> [String] {
+        var flattenedDescription = [String]()
+        for element in self {
+            flattenedDescription += ["\tvisibility: \(element.0)"]
+            flattenedDescription += element.1.humanReadableDescription().map({"\t" + $0})
+        }
+        return flattenedDescription
+    }
+
+}
+
+extension Collection where Element == ObjCIR.Method {
+
+    func humanReadableDescription() -> [String] {
+        return reduce([String](), { (result, element) -> [String] in
+            return result + element.humanReadableDescription().map({"\t" + $0})
+        })
+    }
+
+}
+
+extension ObjCIR.Method {
+
+    func humanReadableDescription() -> [String] {
+        return ["\(signature)"] + body.map({"\t\t" + $0})
+    }
+
+}
+
+extension Dictionary where Value == [ObjCIR.Method] {
+
+    func humanReadableDescription() -> [String] {
+        return reduce([String](), { (result, element) -> [String] in
+            let (key, value) = element
+            return result + [key as! String].map({"\t" + $0}) + value.humanReadableDescription().map({"\t\t" + $0})
+        })
+    }
+
 }

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -148,7 +148,7 @@ extension ObjCModelRenderer {
             case .boolean:
                 return ["\(propertyToAssign) = [\(rawObjectName) boolValue];"]
             case .string(format: .some(.uri)):
-                return ["\(propertyToAssign) = [NSURL URLWithString:\(rawObjectName)];"]
+                return ["\(propertyToAssign) = [NSURLComponents URLWithUnsafeString:\(rawObjectName)];"]
             case .string(format: .some(.dateTime)):
                 return ["\(propertyToAssign) = [[NSValueTransformer valueTransformerForName:\(dateValueTransformerKey)] transformedValue:\(rawObjectName)];"]
             case .reference(with: let ref):

--- a/Sources/Core/UtilitySourceIncluder.swift
+++ b/Sources/Core/UtilitySourceIncluder.swift
@@ -1,0 +1,130 @@
+//
+//  UtilitySourceIncluder.swift
+//  plank
+//
+//  Created by Michael Zuccarino on 10/22/18.
+//
+
+import Foundation
+
+public struct UtilitySourceIncluder {
+    
+    let languages: [Languages]
+    let outputDirectory: URL
+    let generationParameters: GenerationParameters
+    
+    public init(languages langs: [Languages],
+                outputDirectory outputDir: URL,
+                generationParameters genParams: GenerationParameters) {
+        languages = langs
+        outputDirectory = outputDir
+        generationParameters = genParams
+    }
+
+    public func write() {
+        var files = [FileGenerator]()
+        languages.forEach({ (language) in
+            switch language {
+            case .objectiveC:
+                files += ObjectiveCCategoryExtensions.generators()
+            default:
+                return
+            }
+        })
+
+        files.forEach { (file) in
+            writeFile(file: file, outputDirectory: outputDirectory, generationParameters: generationParameters)
+        }
+    }
+    
+    static func imports(for generationParameters: GenerationParameters, language: Languages) -> [String] {
+        guard generationParameters[.includeUtility] != nil else {
+            return []
+        }
+        
+        switch language {
+        case .objectiveC:
+            return [
+                ObjectiveCCategoryExtensions.NSURLComponents.fullName
+            ]
+        default:
+            return []
+        }
+    }
+
+}
+
+// MARK: Objective-C
+
+extension UtilitySourceIncluder {
+    
+    class ObjectiveCCategoryExtensions {
+        
+        // Enlist different generators here i.e. [one list] + NSURLComponents.extensions + ...
+        class func generators() -> [FileGenerator] {
+            return NSURLComponents.extensions()
+        }
+        
+        public class NSURLComponents {
+            
+            static let className = "NSURLComponents"
+            static let categoryName = "PlankUtility"
+            static let fullName = "\(NSURLComponents.className)+\(NSURLComponents.categoryName)"
+            
+            class func extensions() -> [FileGenerator] {
+                let fileNameBase = "\(NSURLComponents.className)+\(NSURLComponents.categoryName)"
+
+                let categoryMethods: [ObjCIR.Method] = [
+                    NSURLComponents.NSURLComponentsUnsafeInitializer()
+                ]
+                
+                let categoryRoots = [
+                    ObjCIR.Root.imports(classNames: Set([NSURLComponents.fullName]), myName: NSURLComponents.fullName, parentName: nil),
+                    ObjCIR.Root.categoryDecl(className: NSURLComponents.className,
+                                             categoryName: NSURLComponents.categoryName,
+                                             methods: categoryMethods,
+                                             properties: [],
+                                             headerOnly: true),
+                    ObjCIR.Root.categoryImpl(className: NSURLComponents.className,
+                                             categoryName: NSURLComponents.categoryName,
+                                             methods: categoryMethods)
+                ]
+                
+                let files: [FileGenerator] = [
+                    ObjCHeaderFile(roots: categoryRoots, className: fileNameBase),
+                    ObjCImplementationFile(roots: categoryRoots, className: fileNameBase)
+                ]
+                return files
+            }
+            
+            class func NSURLComponentsUnsafeInitializer() -> ObjCIR.Method {
+                return ObjCIR.method("+ (NSURL * _Nullable)URLWithUnsafeString:(NSString * _Nonnull)unsafeString", body: { () -> [String] in
+                    return [
+                        "static NSCharacterSet * fragmentDefinition;",
+                        ObjCIR.ifStmt("fragmentDefinition == nil", body: { () -> [String] in
+                            return [ "fragmentDefinition = [NSCharacterSet characterSetWithCharactersInString:@\"#\"];" ]
+                        }),
+                        "NSRange firstFragmentRange = [unsafeString rangeOfCharacterFromSet:fragmentDefinition];",
+                        ObjCIR.ifStmt("firstFragmentRange.location != NSNotFound") {
+                            return [
+                                "NSString *baseURL = [unsafeString substringToIndex:firstFragmentRange.location];",
+                                "NSString *fragment = [unsafeString substringFromIndex:firstFragmentRange.location];",
+                                ObjCIR.ifStmt("[unsafeString rangeOfCharacterFromSet:fragmentDefinition].location != NSNotFound", body: { () -> [String] in
+                                    return [
+                                        "NSString *encodedFragment = [fragment stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLFragmentAllowedCharacterSet];",
+                                        "unsafeString = [NSString stringWithFormat:@\"%@#%@\", baseURL, encodedFragment];"
+                                    ]
+                                })
+                            ]
+                        },
+                        "return [NSURLComponents componentsWithString:unsafeString].URL;"
+                    ]
+                })
+            }
+            
+        }
+    
+        
+    }
+    
+}

--- a/Sources/Core/UtilitySourceIncluder.swift
+++ b/Sources/Core/UtilitySourceIncluder.swift
@@ -109,14 +109,16 @@ extension UtilitySourceIncluder {
                                     return ["unsafeString = baseURL;"]
                                 }),
                                 ObjCIR.elseStmt({ () -> [String] in
-                                    return ["fragment = [unsafeString substringFromIndex:(firstFragmentRange.location+1)];"]
-                                }),
-                                ObjCIR.ifStmt("[fragment rangeOfCharacterFromSet:fragmentDefinition].location != NSNotFound", body: { () -> [String] in
                                     return [
-                                        "fragment = [fragment stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLFragmentAllowedCharacterSet];",
+                                        "fragment = [unsafeString substringFromIndex:(firstFragmentRange.location+1)];",
+                                        ObjCIR.ifStmt("[fragment rangeOfCharacterFromSet:fragmentDefinition].location != NSNotFound", body: { () -> [String] in
+                                            return [
+                                                "fragment = [fragment stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLFragmentAllowedCharacterSet];",
+                                                ]
+                                        }),
+                                        "unsafeString = [NSString stringWithFormat:@\"%@#%@\", baseURL, fragment];"
                                     ]
-                                }),
-                                "unsafeString = [NSString stringWithFormat:@\"%@#%@\", baseURL, fragment];"
+                                })
                             ]
                         },
                         "return [NSURLComponents componentsWithString:unsafeString].URL;"

--- a/Sources/Core/UtilitySourceIncluder.swift
+++ b/Sources/Core/UtilitySourceIncluder.swift
@@ -38,10 +38,6 @@ public struct UtilitySourceIncluder {
     }
     
     static func imports(for generationParameters: GenerationParameters, language: Languages) -> [String] {
-        guard generationParameters[.includeUtility] != nil else {
-            return []
-        }
-        
         switch language {
         case .objectiveC:
             return [

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -25,7 +25,6 @@ enum FlagOptions: String {
     case lang = "lang"
     case help = "help"
     case version = "version"
-    case includeUtility = "include_utility"
     case debugIR = "debug_ir"
 
     func needsArgument() -> Bool {
@@ -41,7 +40,6 @@ enum FlagOptions: String {
         case .help: return false
         case .version: return false
         case .javaPackageName: return true
-        case .includeUtility: return false
         case .debugIR: return false
         }
     }
@@ -59,7 +57,6 @@ extension FlagOptions: HelpCommandOutput {
             "    --\(FlagOptions.lang.rawValue) - Comma separated list of target language(s) for generating code. Default: \"objc\"",
             "    --\(FlagOptions.help.rawValue) - Show this text and exit",
             "    --\(FlagOptions.version.rawValue) - Show version number and exit",
-            "    --\(FlagOptions.includeUtility.rawValue) - Include utility source for the defined language",
             "    --\(FlagOptions.debugIR.rawValue) - Includes IR statement above generated source",
             "",
             "    Objective-C:",
@@ -152,7 +149,6 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     let includeRuntime: String? = flags[.onlyRuntime] != nil || (flags[.noRuntime] == nil || flags[.noRecursive] != nil) ? .some("") : .none
     let indent: String? = flags[.indent]
     let packageName: String? = flags[.javaPackageName]
-    let includeUtility: String? = flags[.includeUtility] != nil ? .some("") : .none
     let debugIR: String? = flags[.debugIR] != nil ? .some("") : .none
 
     let generationParameters: GenerationParameters = [
@@ -161,7 +157,6 @@ func handleGenerateCommand(withArguments arguments: [String]) {
         (.includeRuntime, includeRuntime),
         (.indent, indent),
         (.packageName, packageName),
-        (.includeUtility, includeUtility),
         (.debugIR, debugIR)
         ].reduce(GenerationParameters()) { (dict: GenerationParameters, tuple: (GenerationParameterType, String?)) -> GenerationParameters in
             var d = dict
@@ -219,11 +214,9 @@ func handleGenerateCommand(withArguments arguments: [String]) {
                       forLanguages: languages)
     }
     
-    if flags[.includeUtility] != nil {
-        UtilitySourceIncluder(languages: languages,
-                              outputDirectory: outputDirectory,
-                              generationParameters: generationParameters).write()
-    }
+    UtilitySourceIncluder(languages: languages,
+                          outputDirectory: outputDirectory,
+                          generationParameters: generationParameters).write()
 }
 
 func handleHelpCommand() {


### PR DESCRIPTION
A quick test solution 1:
```
(lldb) p NSURLComponents * $solution1 = [NSURLComponents componentsWithString:@"http://www.elle.fr/Deco/News-tendances/collection-Noel-H-M-Home#Banc-en-bois-Madam-Stoltz"]
(lldb) p ((NSURLComponents *)($solution1)).fragment
(__NSCFString *) $13 = 0x0000600003c8fba0 @"Banc-en-bois-Madam-Stoltz"
(lldb) p ((NSURLComponents *)($solution1)).URL
(NSURL *) $14 = 0x0000600001da7a00 @"http://www.elle.fr/Deco/News-tendances/collection-Noel-H-M-Home#Banc-en-bois-Madam-Stoltz"
```

However that solution fails if there are multiple `#` in the fragment, so we will have to introduce some extra manual labor
```
(lldb) p NSURLComponents * $bads = [NSURLComponents componentsWithString:@"http://www.elle.fr/Deco/News-tendances/collection-Noel-H-M-Home#Banc-en-bois-Madam-Stoltz#dont-dothis-webpeople=yes"]
(lldb) p $bads
(NSURLComponents *) $bads = nil
```

Proposed solution:
```
if fragment exist
    (base_url, fragment) = split by first fragment
    if subfragments exist in fragment
        fragment = urlencode(fragment)
    return NSURLComponent(string: base_url + fragment)
```

that should be 100% nonnull and grant enough clemency to the integrity of the original fragment that we say thats as best as we can do in light of apple API strict RFC enforcement

 # the meat of the PR

This PR introduces the concept of a UtilitySourceIncluder which creates RendererRoots for various languages. Only one category for ObjC was written. The Roots contain any non-model source that is necessary. The only use case implemented is to create a category that extends NSURLComponents to provide a convenience interface for safely parsing string URLs that may contain malformed fragments.