### PR TITLE
Option for adding abilities to tell if a property is set.

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -337,6 +337,38 @@ struct BoardDirtyProperties {
     }
     return dict;
 }
+- (BOOL)isContributorsSet
+{
+    return _boardDirtyProperties.BoardDirtyPropertyContributors == 1;
+}
+- (BOOL)isCountsSet
+{
+    return _boardDirtyProperties.BoardDirtyPropertyCounts == 1;
+}
+- (BOOL)isCreatedAtSet
+{
+    return _boardDirtyProperties.BoardDirtyPropertyCreatedAt == 1;
+}
+- (BOOL)isCreatorSet
+{
+    return _boardDirtyProperties.BoardDirtyPropertyCreator == 1;
+}
+- (BOOL)isDescriptionTextSet
+{
+    return _boardDirtyProperties.BoardDirtyPropertyDescriptionText == 1;
+}
+- (BOOL)isImageSet
+{
+    return _boardDirtyProperties.BoardDirtyPropertyImage == 1;
+}
+- (BOOL)isNameSet
+{
+    return _boardDirtyProperties.BoardDirtyPropertyName == 1;
+}
+- (BOOL)isUrlSet
+{
+    return _boardDirtyProperties.BoardDirtyPropertyUrl == 1;
+}
 #pragma mark - NSCopying
 - (id)copyWithZone:(NSZone *)zone
 {

--- a/Examples/Cocoa/Sources/Objective_C/Everything.m
+++ b/Examples/Cocoa/Sources/Objective_C/Everything.m
@@ -1649,6 +1649,122 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     }
     return dict;
 }
+- (BOOL)isArrayPropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyArrayProp == 1;
+}
+- (BOOL)isBooleanPropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyBooleanProp == 1;
+}
+- (BOOL)isDatePropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyDateProp == 1;
+}
+- (BOOL)isIntEnumSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyIntEnum == 1;
+}
+- (BOOL)isIntPropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyIntProp == 1;
+}
+- (BOOL)isListPolymorphicValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyListPolymorphicValues == 1;
+}
+- (BOOL)isListWithListAndOtherModelValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyListWithListAndOtherModelValues == 1;
+}
+- (BOOL)isListWithMapAndOtherModelValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyListWithMapAndOtherModelValues == 1;
+}
+- (BOOL)isListWithObjectValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyListWithObjectValues == 1;
+}
+- (BOOL)isListWithOtherModelValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyListWithOtherModelValues == 1;
+}
+- (BOOL)isListWithPrimitiveValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyListWithPrimitiveValues == 1;
+}
+- (BOOL)isMapPolymorphicValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyMapPolymorphicValues == 1;
+}
+- (BOOL)isMapPropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyMapProp == 1;
+}
+- (BOOL)isMapWithListAndOtherModelValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyMapWithListAndOtherModelValues == 1;
+}
+- (BOOL)isMapWithMapAndOtherModelValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyMapWithMapAndOtherModelValues == 1;
+}
+- (BOOL)isMapWithObjectValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyMapWithObjectValues == 1;
+}
+- (BOOL)isMapWithOtherModelValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyMapWithOtherModelValues == 1;
+}
+- (BOOL)isMapWithPrimitiveValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyMapWithPrimitiveValues == 1;
+}
+- (BOOL)isNumberPropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyNumberProp == 1;
+}
+- (BOOL)isOtherModelPropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyOtherModelProp == 1;
+}
+- (BOOL)isPolymorphicPropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyPolymorphicProp == 1;
+}
+- (BOOL)isSetPropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertySetProp == 1;
+}
+- (BOOL)isSetPropWithOtherModelValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertySetPropWithOtherModelValues == 1;
+}
+- (BOOL)isSetPropWithPrimitiveValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertySetPropWithPrimitiveValues == 1;
+}
+- (BOOL)isSetPropWithValuesSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertySetPropWithValues == 1;
+}
+- (BOOL)isStringEnumSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyStringEnum == 1;
+}
+- (BOOL)isStringPropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyStringProp == 1;
+}
+- (BOOL)isTypeSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyType == 1;
+}
+- (BOOL)isUriPropSet
+{
+    return _everythingDirtyProperties.EverythingDirtyPropertyUriProp == 1;
+}
 #pragma mark - NSCopying
 - (id)copyWithZone:(NSZone *)zone
 {

--- a/Examples/Cocoa/Sources/Objective_C/Image.m
+++ b/Examples/Cocoa/Sources/Objective_C/Image.m
@@ -182,6 +182,18 @@ struct ImageDirtyProperties {
     }
     return dict;
 }
