### PR TITLE
Fix archive command to work also with Swift 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ output_stability_test: build
 ci_tests: test integration_test output_stability_test
 
 archive:
-	swift build -c release -Xswiftc -static-stdlib --disable-sandbox
+	swift build -c release --static-swift-stdlib --disable-sandbox
 
 upload_pipeline:
 	.buildkite/upload_pipeline.sh


### PR DESCRIPTION
This will trigger a warning for those on >= MacOS 10.14.4 but it will get it working again.

```
warning: Swift compiler no longer supports statically linking the Swift libraries. They're included in the OS by default starting with macOS Mojave 10.14.4. For macOS Mojave 10.14.3 and earlier, there's an optional Swift library package that can be downloaded from "More Downloads" for Apple Developers at https://developer.apple.com/download/more/
```