### PR TITLE
For Boolean, Double and Integer properties, getters should be NonNull

### DIFF
--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -288,8 +288,8 @@ public class Everything {
         return this.arrayProp;
     }
 
-    public @Nullable Boolean getBooleanProp() {
-        return this.booleanProp;
+    public @NonNull Boolean getBooleanProp() {
+        return this.booleanProp == null ? Boolean.FALSE : this.booleanProp;
     }
 
     public @Nullable Date getDateProp() {
@@ -300,8 +300,8 @@ public class Everything {
         return this.intEnum;
     }
 
-    public @Nullable Integer getIntProp() {
-        return this.intProp;
+    public @NonNull Integer getIntProp() {
+        return this.intProp == null ? 0 : this.intProp;
     }
 
     public @Nullable List<Object> getListPolymorphicValues() {
@@ -356,8 +356,8 @@ public class Everything {
         return this.mapWithPrimitiveValues;
     }
 
-    public @Nullable Double getNumberProp() {
-        return this.numberProp;
+    public @NonNull Double getNumberProp() {
+        return this.numberProp == null ? 0 : this.numberProp;
     }
 
     public @Nullable User getOtherModelProp() {

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -88,16 +88,16 @@ public class Image {
         width);
     }
 
-    public @Nullable Integer getHeight() {
-        return this.height;
+    public @NonNull Integer getHeight() {
+        return this.height == null ? 0 : this.height;
     }
 
     public @Nullable String getUrl() {
         return this.url;
     }
 
-    public @Nullable Integer getWidth() {
-        return this.width;
+    public @NonNull Integer getWidth() {
+        return this.width == null ? 0 : this.width;
     }
 
     public boolean getHeightIsSet() {

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -94,20 +94,20 @@ public class VariableSubtitution {
         newProp);
     }
 
-    public @Nullable Integer getAllocProp() {
-        return this.allocProp;
+    public @NonNull Integer getAllocProp() {
+        return this.allocProp == null ? 0 : this.allocProp;
     }
 
-    public @Nullable Integer getCopyProp() {
-        return this.copyProp;
+    public @NonNull Integer getCopyProp() {
+        return this.copyProp == null ? 0 : this.copyProp;
     }
 
-    public @Nullable Integer getMutableCopyProp() {
-        return this.mutableCopyProp;
+    public @NonNull Integer getMutableCopyProp() {
+        return this.mutableCopyProp == null ? 0 : this.mutableCopyProp;
     }
 
-    public @Nullable Integer getNewProp() {
-        return this.newProp;
+    public @NonNull Integer getNewProp() {
+        return this.newProp == null ? 0 : this.newProp;
     }
 
     public boolean getAllocPropIsSet() {

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -31,7 +31,7 @@ enum JavaAnnotation: Hashable {
     case nullable
     case nonnull
     case serializedName(name: String)
-    
+
     var rendered: String {
         switch self {
         case .override:
@@ -59,7 +59,7 @@ public struct JavaIR {
             let annotationLines = annotations.map { "@\($0.rendered)" }
 
             let throwsString = throwableExceptions.isEmpty ? "" : " throws " + throwableExceptions.joined(separator: ", ")
-            
+
             if modifiers.contains(.abstract) {
                 return annotationLines + ["\(modifiers.render()) \(signature)\(throwsString);"]
             }
@@ -99,7 +99,7 @@ public struct JavaIR {
     static func method(annotations: Set<JavaAnnotation> = [], _ modifiers: JavaModifier, _ signature: String, body: () -> [String]) -> JavaIR.Method {
         return JavaIR.Method(annotations: annotations, modifiers: modifiers, body: body(), signature: signature, throwableExceptions: [])
     }
-    
+
     static func methodThatThrows(annotations: Set<JavaAnnotation> = [], _ modifiers: JavaModifier, _ signature: String, _ throwableExceptions: [String], body: () -> [String]) -> JavaIR.Method {
         return JavaIR.Method(annotations: annotations, modifiers: modifiers, body: body(), signature: signature, throwableExceptions: throwableExceptions)
     }

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -77,10 +77,9 @@ public struct JavaModelRenderer: JavaFileRenderer {
     }
 
     func propertyGetterForParam(param: String, schemaObj: SchemaObjectProperty) -> JavaIR.Method {
-        
         let propertyName = param.snakeCaseToPropertyName()
         let capitalizedPropertyName = param.snakeCaseToCapitalizedPropertyName()
-        
+
         // For Booleans, Integers and Doubles, make the getter method @NonNull and squash to a default value if necessary.
         // This makes callers less susceptible to null pointer exceptions.
         switch schemaObj.schema {


### PR DESCRIPTION
Otherwise callers will always have to defend against null values, which is a big pain.
We have isVARIABLESet() methods if developers want to check if a property was actually set or not.