### PR TITLE
Add missing check for null json token. This would trigger an exception if the model is null or non-existent.

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -17,6 +17,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.annotation.Retention;
@@ -388,6 +389,10 @@ public class Board {
 
         @Override
         public Board read(JsonReader reader) throws IOException {
+            if (reader.peek() == JsonToken.NULL) {
+                reader.nextNull();
+                return null;
+            }
             JsonElement tree = this.elementTypeAdapter.read(reader);
             Board model = this.delegateTypeAdapter.fromJsonTree(tree);
             Set<String> keys = tree.getAsJsonObject().keySet();

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -17,6 +17,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.annotation.Retention;
@@ -1029,6 +1030,10 @@ public class Everything {
 
         @Override
         public Everything read(JsonReader reader) throws IOException {
+            if (reader.peek() == JsonToken.NULL) {
+                reader.nextNull();
+                return null;
+            }
             JsonElement tree = this.elementTypeAdapter.read(reader);
             Everything model = this.delegateTypeAdapter.fromJsonTree(tree);
             Set<String> keys = tree.getAsJsonObject().keySet();

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -17,6 +17,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.annotation.Retention;
@@ -208,6 +209,10 @@ public class Image {
 
         @Override
         public Image read(JsonReader reader) throws IOException {
+            if (reader.peek() == JsonToken.NULL) {
+                reader.nextNull();
+                return null;
+            }
             JsonElement tree = this.elementTypeAdapter.read(reader);
             Image model = this.delegateTypeAdapter.fromJsonTree(tree);
             Set<String> keys = tree.getAsJsonObject().keySet();

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -17,6 +17,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.annotation.Retention;
@@ -148,6 +149,10 @@ public class Model {
 
         @Override
         public Model read(JsonReader reader) throws IOException {
+            if (reader.peek() == JsonToken.NULL) {
+                reader.nextNull();
+                return null;
+            }
             JsonElement tree = this.elementTypeAdapter.read(reader);
             Model model = this.delegateTypeAdapter.fromJsonTree(tree);
             Set<String> keys = tree.getAsJsonObject().keySet();

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -17,6 +17,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.annotation.Retention;
@@ -646,6 +647,10 @@ public class Pin {
 
         @Override
         public Pin read(JsonReader reader) throws IOException {
+            if (reader.peek() == JsonToken.NULL) {
+                reader.nextNull();
+                return null;
+            }
             JsonElement tree = this.elementTypeAdapter.read(reader);
             Pin model = this.delegateTypeAdapter.fromJsonTree(tree);
             Set<String> keys = tree.getAsJsonObject().keySet();

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -17,6 +17,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.annotation.Retention;
@@ -422,6 +423,10 @@ public class User {
 
         @Override
         public User read(JsonReader reader) throws IOException {
+            if (reader.peek() == JsonToken.NULL) {
+                reader.nextNull();
+                return null;
+            }
             JsonElement tree = this.elementTypeAdapter.read(reader);
             User model = this.delegateTypeAdapter.fromJsonTree(tree);
             Set<String> keys = tree.getAsJsonObject().keySet();

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -17,6 +17,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.lang.annotation.Retention;
@@ -238,6 +239,10 @@ public class VariableSubtitution {
 
         @Override
         public VariableSubtitution read(JsonReader reader) throws IOException {
+            if (reader.peek() == JsonToken.NULL) {
+                reader.nextNull();
+                return null;
+            }
             JsonElement tree = this.elementTypeAdapter.read(reader);
             VariableSubtitution model = this.delegateTypeAdapter.fromJsonTree(tree);
             Set<String> keys = tree.getAsJsonObject().keySet();

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -258,6 +258,10 @@ public struct JavaModelRenderer: JavaFileRenderer {
             className + " read(JsonReader reader)",
             ["IOException"]
         ) { [
+            JavaIR.ifBlock(condition: "reader.peek() == JsonToken.NULL") { [
+                "reader.nextNull();",
+                "return null;",
+            ] },
             "JsonElement tree = this.elementTypeAdapter.read(reader);",
             className + " model = this.delegateTypeAdapter.fromJsonTree(tree);",
             "Set<String> keys = tree.getAsJsonObject().keySet();",
@@ -293,6 +297,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
                 "com.google.gson.TypeAdapterFactory",
                 "com.google.gson.reflect.TypeToken",
                 "com.google.gson.stream.JsonReader",
+                "com.google.gson.stream.JsonToken",
                 "com.google.gson.stream.JsonWriter",
                 "java.io.IOException",
                 "java.util.Date",


### PR DESCRIPTION
Example:
`{"board": null}` or a non-existent "board" field could trigger an exception.