### PR TITLE
Add a static TYPE variable to java models

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -30,6 +30,8 @@ import java.util.Set;
 
 public class Board {
 
+    public static final String TYPE = "board";
+
     @SerializedName("id") private @Nullable String uid;
     @SerializedName("contributors") private @Nullable Set<User> contributors;
     @SerializedName("counts") private @Nullable Map<String, Integer> counts;

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -71,6 +71,8 @@ public class Everything {
         @SerializedName("case1") CASE1, @SerializedName("case2") CASE2, @SerializedName("case3") CASE3;
     }
 
+    public static final String TYPE = "everything";
+
     @SerializedName("array_prop") private @Nullable List<Object> arrayProp;
     @SerializedName("boolean_prop") private @Nullable Boolean booleanProp;
     @SerializedName("date_prop") private @Nullable Date dateProp;

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -30,6 +30,8 @@ import java.util.Set;
 
 public class Image {
 
+    public static final String TYPE = "image";
+
     @SerializedName("height") private @Nullable Integer height;
     @SerializedName("url") private @Nullable String url;
     @SerializedName("width") private @Nullable Integer width;

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -30,6 +30,8 @@ import java.util.Set;
 
 public class Model {
 
+    public static final String TYPE = "model";
+
     @SerializedName("id") private @Nullable String uid;
 
     static final private int ID_SET = 1 << 0;

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -48,6 +48,8 @@ public class Pin {
         }
     }
 
+    public static final String TYPE = "pin";
+
     @SerializedName("attribution") private @Nullable Map<String, String> attribution;
     @SerializedName("attribution_objects") private @Nullable List<PinAttributionObjects> attributionObjects;
     @SerializedName("board") private @Nullable Board board;

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -34,6 +34,8 @@ public class User {
         @SerializedName("unset") UNSET, @SerializedName("immediate") IMMEDIATE, @SerializedName("daily") DAILY;
     }
 
+    public static final String TYPE = "user";
+
     @SerializedName("bio") private @Nullable String bio;
     @SerializedName("counts") private @Nullable Map<String, Integer> counts;
     @SerializedName("created_at") private @Nullable Date createdAt;

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -30,6 +30,8 @@ import java.util.Set;
 
 public class VariableSubtitution {
 
+    public static final String TYPE = "variable_subtitution";
+
     @SerializedName("alloc_prop") private @Nullable Integer allocProp;
     @SerializedName("copy_prop") private @Nullable Integer copyProp;
     @SerializedName("mutable_copy_prop") private @Nullable Integer mutableCopyProp;

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -30,6 +30,10 @@ public struct JavaModelRenderer: JavaFileRenderer {
         }
     }
 
+    func renderStaticTypeString() -> JavaIR.Property {
+        return JavaIR.Property(annotations: [], modifiers: [.public, .static, .final], type: "String", name: "TYPE", initialValue: "\"" + rootSchema.typeIdentifier + "\"")
+    }
+
     func renderModelHashCode() -> JavaIR.Method {
         let bodyHashCode = transitiveProperties.map { param, _ in
             Languages.java.snakeCaseToPropertyName(param)
@@ -73,7 +77,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
             index += 1
         }
 
-        return [props, bitmasks, [bits]]
+        return [[renderStaticTypeString()], props, bitmasks, [bits]]
     }
 
     func propertyGetterForParam(param: String, schemaObj: SchemaObjectProperty) -> JavaIR.Method {


### PR DESCRIPTION
Example:
```
public class Board {
  public static final String TYPE = "board";
}
```

This can be useful when one needs a string-based representation of the model type. 