### PR TITLE
Use standard Java enum types for enum properties

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -8,10 +8,8 @@
 
 package com.pinterest.models;
 
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -8,10 +8,8 @@
 
 package com.pinterest.models;
 
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
@@ -55,26 +53,27 @@ interface EverythingPolymorphicPropMatcher<R> {
 
 public class Everything {
 
-    @Retention(RetentionPolicy.SOURCE)
-    @IntDef({EverythingIntEnum.INT_CASE_1, EverythingIntEnum.INT_CASE_2, EverythingIntEnum.INT_CASE_3})
-    public @interface EverythingIntEnum {
-        int INT_CASE_1 = 1;
-        int INT_CASE_2 = 2;
-        int INT_CASE_3 = 3;
+    public enum EverythingIntEnum {
+        INT_CASE_1(1), 
+        INT_CASE_2(2), 
+        INT_CASE_3(3);
+        private final int value;
+        EverythingIntEnum(int value) {
+            this.value = value;
+        }
+        public int getValue() {
+            return this.value;
+        }
     }
 
-    @Retention(RetentionPolicy.SOURCE)
-    @StringDef({EverythingStringEnum.CASE1, EverythingStringEnum.CASE2, EverythingStringEnum.CASE3})
-    public @interface EverythingStringEnum {
-        String CASE1 = "case1";
-        String CASE2 = "case2";
-        String CASE3 = "case3";
+    public enum EverythingStringEnum {
+        @SerializedName("case1") CASE1, @SerializedName("case2") CASE2, @SerializedName("case3") CASE3;
     }
 
     @SerializedName("array_prop") private @Nullable List<Object> arrayProp;
     @SerializedName("boolean_prop") private @Nullable Boolean booleanProp;
     @SerializedName("date_prop") private @Nullable Date dateProp;
-    @SerializedName("int_enum") private @Nullable @EverythingIntEnum int intEnum;
+    @SerializedName("int_enum") private @Nullable EverythingIntEnum intEnum;
     @SerializedName("int_prop") private @Nullable Integer intProp;
     @SerializedName("list_polymorphic_values") private @Nullable List<Object> listPolymorphicValues;
     @SerializedName("list_with_list_and_other_model_values") private @Nullable List<List<User>> listWithListAndOtherModelValues;
@@ -96,7 +95,7 @@ public class Everything {
     @SerializedName("set_prop_with_other_model_values") private @Nullable Set<User> setPropWithOtherModelValues;
     @SerializedName("set_prop_with_primitive_values") private @Nullable Set<Integer> setPropWithPrimitiveValues;
     @SerializedName("set_prop_with_values") private @Nullable Set<String> setPropWithValues;
-    @SerializedName("string_enum") private @Nullable @EverythingStringEnum String stringEnum;
+    @SerializedName("string_enum") private @Nullable EverythingStringEnum stringEnum;
     @SerializedName("string_prop") private @Nullable String stringProp;
     @SerializedName("type") private @Nullable String type;
     @SerializedName("uri_prop") private @Nullable String uriProp;
@@ -137,7 +136,7 @@ public class Everything {
         @Nullable List<Object> arrayProp,
         @Nullable Boolean booleanProp,
         @Nullable Date dateProp,
-        @Nullable @EverythingIntEnum int intEnum,
+        @Nullable EverythingIntEnum intEnum,
         @Nullable Integer intProp,
         @Nullable List<Object> listPolymorphicValues,
         @Nullable List<List<User>> listWithListAndOtherModelValues,
@@ -159,7 +158,7 @@ public class Everything {
         @Nullable Set<User> setPropWithOtherModelValues,
         @Nullable Set<Integer> setPropWithPrimitiveValues,
         @Nullable Set<String> setPropWithValues,
-        @Nullable @EverythingStringEnum String stringEnum,
+        @Nullable EverythingStringEnum stringEnum,
         @Nullable String stringProp,
         @Nullable String type,
         @Nullable String uriProp,
@@ -296,7 +295,7 @@ public class Everything {
         return this.dateProp;
     }
 
-    public @Nullable @EverythingIntEnum int getIntEnum() {
+    public @Nullable EverythingIntEnum getIntEnum() {
         return this.intEnum;
     }
 
@@ -384,7 +383,7 @@ public class Everything {
         return this.setPropWithValues;
     }
 
-    public @Nullable @EverythingStringEnum String getStringEnum() {
+    public @Nullable EverythingStringEnum getStringEnum() {
         return this.stringEnum;
     }
 
@@ -521,7 +520,7 @@ public class Everything {
         @SerializedName("array_prop") private @Nullable List<Object> arrayProp;
         @SerializedName("boolean_prop") private @Nullable Boolean booleanProp;
         @SerializedName("date_prop") private @Nullable Date dateProp;
-        @SerializedName("int_enum") private @Nullable @EverythingIntEnum int intEnum;
+        @SerializedName("int_enum") private @Nullable EverythingIntEnum intEnum;
         @SerializedName("int_prop") private @Nullable Integer intProp;
         @SerializedName("list_polymorphic_values") private @Nullable List<Object> listPolymorphicValues;
         @SerializedName("list_with_list_and_other_model_values") private @Nullable List<List<User>> listWithListAndOtherModelValues;
@@ -543,7 +542,7 @@ public class Everything {
         @SerializedName("set_prop_with_other_model_values") private @Nullable Set<User> setPropWithOtherModelValues;
         @SerializedName("set_prop_with_primitive_values") private @Nullable Set<Integer> setPropWithPrimitiveValues;
         @SerializedName("set_prop_with_values") private @Nullable Set<String> setPropWithValues;
-        @SerializedName("string_enum") private @Nullable @EverythingStringEnum String stringEnum;
+        @SerializedName("string_enum") private @Nullable EverythingStringEnum stringEnum;
         @SerializedName("string_prop") private @Nullable String stringProp;
         @SerializedName("type") private @Nullable String type;
         @SerializedName("uri_prop") private @Nullable String uriProp;
@@ -604,7 +603,7 @@ public class Everything {
             return this;
         }
 
-        public Builder setIntEnum(@Nullable @EverythingIntEnum int value) {
+        public Builder setIntEnum(@Nullable EverythingIntEnum value) {
             this.intEnum = value;
             this._bits |= INT_ENUM_SET;
             return this;
@@ -736,7 +735,7 @@ public class Everything {
             return this;
         }
 
-        public Builder setStringEnum(@Nullable @EverythingStringEnum String value) {
+        public Builder setStringEnum(@Nullable EverythingStringEnum value) {
             this.stringEnum = value;
             this._bits |= STRING_ENUM_SET;
             return this;
@@ -772,7 +771,7 @@ public class Everything {
             return this.dateProp;
         }
 
-        public @Nullable @EverythingIntEnum int getIntEnum() {
+        public @Nullable EverythingIntEnum getIntEnum() {
             return this.intEnum;
         }
 
@@ -860,7 +859,7 @@ public class Everything {
             return this.setPropWithValues;
         }
 
-        public @Nullable @EverythingStringEnum String getStringEnum() {
+        public @Nullable EverythingStringEnum getStringEnum() {
             return this.stringEnum;
         }
 
@@ -1132,16 +1131,21 @@ public class Everything {
 
     public static final class EverythingMapPolymorphicValues<R> {
 
-        @Retention(RetentionPolicy.SOURCE)
-        @IntDef({InternalStorage.USER, InternalStorage.BOARD, InternalStorage.IMAGE, InternalStorage.PIN, InternalStorage.EVERYTHING, InternalStorage.LISTOBJECT, InternalStorage.MAPSTRING_OBJECT})
-        public @interface InternalStorage {
-            int USER = 0;
-            int BOARD = 1;
-            int IMAGE = 2;
-            int PIN = 3;
-            int EVERYTHING = 4;
-            int LISTOBJECT = 5;
-            int MAPSTRING_OBJECT = 6;
+        public enum InternalStorage {
+            USER(0), 
+            BOARD(1), 
+            IMAGE(2), 
+            PIN(3), 
+            EVERYTHING(4), 
+            LISTOBJECT(5), 
+            MAPSTRING_OBJECT(6);
+            private final int value;
+            InternalStorage(int value) {
+                this.value = value;
+            }
+            public int getValue() {
+                return this.value;
+            }
         }
 
         private @Nullable User value0;
@@ -1152,7 +1156,7 @@ public class Everything {
         private @Nullable List<Object> value5;
         private @Nullable Map<String, Object> value6;
 
-        static private @InternalStorage int internalStorage;
+        static private InternalStorage internalStorage;
 
         private EverythingMapPolymorphicValues() {
         }
@@ -1165,20 +1169,25 @@ public class Everything {
 
     public static final class EverythingPolymorphicProp<R> {
 
-        @Retention(RetentionPolicy.SOURCE)
-        @IntDef({InternalStorage.USER, InternalStorage.BOARD, InternalStorage.IMAGE, InternalStorage.PIN, InternalStorage.EVERYTHING, InternalStorage.STRING, InternalStorage.BOOLEAN, InternalStorage.INTEGER, InternalStorage.DOUBLE, InternalStorage.DATE, InternalStorage.STRING})
-        public @interface InternalStorage {
-            int USER = 0;
-            int BOARD = 1;
-            int IMAGE = 2;
-            int PIN = 3;
-            int EVERYTHING = 4;
-            int STRING = 5;
-            int BOOLEAN = 6;
-            int INTEGER = 7;
-            int DOUBLE = 8;
-            int DATE = 9;
-            int STRING = 10;
+        public enum InternalStorage {
+            USER(0), 
+            BOARD(1), 
+            IMAGE(2), 
+            PIN(3), 
+            EVERYTHING(4), 
+            STRING(5), 
+            BOOLEAN(6), 
+            INTEGER(7), 
+            DOUBLE(8), 
+            DATE(9), 
+            STRING(10);
+            private final int value;
+            InternalStorage(int value) {
+                this.value = value;
+            }
+            public int getValue() {
+                return this.value;
+            }
         }
 
         private @Nullable User value0;
@@ -1193,7 +1202,7 @@ public class Everything {
         private @Nullable Date value9;
         private @Nullable String value10;
 
-        static private @InternalStorage int internalStorage;
+        static private InternalStorage internalStorage;
 
         private EverythingPolymorphicProp() {
         }

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -8,10 +8,8 @@
 
 package com.pinterest.models;
 
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -8,10 +8,8 @@
 
 package com.pinterest.models;
 
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -8,10 +8,8 @@
 
 package com.pinterest.models;
 
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
@@ -36,12 +34,17 @@ interface PinAttributionObjectsMatcher<R> {
 
 public class Pin {
 
-    @Retention(RetentionPolicy.SOURCE)
-    @IntDef({PinInStock.UNKNOWN, PinInStock.OUT_OF_STOCK, PinInStock.IN_STOCK})
-    public @interface PinInStock {
-        int UNKNOWN = -1;
-        int OUT_OF_STOCK = 0;
-        int IN_STOCK = 1;
+    public enum PinInStock {
+        UNKNOWN(-1), 
+        OUT_OF_STOCK(0), 
+        IN_STOCK(1);
+        private final int value;
+        PinInStock(int value) {
+            this.value = value;
+        }
+        public int getValue() {
+            return this.value;
+        }
     }
 
     @SerializedName("attribution") private @Nullable Map<String, String> attribution;
@@ -54,7 +57,7 @@ public class Pin {
     @SerializedName("description") private @Nullable String descriptionText;
     @SerializedName("id") private @NonNull String identifier;
     @SerializedName("image") private @Nullable Image image;
-    @SerializedName("in_stock") private @Nullable @PinInStock int inStock;
+    @SerializedName("in_stock") private @Nullable PinInStock inStock;
     @SerializedName("link") private @Nullable String link;
     @SerializedName("media") private @Nullable Map<String, String> media;
     @SerializedName("note") private @Nullable String note;
@@ -93,7 +96,7 @@ public class Pin {
         @Nullable String descriptionText,
         @NonNull String identifier,
         @Nullable Image image,
-        @Nullable @PinInStock int inStock,
+        @Nullable PinInStock inStock,
         @Nullable String link,
         @Nullable Map<String, String> media,
         @Nullable String note,
@@ -225,7 +228,7 @@ public class Pin {
         return this.image;
     }
 
-    public @Nullable @PinInStock int getInStock() {
+    public @Nullable PinInStock getInStock() {
         return this.inStock;
     }
 
@@ -333,7 +336,7 @@ public class Pin {
         @SerializedName("description") private @Nullable String descriptionText;
         @SerializedName("id") private @NonNull String identifier;
         @SerializedName("image") private @Nullable Image image;
-        @SerializedName("in_stock") private @Nullable @PinInStock int inStock;
+        @SerializedName("in_stock") private @Nullable PinInStock inStock;
         @SerializedName("link") private @Nullable String link;
         @SerializedName("media") private @Nullable Map<String, String> media;
         @SerializedName("note") private @Nullable String note;
@@ -427,7 +430,7 @@ public class Pin {
             return this;
         }
 
-        public Builder setInStock(@Nullable @PinInStock int value) {
+        public Builder setInStock(@Nullable PinInStock value) {
             this.inStock = value;
             this._bits |= IN_STOCK_SET;
             return this;
@@ -509,7 +512,7 @@ public class Pin {
             return this.image;
         }
 
-        public @Nullable @PinInStock int getInStock() {
+        public @Nullable PinInStock getInStock() {
             return this.inStock;
         }
 
@@ -709,17 +712,22 @@ public class Pin {
 
     public static final class PinAttributionObjects<R> {
 
-        @Retention(RetentionPolicy.SOURCE)
-        @IntDef({InternalStorage.BOARD, InternalStorage.USER})
-        public @interface InternalStorage {
-            int BOARD = 0;
-            int USER = 1;
+        public enum InternalStorage {
+            BOARD(0), 
+            USER(1);
+            private final int value;
+            InternalStorage(int value) {
+                this.value = value;
+            }
+            public int getValue() {
+                return this.value;
+            }
         }
 
         private @Nullable Board value0;
         private @Nullable User value1;
 
-        static private @InternalStorage int internalStorage;
+        static private InternalStorage internalStorage;
 
         private PinAttributionObjects() {
         }

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -8,10 +8,8 @@
 
 package com.pinterest.models;
 
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
@@ -31,18 +29,14 @@ import java.util.Set;
 
 public class User {
 
-    @Retention(RetentionPolicy.SOURCE)
-    @StringDef({UserEmailFrequency.UNSET, UserEmailFrequency.IMMEDIATE, UserEmailFrequency.DAILY})
-    public @interface UserEmailFrequency {
-        String UNSET = "unset";
-        String IMMEDIATE = "immediate";
-        String DAILY = "daily";
+    public enum UserEmailFrequency {
+        @SerializedName("unset") UNSET, @SerializedName("immediate") IMMEDIATE, @SerializedName("daily") DAILY;
     }
 
     @SerializedName("bio") private @Nullable String bio;
     @SerializedName("counts") private @Nullable Map<String, Integer> counts;
     @SerializedName("created_at") private @Nullable Date createdAt;
-    @SerializedName("email_frequency") private @Nullable @UserEmailFrequency String emailFrequency;
+    @SerializedName("email_frequency") private @Nullable UserEmailFrequency emailFrequency;
     @SerializedName("first_name") private @Nullable String firstName;
     @SerializedName("id") private @Nullable String identifier;
     @SerializedName("image") private @Nullable Image image;
@@ -67,7 +61,7 @@ public class User {
         @Nullable String bio,
         @Nullable Map<String, Integer> counts,
         @Nullable Date createdAt,
-        @Nullable @UserEmailFrequency String emailFrequency,
+        @Nullable UserEmailFrequency emailFrequency,
         @Nullable String firstName,
         @Nullable String identifier,
         @Nullable Image image,
@@ -150,7 +144,7 @@ public class User {
         return this.createdAt;
     }
 
-    public @Nullable @UserEmailFrequency String getEmailFrequency() {
+    public @Nullable UserEmailFrequency getEmailFrequency() {
         return this.emailFrequency;
     }
 
@@ -223,7 +217,7 @@ public class User {
         @SerializedName("bio") private @Nullable String bio;
         @SerializedName("counts") private @Nullable Map<String, Integer> counts;
         @SerializedName("created_at") private @Nullable Date createdAt;
-        @SerializedName("email_frequency") private @Nullable @UserEmailFrequency String emailFrequency;
+        @SerializedName("email_frequency") private @Nullable UserEmailFrequency emailFrequency;
         @SerializedName("first_name") private @Nullable String firstName;
         @SerializedName("id") private @Nullable String identifier;
         @SerializedName("image") private @Nullable Image image;
@@ -268,7 +262,7 @@ public class User {
             return this;
         }
 
-        public Builder setEmailFrequency(@Nullable @UserEmailFrequency String value) {
+        public Builder setEmailFrequency(@Nullable UserEmailFrequency value) {
             this.emailFrequency = value;
             this._bits |= EMAIL_FREQUENCY_SET;
             return this;
@@ -322,7 +316,7 @@ public class User {
             return this.createdAt;
         }
 
-        public @Nullable @UserEmailFrequency String getEmailFrequency() {
+        public @Nullable UserEmailFrequency getEmailFrequency() {
             return this.emailFrequency;
         }
 

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -8,10 +8,8 @@
 
 package com.pinterest.models;
 
-import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.StringDef;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;

--- a/Sources/Core/JavaADTRenderer.swift
+++ b/Sources/Core/JavaADTRenderer.swift
@@ -60,7 +60,7 @@ extension JavaModelRenderer {
 
         let internalStorageEnum = JavaIR.Enum(name: "InternalStorage", values: .integer(enumOptions))
 
-        let internalStorageProp = JavaIR.Property(annotations: [], modifiers: [.private, .static], type: "@InternalStorage int", name: "internalStorage", initialValue: "")
+        let internalStorageProp = JavaIR.Property(annotations: [], modifiers: [.private, .static], type: "InternalStorage", name: "internalStorage", initialValue: "")
         let cls = JavaIR.Class(annotations: [],
                                modifiers: [.public, .static, .final],
                                extends: nil,

--- a/Sources/Core/JavaFileRenderer.swift
+++ b/Sources/Core/JavaFileRenderer.swift
@@ -78,14 +78,8 @@ extension JavaFileRenderer {
             return "Double"
         case .boolean:
             return "Boolean"
-        case let .enumT(enumObj):
-            let enumName = enumTypeName(propertyName: param, className: className)
-            switch enumObj {
-            case .integer:
-                return "@\(enumName) int"
-            case .string(_, defaultValue: _):
-                return "@\(enumName) String"
-            }
+        case .enumT:
+            return enumTypeName(propertyName: param, className: className)
         case let .object(objSchemaRoot):
             return "\(objSchemaRoot.className(with: params))"
         case let .reference(with: ref):

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -155,25 +155,25 @@ public struct JavaIR {
                 let names = values
                     .map { ($0.description, $0.defaultValue) }
                     .map { "\($0.0.uppercased())(\($0.1))" }.joined(separator: ", \n")
-                let enumInitializer = JavaIR.method([], "\(name)(int value)") {[
-                    "this.value = value;"
-                ]}
+                let enumInitializer = JavaIR.method([], "\(name)(int value)") { [
+                    "this.value = value;",
+                ] }
 
-                let getterMethod = JavaIR.method([.public], "int getValue()") {[
-                    "return this.value;"
-                ]}
+                let getterMethod = JavaIR.method([.public], "int getValue()") { [
+                    "return this.value;",
+                ] }
                 return [
                     "public enum \(name) {",
-                        -->["\(names);", "private final int value;",],
-                        -->enumInitializer.render(),
-                        -->getterMethod.render(),
+                    -->["\(names);", "private final int value;"],
+                    -->enumInitializer.render(),
+                    -->getterMethod.render(),
                     "}",
                 ]
             case let .string(values, defaultValue: _):
                 let names = values
                     .map { ($0.description, $0.defaultValue) }
                     .map { "@\(JavaAnnotation.serializedName(name: "\($0.1)").rendered) \($0.0.uppercased())" }.joined(separator: ", ")
-                
+
                 return [
                     "public enum \(name) {",
                     -->["\(names);"],

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -302,10 +302,8 @@ public struct JavaModelRenderer: JavaFileRenderer {
                 "java.util.Objects",
                 "java.lang.annotation.Retention",
                 "java.lang.annotation.RetentionPolicy",
-                "android.support.annotation.IntDef",
                 "android.support.annotation.NonNull",
                 "android.support.annotation.Nullable",
-                "android.support.annotation.StringDef",
             ]),
         ]
 


### PR DESCRIPTION
- Migrate generated code away from @IntDef @StringDef annotations
- Update references throughout codebase