+- (BOOL)isHeightSet
+{
+    return _imageDirtyProperties.ImageDirtyPropertyHeight == 1;
+}
+- (BOOL)isUrlSet
+{
+    return _imageDirtyProperties.ImageDirtyPropertyUrl == 1;
+}
+- (BOOL)isWidthSet
+{
+    return _imageDirtyProperties.ImageDirtyPropertyWidth == 1;
+}
 #pragma mark - NSCopying
 - (id)copyWithZone:(NSZone *)zone
 {

--- a/Examples/Cocoa/Sources/Objective_C/Model.m
+++ b/Examples/Cocoa/Sources/Objective_C/Model.m
@@ -144,6 +144,10 @@ struct ModelDirtyProperties {
     }
     return dict;
 }
+- (BOOL)isIdentifierSet
+{
+    return _modelDirtyProperties.ModelDirtyPropertyIdentifier == 1;
+}
 #pragma mark - NSCopying
 - (id)copyWithZone:(NSZone *)zone
 {

--- a/Examples/Cocoa/Sources/Objective_C/Pin.m
+++ b/Examples/Cocoa/Sources/Objective_C/Pin.m
@@ -693,6 +693,74 @@ struct PinDirtyProperties {
     }
     return dict;
 }
+- (BOOL)isAttributionSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyAttribution == 1;
+}
+- (BOOL)isAttributionObjectsSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyAttributionObjects == 1;
+}
+- (BOOL)isBoardSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyBoard == 1;
+}
+- (BOOL)isColorSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyColor == 1;
+}
+- (BOOL)isCountsSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyCounts == 1;
+}
+- (BOOL)isCreatedAtSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyCreatedAt == 1;
+}
+- (BOOL)isCreatorSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyCreator == 1;
+}
+- (BOOL)isDescriptionTextSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyDescriptionText == 1;
+}
+- (BOOL)isIdentifierSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyIdentifier == 1;
+}
+- (BOOL)isImageSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyImage == 1;
+}
+- (BOOL)isInStockSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyInStock == 1;
+}
+- (BOOL)isLinkSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyLink == 1;
+}
+- (BOOL)isMediaSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyMedia == 1;
+}
+- (BOOL)isNoteSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyNote == 1;
+}
+- (BOOL)isTagsSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyTags == 1;
+}
+- (BOOL)isUrlSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyUrl == 1;
+}
+- (BOOL)isVisualSearchAttrsSet
+{
+    return _pinDirtyProperties.PinDirtyPropertyVisualSearchAttrs == 1;
+}
 #pragma mark - NSCopying
 - (id)copyWithZone:(NSZone *)zone
 {

--- a/Examples/Cocoa/Sources/Objective_C/User.m
+++ b/Examples/Cocoa/Sources/Objective_C/User.m
@@ -382,6 +382,46 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
     }
     return dict;
 }
