### PR TITLE
Pass through Raw URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ docs/_site
 .bazel/
 bazel-out/
 bazel-out
+plank.xcodeproj/project.pbxproj
+plank.xcodeproj/xcshareddata/xcschemes/plank.xcscheme

--- a/Sources/Core/ObjCFileRenderer.swift
+++ b/Sources/Core/ObjCFileRenderer.swift
@@ -40,12 +40,11 @@ extension ObjCFileRenderer {
              .string(format: .some(.email)),
              .string(format: .some(.hostname)),
              .string(format: .some(.ipv4)),
-             .string(format: .some(.ipv6)):
+             .string(format: .some(.ipv6)),
+             .string(format: .some(.uri)):
             return "NSString *"
         case .string(format: .some(.dateTime)):
             return "NSDate *"
-        case .string(format: .some(.uri)):
-            return "NSURL *"
         case .integer:
             return "NSInteger"
         case .float:

--- a/Sources/Core/ObjectiveCDictionaryExtension.swift
+++ b/Sources/Core/ObjectiveCDictionaryExtension.swift
@@ -106,10 +106,9 @@ extension ObjCFileRenderer {
              .string(format: .some(.email)),
              .string(format: .some(.hostname)),
              .string(format: .some(.ipv4)),
-             .string(format: .some(.ipv6)):
+             .string(format: .some(.ipv6)),
+             .string(format: .some(.uri)):
             return "[\(dictionary) setObject:\(propIVarName) forKey:@\"\(param)\"];"
-        case .string(format: .some(.uri)):
-            return "[\(dictionary) setObject:[\(propIVarName) absoluteString] forKey:@\"\(param)\"];"
         case .string(format: .some(.dateTime)):
             return [
                 "NSValueTransformer *valueTransformer = [NSValueTransformer valueTransformerForName:\(dateValueTransformerKey)];",
@@ -171,10 +170,9 @@ extension ObjCFileRenderer {
                      .string(format: .some(.email)),
                      .string(format: .some(.hostname)),
                      .string(format: .some(.ipv4)),
-                     .string(format: .some(.ipv6)):
+                     .string(format: .some(.ipv6)),
+                     .string(format: .some(.uri)):
                     return "[\(destCollection) addObject:\(processObject)];"
-                case .string(format: .some(.uri)):
-                    return "[\(destCollection) addObject:[\(processObject) absoluteString]];"
                 case .string(format: .some(.dateTime)):
                     return [
                         "NSValueTransformer *valueTransformer = [NSValueTransformer valueTransformerForName:\(dateValueTransformerKey)];",

--- a/Sources/Core/ObjectiveCEqualityExtension.swift
+++ b/Sources/Core/ObjectiveCEqualityExtension.swift
@@ -71,9 +71,10 @@ extension ObjCFileRenderer {
                  .string(format: .some(.email)),
                  .string(format: .some(.hostname)),
                  .string(format: .some(.ipv4)),
-                 .string(format: .some(.ipv6)):
+                 .string(format: .some(.ipv6)),
+                 .string(format: .some(.uri)):
                 return ObjCIR.msg("_\(param)", ("isEqualToString", "anObject.\(param)"))
-            case .oneOf(types:_), .object, .string(format: .some(.uri)):
+            case .oneOf(types:_), .object:
                 return ObjCIR.msg("_\(param)", ("isEqual", "anObject.\(param)"))
             case .reference(with: let ref):
                 switch ref.force() {

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -148,7 +148,7 @@ extension ObjCModelRenderer {
             case .boolean:
                 return ["\(propertyToAssign) = [\(rawObjectName) boolValue];"]
             case .string(format: .some(.uri)):
-                return ["\(propertyToAssign) = [NSURL URLWithString:\(rawObjectName)];"]
+                return ["\(propertyToAssign) = \(rawObjectName);"]
             case .string(format: .some(.dateTime)):
                 return ["\(propertyToAssign) = [[NSValueTransformer valueTransformerForName:\(dateValueTransformerKey)] transformedValue:\(rawObjectName)];"]
             case .reference(with: let ref):
@@ -232,7 +232,7 @@ extension ObjCModelRenderer {
                             return transformToADTInit(renderPropertyInit(propertyToAssign, rawObjectName, schema: schema, firstName: firstName, counter: counter))
                         }
                     case .string(.some(.uri)):
-                        return ObjCIR.ifStmt("[\(rawObjectName) isKindOfClass:[NSString class]] && [NSURL URLWithString:\(rawObjectName)] != nil") {
+                        return ObjCIR.ifStmt("[\(rawObjectName) isKindOfClass:[NSString class]]") {
                             return transformToADTInit(renderPropertyInit(propertyToAssign, rawObjectName, schema: schema, firstName: firstName, counter: counter))
                         }
                     case .string(.some(.dateTime)):

--- a/Sources/Core/ObjectiveCNSCodingExtension.swift
+++ b/Sources/Core/ObjectiveCNSCodingExtension.swift
@@ -87,12 +87,11 @@ extension ObjCFileRenderer {
              .string(format: .some(.email)),
              .string(format: .some(.hostname)),
              .string(format: .some(.ipv4)),
-             .string(format: .some(.ipv6)):
+             .string(format: .some(.ipv6)),
+             .string(format: .some(.uri)):
             return Set(["NSString"])
         case .string(format: .some(.dateTime)):
             return Set(["NSDate"])
-        case .string(format: .some(.uri)):
-            return Set(["NSURL"])
         case .integer, .float, .boolean, .enumT:
             return Set(["NSNumber"])
         case .object(let objSchemaRoot):


### PR DESCRIPTION
Due to the strictness of the `NSURL +URLWithString:` constructor, we designate URI's as strings rather than URL's