+- (BOOL)isBioSet
+{
+    return _userDirtyProperties.UserDirtyPropertyBio == 1;
+}
+- (BOOL)isCountsSet
+{
+    return _userDirtyProperties.UserDirtyPropertyCounts == 1;
+}
+- (BOOL)isCreatedAtSet
+{
+    return _userDirtyProperties.UserDirtyPropertyCreatedAt == 1;
+}
+- (BOOL)isEmailFrequencySet
+{
+    return _userDirtyProperties.UserDirtyPropertyEmailFrequency == 1;
+}
+- (BOOL)isFirstNameSet
+{
+    return _userDirtyProperties.UserDirtyPropertyFirstName == 1;
+}
+- (BOOL)isIdentifierSet
+{
+    return _userDirtyProperties.UserDirtyPropertyIdentifier == 1;
+}
+- (BOOL)isImageSet
+{
+    return _userDirtyProperties.UserDirtyPropertyImage == 1;
+}
+- (BOOL)isLastNameSet
+{
+    return _userDirtyProperties.UserDirtyPropertyLastName == 1;
+}
+- (BOOL)isTypeSet
+{
+    return _userDirtyProperties.UserDirtyPropertyType == 1;
+}
+- (BOOL)isUsernameSet
+{
+    return _userDirtyProperties.UserDirtyPropertyUsername == 1;
+}
 #pragma mark - NSCopying
 - (id)copyWithZone:(NSZone *)zone
 {

--- a/Examples/Cocoa/Sources/Objective_C/include/Board.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Board.h
@@ -29,6 +29,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToBoard:(Board *)anObject;
 - (instancetype)mergeWithModel:(Board *)modelObject;
 - (instancetype)mergeWithModel:(Board *)modelObject initType:(PlankModelInitType)initType;
+- (BOOL)isContributorsSet;
+- (BOOL)isCountsSet;
+- (BOOL)isCreatedAtSet;
+- (BOOL)isCreatorSet;
+- (BOOL)isDescriptionTextSet;
+- (BOOL)isImageSet;
+- (BOOL)isNameSet;
+- (BOOL)isUrlSet;
 @end
 
 @interface BoardBuilder : ModelBuilder

--- a/Examples/Cocoa/Sources/Objective_C/include/Everything.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Everything.h
@@ -138,6 +138,35 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)mergeWithModel:(Everything *)modelObject;
 - (instancetype)mergeWithModel:(Everything *)modelObject initType:(PlankModelInitType)initType;
 - (NSDictionary *)dictionaryObjectRepresentation;
+- (BOOL)isArrayPropSet;
+- (BOOL)isBooleanPropSet;
+- (BOOL)isDatePropSet;
+- (BOOL)isIntEnumSet;
+- (BOOL)isIntPropSet;
+- (BOOL)isListPolymorphicValuesSet;
+- (BOOL)isListWithListAndOtherModelValuesSet;
+- (BOOL)isListWithMapAndOtherModelValuesSet;
+- (BOOL)isListWithObjectValuesSet;
+- (BOOL)isListWithOtherModelValuesSet;
+- (BOOL)isListWithPrimitiveValuesSet;
+- (BOOL)isMapPolymorphicValuesSet;
+- (BOOL)isMapPropSet;
+- (BOOL)isMapWithListAndOtherModelValuesSet;
+- (BOOL)isMapWithMapAndOtherModelValuesSet;
+- (BOOL)isMapWithObjectValuesSet;
+- (BOOL)isMapWithOtherModelValuesSet;
+- (BOOL)isMapWithPrimitiveValuesSet;
+- (BOOL)isNumberPropSet;
+- (BOOL)isOtherModelPropSet;
+- (BOOL)isPolymorphicPropSet;
+- (BOOL)isSetPropSet;
+- (BOOL)isSetPropWithOtherModelValuesSet;
+- (BOOL)isSetPropWithPrimitiveValuesSet;
+- (BOOL)isSetPropWithValuesSet;
+- (BOOL)isStringEnumSet;
+- (BOOL)isStringPropSet;
+- (BOOL)isTypeSet;
+- (BOOL)isUriPropSet;
 @end
 
 @interface EverythingBuilder : NSObject

--- a/Examples/Cocoa/Sources/Objective_C/include/Image.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Image.h
@@ -27,6 +27,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)mergeWithModel:(Image *)modelObject;
 - (instancetype)mergeWithModel:(Image *)modelObject initType:(PlankModelInitType)initType;
 - (NSDictionary *)dictionaryObjectRepresentation;
+- (BOOL)isHeightSet;
+- (BOOL)isUrlSet;
+- (BOOL)isWidthSet;
 @end
 
 @interface ImageBuilder : NSObject

--- a/Examples/Cocoa/Sources/Objective_C/include/Model.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Model.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)mergeWithModel:(Model *)modelObject;
 - (instancetype)mergeWithModel:(Model *)modelObject initType:(PlankModelInitType)initType;
 - (NSDictionary *)dictionaryObjectRepresentation;
+- (BOOL)isIdentifierSet;
 @end
 
 @interface ModelBuilder : NSObject

--- a/Examples/Cocoa/Sources/Objective_C/include/Pin.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Pin.h
@@ -68,6 +68,23 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)mergeWithModel:(Pin *)modelObject;
 - (instancetype)mergeWithModel:(Pin *)modelObject initType:(PlankModelInitType)initType;
 - (NSDictionary *)dictionaryObjectRepresentation;
+- (BOOL)isAttributionSet;
+- (BOOL)isAttributionObjectsSet;
+- (BOOL)isBoardSet;
+- (BOOL)isColorSet;
+- (BOOL)isCountsSet;
+- (BOOL)isCreatedAtSet;
+- (BOOL)isCreatorSet;
+- (BOOL)isDescriptionTextSet;
+- (BOOL)isIdentifierSet;
+- (BOOL)isImageSet;
+- (BOOL)isInStockSet;
+- (BOOL)isLinkSet;
+- (BOOL)isMediaSet;
+- (BOOL)isNoteSet;
+- (BOOL)isTagsSet;
+- (BOOL)isUrlSet;
+- (BOOL)isVisualSearchAttrsSet;
 @end
 
 @interface PinBuilder : NSObject

--- a/Examples/Cocoa/Sources/Objective_C/include/User.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/User.h
@@ -45,6 +45,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)mergeWithModel:(User *)modelObject;
 - (instancetype)mergeWithModel:(User *)modelObject initType:(PlankModelInitType)initType;
 - (NSDictionary *)dictionaryObjectRepresentation;
+- (BOOL)isBioSet;
+- (BOOL)isCountsSet;
+- (BOOL)isCreatedAtSet;
+- (BOOL)isEmailFrequencySet;
+- (BOOL)isFirstNameSet;
+- (BOOL)isIdentifierSet;
+- (BOOL)isImageSet;
+- (BOOL)isLastNameSet;
+- (BOOL)isTypeSet;
+- (BOOL)isUsernameSet;
 @end
 
 @interface UserBuilder : NSObject

--- a/Examples/Cocoa/Tests/Objective_CTests/ObjcTests.swift
+++ b/Examples/Cocoa/Tests/Objective_CTests/ObjcTests.swift
@@ -49,6 +49,45 @@ class ObjcTestSuite: XCTestCase {
 
         XCTAssert(userModelDictionary == user.dictionaryObjectRepresentation(), "User dictionary representation should be the same as the model dictionary")
     }
+
+    func testIsSetWithSetProperty() {
+        // Test that properties which are set to values are reported as set
+        let imageModelDictionary: JSONDict = [
+            "height": 12,
+            "width": 11,
+            "url": "http://google.com"
+        ]
+        let image = Image(modelDictionary: imageModelDictionary)
+        // All properties should be set
+        XCTAssertTrue(image.isHeightSet())
+        XCTAssertTrue(image.isWidthSet())
+        XCTAssertTrue(image.isUrlSet())
+    }
+
+    func testIsSetWithUnsetProperty() {
+        // Test that properties which have not been set to a value are reported as unset
+        let imageModelDictionary: JSONDict = [
+            "height": 12,
+            "width": 11,
+        ]
+        let image = Image(modelDictionary: imageModelDictionary)
+        // Set properties
+        XCTAssertTrue(image.isHeightSet())
+        XCTAssertTrue(image.isWidthSet())
+        // Unset properties
+        XCTAssertFalse(image.isUrlSet())
+    }
+
+    func testIsSetWithNullValue() {
+        // Test that properties which are set to null values are reported as set
+        let imageModelDictionary: JSONDict = [
+            "height": 12,
+            "width": 11,
+            "url": NSNull()
+        ]
+        let image = Image(modelDictionary: imageModelDictionary)
+        XCTAssertTrue(image.isUrlSet())
+    }
 }
 
 class ObjcDictionaryRepresentationTestSuite: XCTestCase {


### PR DESCRIPTION
This follows the traditional thrift style isset methods that utilizes the internal dirty
properties bitmask to return the correct value.

This is one potential way to address: https://github.com/pinterest/plank/issues/139

The alternative I have in mind is creating a simple Optional type that the caller would have to pattern match the value for but at that point we might want to return that for any nullable property