### PR TITLE
Emit BOOL properties as bitfields

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -167,6 +167,7 @@ struct BoardDirtyProperties {
     _image = builder.image;
     _name = builder.name;
     _url = builder.url;
+
     _boardDirtyProperties = builder.boardDirtyProperties;
     if ([self class] == [Board class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(initType) }];
@@ -203,6 +204,7 @@ struct BoardDirtyProperties {
     if (props.BoardDirtyPropertyUrl) {
         [descriptionFields addObject:[@"_url = " stringByAppendingFormat:@"%@", _url]];
     }
+
     return [NSString stringWithFormat:@"Board = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(BoardBuilder *builder))block
@@ -335,6 +337,7 @@ struct BoardDirtyProperties {
             [dict setObject:[NSNull null] forKey:@"url"];
         }
     }
+
     return dict;
 }
 - (BOOL)isContributorsSet
@@ -390,6 +393,7 @@ struct BoardDirtyProperties {
     _image = [aDecoder decodeObjectOfClass:[Image class] forKey:@"image"];
     _name = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"name"];
     _url = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"url"];
+
     _boardDirtyProperties.BoardDirtyPropertyContributors = [aDecoder decodeIntForKey:@"contributors_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyCounts = [aDecoder decodeIntForKey:@"counts_dirty_property"] & 0x1;
     _boardDirtyProperties.BoardDirtyPropertyCreatedAt = [aDecoder decodeIntForKey:@"created_at_dirty_property"] & 0x1;

--- a/Examples/Cocoa/Sources/Objective_C/Everything.m
+++ b/Examples/Cocoa/Sources/Objective_C/Everything.m
@@ -1174,7 +1174,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     _stringProp = builder.stringProp;
     _type = builder.type;
     _uriProp = builder.uriProp;
-    _everythingBooleanProperties.EverythingBooleanBooleanProp = builder.booleanProp;
+    _everythingBooleanProperties.EverythingBooleanBooleanProp = builder.booleanProp == 1;
     _everythingDirtyProperties = builder.everythingDirtyProperties;
     if ([self class] == [Everything class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(initType) }];

--- a/Examples/Cocoa/Sources/Objective_C/Everything.m
+++ b/Examples/Cocoa/Sources/Objective_C/Everything.m
@@ -610,8 +610,13 @@ struct EverythingDirtyProperties {
     unsigned int EverythingDirtyPropertyUriProp:1;
 };
 
+struct EverythingBooleanProperties {
+    unsigned int EverythingBooleanBooleanProp:1;
+};
+
 @interface Everything ()
 @property (nonatomic, assign, readwrite) struct EverythingDirtyProperties everythingDirtyProperties;
+@property (nonatomic, assign, readwrite) struct EverythingBooleanProperties everythingBooleanProperties;
 @end
 
 @interface EverythingBuilder ()
@@ -686,7 +691,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
             __unsafe_unretained id value = modelDictionary[@"boolean_prop"]; // Collection will retain.
             if (value != nil) {
                 if (value != (id)kCFNull) {
-                    self->_booleanProp = [value boolValue];
+                    self->_everythingBooleanProperties.EverythingBooleanBooleanProp = [value boolValue] && 0x1;
                 }
                 self->_everythingDirtyProperties.EverythingDirtyPropertyBooleanProp = 1;
             }
@@ -1004,7 +1009,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
                         self->_polymorphicProp = [EverythingPolymorphicProp  objectWithString:[value copy]];
                     }
                     if ([value isKindOfClass:[NSNumber class]] && strcmp([value objCType], @encode(BOOL)) == 0) {
-                        self->_polymorphicProp = [EverythingPolymorphicProp  objectWithBoolean:[value boolValue]];
+                        self->_polymorphicProp = [EverythingPolymorphicProp  objectWithBoolean:[value boolValue] && 0x1];
                     }
                     if ([value isKindOfClass:[NSNumber class]] && (strcmp([value objCType], @encode(int)) == 0 ||
                     strcmp([value objCType], @encode(unsigned int)) == 0 ||
@@ -1142,7 +1147,6 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
         return self;
     }
     _arrayProp = builder.arrayProp;
-    _booleanProp = builder.booleanProp;
     _dateProp = builder.dateProp;
     _intEnum = builder.intEnum;
     _intProp = builder.intProp;
@@ -1170,6 +1174,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     _stringProp = builder.stringProp;
     _type = builder.type;
     _uriProp = builder.uriProp;
+    _everythingBooleanProperties.EverythingBooleanBooleanProp = builder.booleanProp;
     _everythingDirtyProperties = builder.everythingDirtyProperties;
     if ([self class] == [Everything class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(initType) }];
@@ -1184,9 +1189,6 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     struct EverythingDirtyProperties props = _everythingDirtyProperties;
     if (props.EverythingDirtyPropertyArrayProp) {
         [descriptionFields addObject:[@"_arrayProp = " stringByAppendingFormat:@"%@", _arrayProp]];
-    }
-    if (props.EverythingDirtyPropertyBooleanProp) {
-        [descriptionFields addObject:[@"_booleanProp = " stringByAppendingFormat:@"%@", @(_booleanProp)]];
     }
     if (props.EverythingDirtyPropertyDateProp) {
         [descriptionFields addObject:[@"_dateProp = " stringByAppendingFormat:@"%@", _dateProp]];
@@ -1269,6 +1271,9 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     if (props.EverythingDirtyPropertyUriProp) {
         [descriptionFields addObject:[@"_uriProp = " stringByAppendingFormat:@"%@", _uriProp]];
     }
+    if (props.EverythingDirtyPropertyBooleanProp) {
+        [descriptionFields addObject:[@"_everythingBooleanProperties.EverythingBooleanBooleanProp = " stringByAppendingFormat:@"%@", @(_everythingBooleanProperties.EverythingBooleanBooleanProp)]];
+    }
     return [NSString stringWithFormat:@"Everything = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(EverythingBuilder *builder))block
@@ -1296,7 +1301,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
         (_intProp == anObject.intProp) &&
         (_intEnum == anObject.intEnum) &&
         (_stringEnum == anObject.stringEnum) &&
-        (_booleanProp == anObject.booleanProp) &&
+        (_everythingBooleanProperties.EverythingBooleanBooleanProp == anObject.booleanProp) &&
         (_arrayProp == anObject.arrayProp || [_arrayProp isEqualToArray:anObject.arrayProp]) &&
         (_listWithListAndOtherModelValues == anObject.listWithListAndOtherModelValues || [_listWithListAndOtherModelValues isEqualToArray:anObject.listWithListAndOtherModelValues]) &&
         (_listWithMapAndOtherModelValues == anObject.listWithMapAndOtherModelValues || [_listWithMapAndOtherModelValues isEqualToArray:anObject.listWithMapAndOtherModelValues]) &&
@@ -1328,7 +1333,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     NSUInteger subhashes[] = {
         17,
         [_arrayProp hash],
-        (_booleanProp ? 1231 : 1237),
+        (_everythingBooleanProperties.EverythingBooleanBooleanProp ? 1231 : 1237),
         [_dateProp hash],
         (NSUInteger)_intEnum,
         (NSUInteger)_intProp,
@@ -1379,9 +1384,6 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
         } else {
             [dict setObject:[NSNull null] forKey:@"array_prop"];
         }
-    }
-    if (_everythingDirtyProperties.EverythingDirtyPropertyBooleanProp) {
-        [dict setObject:@(_booleanProp) forKey: @"boolean_prop"];
     }
     if (_everythingDirtyProperties.EverythingDirtyPropertyDateProp) {
         if (_dateProp != nil) {
@@ -1647,6 +1649,9 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
             [dict setObject:[NSNull null] forKey:@"uri_prop"];
         }
     }
+    if (_everythingDirtyProperties.EverythingDirtyPropertyBooleanProp) {
+        [dict setObject:@(_everythingBooleanProperties.EverythingBooleanBooleanProp) forKey: @"boolean_prop"];
+    }
     return dict;
 }
 - (BOOL)isArrayPropSet
@@ -1765,6 +1770,10 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
 {
     return _everythingDirtyProperties.EverythingDirtyPropertyUriProp == 1;
 }
+- (BOOL)booleanProp
+{
+    return _everythingBooleanProperties.EverythingBooleanBooleanProp;
+}
 #pragma mark - NSCopying
 - (id)copyWithZone:(NSZone *)zone
 {
@@ -1781,7 +1790,6 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
         return self;
     }
     _arrayProp = [aDecoder decodeObjectOfClass:[NSArray class] forKey:@"array_prop"];
-    _booleanProp = [aDecoder decodeBoolForKey:@"boolean_prop"];
     _dateProp = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"date_prop"];
     _intEnum = [aDecoder decodeIntegerForKey:@"int_enum"];
     _intProp = [aDecoder decodeIntegerForKey:@"int_prop"];
@@ -1809,6 +1817,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     _stringProp = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"string_prop"];
     _type = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"type"];
     _uriProp = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"uri_prop"];
+    _everythingBooleanProperties.EverythingBooleanBooleanProp = [aDecoder decodeBoolForKey:@"boolean_prop"];
     _everythingDirtyProperties.EverythingDirtyPropertyArrayProp = [aDecoder decodeIntForKey:@"array_prop_dirty_property"] & 0x1;
     _everythingDirtyProperties.EverythingDirtyPropertyBooleanProp = [aDecoder decodeIntForKey:@"boolean_prop_dirty_property"] & 0x1;
     _everythingDirtyProperties.EverythingDirtyPropertyDateProp = [aDecoder decodeIntForKey:@"date_prop_dirty_property"] & 0x1;

--- a/Examples/Cocoa/Sources/Objective_C/Everything.m
+++ b/Examples/Cocoa/Sources/Objective_C/Everything.m
@@ -1817,7 +1817,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     _stringProp = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"string_prop"];
     _type = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"type"];
     _uriProp = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"uri_prop"];
-    _everythingBooleanProperties.EverythingBooleanBooleanProp = [aDecoder decodeBoolForKey:@"boolean_prop"];
+    _everythingBooleanProperties.EverythingBooleanBooleanProp = [aDecoder decodeBoolForKey:@"boolean_prop"] & 0x1;
     _everythingDirtyProperties.EverythingDirtyPropertyArrayProp = [aDecoder decodeIntForKey:@"array_prop_dirty_property"] & 0x1;
     _everythingDirtyProperties.EverythingDirtyPropertyBooleanProp = [aDecoder decodeIntForKey:@"boolean_prop_dirty_property"] & 0x1;
     _everythingDirtyProperties.EverythingDirtyPropertyDateProp = [aDecoder decodeIntForKey:@"date_prop_dirty_property"] & 0x1;

--- a/Examples/Cocoa/Sources/Objective_C/Image.m
+++ b/Examples/Cocoa/Sources/Objective_C/Image.m
@@ -94,6 +94,7 @@ struct ImageDirtyProperties {
     _height = builder.height;
     _url = builder.url;
     _width = builder.width;
+
     _imageDirtyProperties = builder.imageDirtyProperties;
     if ([self class] == [Image class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(initType) }];
@@ -115,6 +116,7 @@ struct ImageDirtyProperties {
     if (props.ImageDirtyPropertyWidth) {
         [descriptionFields addObject:[@"_width = " stringByAppendingFormat:@"%@", @(_width)]];
     }
+
     return [NSString stringWithFormat:@"Image = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(ImageBuilder *builder))block
@@ -180,6 +182,7 @@ struct ImageDirtyProperties {
     if (_imageDirtyProperties.ImageDirtyPropertyWidth) {
         [dict setObject:@(_width) forKey: @"width"];
     }
+
     return dict;
 }
 - (BOOL)isHeightSet
@@ -212,6 +215,7 @@ struct ImageDirtyProperties {
     _height = [aDecoder decodeIntegerForKey:@"height"];
     _url = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"url"];
     _width = [aDecoder decodeIntegerForKey:@"width"];
+
     _imageDirtyProperties.ImageDirtyPropertyHeight = [aDecoder decodeIntForKey:@"height_dirty_property"] & 0x1;
     _imageDirtyProperties.ImageDirtyPropertyUrl = [aDecoder decodeIntForKey:@"url_dirty_property"] & 0x1;
     _imageDirtyProperties.ImageDirtyPropertyWidth = [aDecoder decodeIntForKey:@"width_dirty_property"] & 0x1;

--- a/Examples/Cocoa/Sources/Objective_C/Model.m
+++ b/Examples/Cocoa/Sources/Objective_C/Model.m
@@ -72,6 +72,7 @@ struct ModelDirtyProperties {
         return self;
     }
     _identifier = builder.identifier;
+
     _modelDirtyProperties = builder.modelDirtyProperties;
     if ([self class] == [Model class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(initType) }];
@@ -87,6 +88,7 @@ struct ModelDirtyProperties {
     if (props.ModelDirtyPropertyIdentifier) {
         [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", _identifier]];
     }
+
     return [NSString stringWithFormat:@"Model = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(ModelBuilder *builder))block
@@ -142,6 +144,7 @@ struct ModelDirtyProperties {
             [dict setObject:[NSNull null] forKey:@"id"];
         }
     }
+
     return dict;
 }
 - (BOOL)isIdentifierSet
@@ -164,6 +167,7 @@ struct ModelDirtyProperties {
         return self;
     }
     _identifier = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"id"];
+
     _modelDirtyProperties.ModelDirtyPropertyIdentifier = [aDecoder decodeIntForKey:@"id_dirty_property"] & 0x1;
     if ([self class] == [Model class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(PlankModelInitTypeDefault) }];

--- a/Examples/Cocoa/Sources/Objective_C/Pin.m
+++ b/Examples/Cocoa/Sources/Objective_C/Pin.m
@@ -411,6 +411,7 @@ struct PinDirtyProperties {
     _tags = builder.tags;
     _url = builder.url;
     _visualSearchAttrs = builder.visualSearchAttrs;
+
     _pinDirtyProperties = builder.pinDirtyProperties;
     if ([self class] == [Pin class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(initType) }];
@@ -474,6 +475,7 @@ struct PinDirtyProperties {
     if (props.PinDirtyPropertyVisualSearchAttrs) {
         [descriptionFields addObject:[@"_visualSearchAttrs = " stringByAppendingFormat:@"%@", _visualSearchAttrs]];
     }
+
     return [NSString stringWithFormat:@"Pin = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(PinBuilder *builder))block
@@ -691,6 +693,7 @@ struct PinDirtyProperties {
             [dict setObject:[NSNull null] forKey:@"visual_search_attrs"];
         }
     }
+
     return dict;
 }
 - (BOOL)isAttributionSet
@@ -793,6 +796,7 @@ struct PinDirtyProperties {
     _tags = [aDecoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSArray class], [NSDictionary class]]] forKey:@"tags"];
     _url = [aDecoder decodeObjectOfClass:[NSURL class] forKey:@"url"];
     _visualSearchAttrs = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"visual_search_attrs"];
+
     _pinDirtyProperties.PinDirtyPropertyAttribution = [aDecoder decodeIntForKey:@"attribution_dirty_property"] & 0x1;
     _pinDirtyProperties.PinDirtyPropertyAttributionObjects = [aDecoder decodeIntForKey:@"attribution_objects_dirty_property"] & 0x1;
     _pinDirtyProperties.PinDirtyPropertyBoard = [aDecoder decodeIntForKey:@"board_dirty_property"] & 0x1;

--- a/Examples/Cocoa/Sources/Objective_C/User.m
+++ b/Examples/Cocoa/Sources/Objective_C/User.m
@@ -201,6 +201,7 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
     _lastName = builder.lastName;
     _type = builder.type;
     _username = builder.username;
+
     _userDirtyProperties = builder.userDirtyProperties;
     if ([self class] == [User class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(initType) }];
@@ -243,6 +244,7 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
     if (props.UserDirtyPropertyUsername) {
         [descriptionFields addObject:[@"_username = " stringByAppendingFormat:@"%@", _username]];
     }
+
     return [NSString stringWithFormat:@"User = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(UserBuilder *builder))block
@@ -380,6 +382,7 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
             [dict setObject:[NSNull null] forKey:@"username"];
         }
     }
+
     return dict;
 }
 - (BOOL)isBioSet
@@ -447,6 +450,7 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
     _lastName = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"last_name"];
     _type = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"type"];
     _username = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"username"];
+
     _userDirtyProperties.UserDirtyPropertyBio = [aDecoder decodeIntForKey:@"bio_dirty_property"] & 0x1;
     _userDirtyProperties.UserDirtyPropertyCounts = [aDecoder decodeIntForKey:@"counts_dirty_property"] & 0x1;
     _userDirtyProperties.UserDirtyPropertyCreatedAt = [aDecoder decodeIntForKey:@"created_at_dirty_property"] & 0x1;

--- a/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
+++ b/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
@@ -105,6 +105,7 @@ struct VariableSubtitutionDirtyProperties {
     _copyProp = builder.copyProp;
     _mutableCopyProp = builder.mutableCopyProp;
     _newProp = builder.newProp;
+
     _variableSubtitutionDirtyProperties = builder.variableSubtitutionDirtyProperties;
     if ([self class] == [VariableSubtitution class]) {
         [[NSNotificationCenter defaultCenter] postNotificationName:kPlankDidInitializeNotification object:self userInfo:@{ kPlankInitTypeKey : @(initType) }];
@@ -129,6 +130,7 @@ struct VariableSubtitutionDirtyProperties {
     if (props.VariableSubtitutionDirtyPropertyNewProp) {
         [descriptionFields addObject:[@"_newProp = " stringByAppendingFormat:@"%@", @(_newProp)]];
     }
+
     return [NSString stringWithFormat:@"VariableSubtitution = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(VariableSubtitutionBuilder *builder))block
@@ -195,6 +197,7 @@ struct VariableSubtitutionDirtyProperties {
     if (_variableSubtitutionDirtyProperties.VariableSubtitutionDirtyPropertyNewProp) {
         [dict setObject:@(_newProp) forKey: @"new_prop"];
     }
+
     return dict;
 }
 - (BOOL)isAllocPropSet
@@ -232,6 +235,7 @@ struct VariableSubtitutionDirtyProperties {
     _copyProp = [aDecoder decodeIntegerForKey:@"copy_prop"];
     _mutableCopyProp = [aDecoder decodeIntegerForKey:@"mutable_copy_prop"];
     _newProp = [aDecoder decodeIntegerForKey:@"new_prop"];
+
     _variableSubtitutionDirtyProperties.VariableSubtitutionDirtyPropertyAllocProp = [aDecoder decodeIntForKey:@"alloc_prop_dirty_property"] & 0x1;
     _variableSubtitutionDirtyProperties.VariableSubtitutionDirtyPropertyCopyProp = [aDecoder decodeIntForKey:@"copy_prop_dirty_property"] & 0x1;
     _variableSubtitutionDirtyProperties.VariableSubtitutionDirtyPropertyMutableCopyProp = [aDecoder decodeIntForKey:@"mutable_copy_prop_dirty_property"] & 0x1;

--- a/Examples/Cocoa/Sources/Objective_C/include/Everything.h
+++ b/Examples/Cocoa/Sources/Objective_C/include/Everything.h
@@ -170,6 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isStringPropSet;
 - (BOOL)isTypeSet;
 - (BOOL)isUriPropSet;
+- (BOOL)booleanProp;
 @end
 
 @interface EverythingBuilder : NSObject

--- a/Sources/Core/ObjCModelRenderer.swift
+++ b/Sources/Core/ObjCModelRenderer.swift
@@ -23,8 +23,16 @@ public struct ObjCModelRenderer: ObjCFileRenderer {
         return "\(className)DirtyProperties"
     }
 
+    var booleanPropertiesStructName: String {
+        return "\(className)BooleanProperties"
+    }
+
     var dirtyPropertiesIVarName: String {
         return "\(Languages.objectiveC.snakeCaseToPropertyName(rootSchema.name))DirtyProperties"
+    }
+
+    var booleanPropertiesIVarName: String {
+        return "\(Languages.objectiveC.snakeCaseToPropertyName(rootSchema.name))BooleanProperties"
     }
 
     // MARK: Model methods
@@ -119,8 +127,36 @@ public struct ObjCModelRenderer: ObjCFileRenderer {
         }
     }
 
+    func renderBooleanPropertyAccessorMethods() -> [ObjCIR.Method] {
+        return properties.flatMap { (param, prop) -> [ObjCIR.Method] in
+            switch prop.schema {
+            case .boolean:
+                return [ObjCIR.method("- (BOOL)\(Languages.objectiveC.snakeCaseToPropertyName(param))") { ["return _\(self.booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: param, className: self.className));"] }]
+            default:
+                return []
+            }
+        }
+    }
+
     func renderRoots() -> [ObjCIR.Root] {
         let properties: [(Parameter, SchemaObjectProperty)] = rootSchema.properties.map { $0 } // Convert [String:Schema] -> [(String, Schema)]
+
+        let booleanProperties = rootSchema.properties.filter { (arg) -> Bool in
+            let (_, schema) = arg
+            switch schema.schema {
+            case .boolean:
+                return true
+            default:
+                return false
+            }
+        }
+
+        let booleanStructDeclaration = !booleanProperties.isEmpty ? [ObjCIR.Root.structDecl(name: self.booleanPropertiesStructName,
+                                                                                            fields: booleanProperties.keys.map { "unsigned int \(booleanPropertyOption(propertyName: $0, className: self.className)):1;" })] : []
+
+        let booleanIvarDeclaration: [SimpleProperty] = !booleanProperties.isEmpty ? [(self.booleanPropertiesIVarName, "struct \(self.booleanPropertiesStructName)",
+                                                                                      SchemaObjectProperty(schema: .integer, nullability: nil),
+                                                                                      .readwrite)] : []
 
         let protocols: [String: [ObjCIR.Method]] = [
             "NSSecureCoding": [self.renderSupportsSecureCoding(), self.renderInitWithCoder(), self.renderEncodeWithCoder()],
@@ -183,61 +219,63 @@ public struct ObjCModelRenderer: ObjCFileRenderer {
                 myName: self.className,
                 parentName: parentName
             ),
-        ] + adtRoots + enumRoots + [
-            ObjCIR.Root.structDecl(name: self.dirtyPropertyOptionName,
-                                   fields: rootSchema.properties.keys
-                                       .map { "unsigned int \(dirtyPropertyOption(propertyName: $0, className: self.className)):1;" }),
-            ObjCIR.Root.category(className: self.className,
-                                 categoryName: nil,
-                                 methods: [],
-                                 properties: [(self.dirtyPropertiesIVarName, "struct \(self.dirtyPropertyOptionName)",
-                                               SchemaObjectProperty(schema: .integer, nullability: nil),
-                                               .readwrite)]),
-            ObjCIR.Root.category(className: self.builderClassName,
-                                 categoryName: nil,
-                                 methods: [],
-                                 properties: [(self.dirtyPropertiesIVarName, "struct \(self.dirtyPropertyOptionName)",
-                                               SchemaObjectProperty(schema: .integer, nullability: nil),
-                                               .readwrite)]),
-        ] + renderStringEnumerationMethods().map { ObjCIR.Root.function($0) } + [
-            ObjCIR.Root.macro("NS_ASSUME_NONNULL_BEGIN"),
-            ObjCIR.Root.classDecl(
-                name: self.className,
-                extends: parentName,
-                methods: [
-                    (self.isBaseClass ? .publicM : .privateM, self.renderClassName()),
-                    (self.isBaseClass ? .publicM : .privateM, self.renderPolymorphicTypeIdentifier()),
-                    (self.isBaseClass ? .publicM : .privateM, self.renderModelObjectWithDictionary()),
-                    (.privateM, self.renderDesignatedInit()),
-                    (self.isBaseClass ? .publicM : .privateM, self.renderInitWithModelDictionary()),
-                    (.publicM, self.renderInitWithBuilder()),
-                    (self.isBaseClass ? .publicM : .privateM, self.renderInitWithBuilderWithInitType()),
-                    (.privateM, self.renderDebugDescription()),
-                    (.publicM, self.renderCopyWithBlock()),
-                    (.privateM, self.renderIsEqual()),
-                    (.publicM, self.renderIsEqualToClass()),
-                    (.privateM, self.renderHash()),
-                    (.publicM, self.renderMergeWithModel()),
-                    (.publicM, self.renderMergeWithModelWithInitType()),
-                    (self.isBaseClass ? .publicM : .privateM, self.renderGenerateDictionary()),
-                ] + self.renderIsSetMethods().map { (.publicM, $0) },
-                properties: properties.map { param, prop in (param, typeFromSchema(param, prop), prop, .readonly) }.sorted { $0.0 < $1.0 },
-                protocols: protocols
-            ),
-            ObjCIR.Root.classDecl(
-                name: self.builderClassName,
-                extends: resolveClassName(self.parentDescriptor).map { "\($0)Builder" },
-                methods: [
-                    (.publicM, self.renderBuilderInitWithModel()),
-                    (.publicM, ObjCIR.method("- (\(self.className) *)build") {
-                        ["return [[\(self.className) alloc] initWithBuilder:self];"]
-                    }),
-                    (.publicM, self.renderBuilderMergeWithModel()),
-                ] + self.renderBuilderPropertySetters().map { (.privateM, $0) },
-                properties: properties.map { param, prop in (param, typeFromSchema(param, prop), prop, .readwrite) },
-                protocols: [:]
-            ),
-            ObjCIR.Root.macro("NS_ASSUME_NONNULL_END"),
-        ]
+        ] + adtRoots + enumRoots +
+            [ObjCIR.Root.structDecl(name: self.dirtyPropertyOptionName,
+                                    fields: rootSchema.properties.keys
+                                        .map { "unsigned int \(dirtyPropertyOption(propertyName: $0, className: self.className)):1;" })] +
+            booleanStructDeclaration +
+            [
+                ObjCIR.Root.category(className: self.className,
+                                     categoryName: nil,
+                                     methods: [],
+                                     properties: [(self.dirtyPropertiesIVarName, "struct \(self.dirtyPropertyOptionName)",
+                                                   SchemaObjectProperty(schema: .integer, nullability: nil),
+                                                   .readwrite)] + booleanIvarDeclaration),
+                ObjCIR.Root.category(className: self.builderClassName,
+                                     categoryName: nil,
+                                     methods: [],
+                                     properties: [(self.dirtyPropertiesIVarName, "struct \(self.dirtyPropertyOptionName)",
+                                                   SchemaObjectProperty(schema: .integer, nullability: nil),
+                                                   .readwrite)]),
+            ] + renderStringEnumerationMethods().map { ObjCIR.Root.function($0) } + [
+                ObjCIR.Root.macro("NS_ASSUME_NONNULL_BEGIN"),
+                ObjCIR.Root.classDecl(
+                    name: self.className,
+                    extends: parentName,
+                    methods: [
+                        (self.isBaseClass ? .publicM : .privateM, self.renderClassName()),
+                        (self.isBaseClass ? .publicM : .privateM, self.renderPolymorphicTypeIdentifier()),
+                        (self.isBaseClass ? .publicM : .privateM, self.renderModelObjectWithDictionary()),
+                        (.privateM, self.renderDesignatedInit()),
+                        (self.isBaseClass ? .publicM : .privateM, self.renderInitWithModelDictionary()),
+                        (.publicM, self.renderInitWithBuilder()),
+                        (self.isBaseClass ? .publicM : .privateM, self.renderInitWithBuilderWithInitType()),
+                        (.privateM, self.renderDebugDescription()),
+                        (.publicM, self.renderCopyWithBlock()),
+                        (.privateM, self.renderIsEqual()),
+                        (.publicM, self.renderIsEqualToClass(self.booleanPropertiesIVarName)),
+                        (.privateM, self.renderHash(self.booleanPropertiesIVarName)),
+                        (.publicM, self.renderMergeWithModel()),
+                        (.publicM, self.renderMergeWithModelWithInitType()),
+                        (self.isBaseClass ? .publicM : .privateM, self.renderGenerateDictionary()),
+                    ] + self.renderIsSetMethods().map { (.publicM, $0) } + self.renderBooleanPropertyAccessorMethods().map { (.publicM, $0) },
+                    properties: properties.map { param, prop in (param, typeFromSchema(param, prop), prop, .readonly) }.sorted { $0.0 < $1.0 },
+                    protocols: protocols
+                ),
+                ObjCIR.Root.classDecl(
+                    name: self.builderClassName,
+                    extends: resolveClassName(self.parentDescriptor).map { "\($0)Builder" },
+                    methods: [
+                        (.publicM, self.renderBuilderInitWithModel()),
+                        (.publicM, ObjCIR.method("- (\(self.className) *)build") {
+                            ["return [[\(self.className) alloc] initWithBuilder:self];"]
+                        }),
+                        (.publicM, self.renderBuilderMergeWithModel()),
+                    ] + self.renderBuilderPropertySetters().map { (.privateM, $0) },
+                    properties: properties.map { param, prop in (param, typeFromSchema(param, prop), prop, .readwrite) },
+                    protocols: [:]
+                ),
+                ObjCIR.Root.macro("NS_ASSUME_NONNULL_END"),
+            ]
     }
 }

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -52,14 +52,22 @@ typealias Parameter = String
 typealias TypeName = String
 typealias SimpleProperty = (Parameter, TypeName, SchemaObjectProperty, ObjCMutabilityType)
 
-func dirtyPropertyOption(propertyName aPropertyName: String, className: String) -> String {
+func propertyOption(propertyName aPropertyName: String, className: String, variant: String) -> String {
     guard !className.isEmpty, !aPropertyName.isEmpty else {
-        fatalError("Invalid class name or property name passed to dirtyPropertyOption(propertyName:className)")
+        fatalError("Invalid class name or property name passed propertyOption(propertyName:className:variant)")
     }
     let propertyName = Languages.objectiveC.snakeCaseToPropertyName(aPropertyName)
     let capitalizedFirstLetter = String(propertyName[propertyName.startIndex]).uppercased()
     let capitalizedPropertyName = capitalizedFirstLetter + String(propertyName.dropFirst())
-    return className + "DirtyProperty" + capitalizedPropertyName
+    return className + variant + capitalizedPropertyName
+}
+
+func dirtyPropertyOption(propertyName aPropertyName: String, className: String) -> String {
+    return propertyOption(propertyName: aPropertyName, className: className, variant: "DirtyProperty")
+}
+
+func booleanPropertyOption(propertyName aPropertyName: String, className: String) -> String {
+    return propertyOption(propertyName: aPropertyName, className: className, variant: "Boolean")
 }
 
 func enumFromStringMethodName(propertyName: String, className: String) -> String {

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -46,9 +46,26 @@ extension ObjCModelRenderer {
                 "NSParameterAssert(builder);",
                 self.isBaseClass ? ObjCIR.ifStmt("!(self = [super init])") { ["return self;"] } :
                     ObjCIR.ifStmt("!(self = [super initWithBuilder:builder initType:initType])") { ["return self;"] },
-                self.properties.map { name, _ in
+                self.properties.filter { (_, schema) -> Bool in
+                    switch schema.schema {
+                    case .boolean:
+                        return false
+                    default:
+                        return true
+                    }
+                    }.map { name, _ in
                     "_\(Languages.objectiveC.snakeCaseToPropertyName(name)) = builder.\(Languages.objectiveC.snakeCaseToPropertyName(name));"
                 }.joined(separator: "\n"),
+                self.properties.filter { (_, schema) -> Bool in
+                    switch schema.schema {
+                    case .boolean:
+                        return true
+                    default:
+                        return false
+                    }
+                    }.map { name, _ in
+                        "_\(self.booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: name, className: self.className)) = builder.\(Languages.objectiveC.snakeCaseToPropertyName(name));"
+                    }.joined(separator: "\n"),
                 "_\(self.dirtyPropertiesIVarName) = builder.\(self.dirtyPropertiesIVarName);",
                 ObjCIR.ifStmt("[self class] == [\(self.className) class]") {
                     [renderPostInitNotification(type: "initType")]
@@ -144,7 +161,7 @@ extension ObjCModelRenderer {
             case .integer:
                 return ["\(propertyToAssign) = [\(rawObjectName) integerValue];"]
             case .boolean:
-                return ["\(propertyToAssign) = [\(rawObjectName) boolValue];"]
+                return ["\(propertyToAssign) = [\(rawObjectName) boolValue] && 0x1;"]
             case .string(format: .some(.uri)):
                 return ["\(propertyToAssign) = [NSURL URLWithString:\(rawObjectName)];"]
             case .string(format: .some(.dateTime)):
@@ -268,7 +285,12 @@ extension ObjCModelRenderer {
                         "__unsafe_unretained id value = modelDictionary[\(name.objcLiteral())]; // Collection will retain.",
                         ObjCIR.ifStmt("value != nil") { [
                             ObjCIR.ifStmt("value != (id)kCFNull") {
-                                renderPropertyInit("self->_\(Languages.objectiveC.snakeCaseToPropertyName(name))", "value", schema: prop.schema, firstName: name)
+                                switch prop.schema {
+                                case .boolean:
+                                    return renderPropertyInit("self->_\(booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: name, className: className))", "value", schema: prop.schema, firstName: name)
+                                default:
+                                    return renderPropertyInit("self->_\(Languages.objectiveC.snakeCaseToPropertyName(name))", "value", schema: prop.schema, firstName: name)
+                                }
                             },
                             "self->_\(dirtyPropertiesIVarName).\(dirtyPropertyOption(propertyName: name, className: className)) = 1;",
                         ] },

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -53,7 +53,7 @@ extension ObjCModelRenderer {
                     default:
                         return true
                     }
-                    }.map { name, _ in
+                }.map { name, _ in
                     "_\(Languages.objectiveC.snakeCaseToPropertyName(name)) = builder.\(Languages.objectiveC.snakeCaseToPropertyName(name));"
                 }.joined(separator: "\n"),
                 self.properties.filter { (_, schema) -> Bool in
@@ -63,9 +63,9 @@ extension ObjCModelRenderer {
                     default:
                         return false
                     }
-                    }.map { name, _ in
-                        "_\(self.booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: name, className: self.className)) = builder.\(Languages.objectiveC.snakeCaseToPropertyName(name)) == 1;"
-                    }.joined(separator: "\n"),
+                }.map { name, _ in
+                    "_\(self.booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: name, className: self.className)) = builder.\(Languages.objectiveC.snakeCaseToPropertyName(name)) == 1;"
+                }.joined(separator: "\n"),
                 "_\(self.dirtyPropertiesIVarName) = builder.\(self.dirtyPropertiesIVarName);",
                 ObjCIR.ifStmt("[self class] == [\(self.className) class]") {
                     [renderPostInitNotification(type: "initType")]

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -64,7 +64,7 @@ extension ObjCModelRenderer {
                         return false
                     }
                     }.map { name, _ in
-                        "_\(self.booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: name, className: self.className)) = builder.\(Languages.objectiveC.snakeCaseToPropertyName(name));"
+                        "_\(self.booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: name, className: self.className)) = builder.\(Languages.objectiveC.snakeCaseToPropertyName(name)) == 1;"
                     }.joined(separator: "\n"),
                 "_\(self.dirtyPropertiesIVarName) = builder.\(self.dirtyPropertiesIVarName);",
                 ObjCIR.ifStmt("[self class] == [\(self.className) class]") {

--- a/Sources/Core/ObjectiveCNSCodingExtension.swift
+++ b/Sources/Core/ObjectiveCNSCodingExtension.swift
@@ -33,7 +33,7 @@ extension ObjCModelRenderer {
                     }
                 }.map { (arg: (Parameter, SchemaObjectProperty)) -> String in
                     let (param, _) = arg
-                    return "_\(booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: param, className: self.className)) = [aDecoder decodeBoolForKey:\(param.objcLiteral())];"
+                    return "_\(booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: param, className: self.className)) = [aDecoder decodeBoolForKey:\(param.objcLiteral())] & 0x1;"
                 }.joined(separator: "\n"),
                 self.properties.map { (param, _) -> String in
                     "_\(dirtyPropertiesIVarName).\(dirtyPropertyOption(propertyName: param, className: self.className)) = [aDecoder decodeIntForKey:\((param + "_dirty_property").objcLiteral())] & 0x1;"

--- a/Sources/Core/ObjectiveCNSCodingExtension.swift
+++ b/Sources/Core/ObjectiveCNSCodingExtension.swift
@@ -14,9 +14,27 @@ extension ObjCModelRenderer {
             [
                 self.isBaseClass ? ObjCIR.ifStmt("!(self = [super init])") { ["return self;"] } :
                     "if (!(self = [super initWithCoder:aDecoder])) { return self; }",
-                self.properties.map { ($0.0, $0.1.schema) }
+                self.properties.filter { (_, schema) -> Bool in
+                    switch schema.schema {
+                    case .boolean:
+                        return false
+                    default:
+                        return true
+                    }
+                }.map { ($0.0, $0.1.schema) }
                     .map(decodeStatement)
                     .joined(separator: "\n"),
+                self.properties.filter { (_, schema) -> Bool in
+                    switch schema.schema {
+                    case .boolean:
+                        return true
+                    default:
+                        return false
+                    }
+                }.map { (arg: (Parameter, SchemaObjectProperty)) -> String in
+                    let (param, _) = arg
+                    return "_\(booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: param, className: self.className)) = [aDecoder decodeBoolForKey:\(param.objcLiteral())];"
+                }.joined(separator: "\n"),
                 self.properties.map { (param, _) -> String in
                     "_\(dirtyPropertiesIVarName).\(dirtyPropertyOption(propertyName: param, className: self.className)) = [aDecoder decodeIntForKey:\((param + "_dirty_property").objcLiteral())] & 0x1;"
                 }.joined(separator: "\n"),

--- a/plank.xcodeproj/xcshareddata/xcschemes/plank.xcscheme
+++ b/plank.xcodeproj/xcshareddata/xcschemes/plank.xcscheme
@@ -62,6 +62,12 @@
             ReferencedContainer = "container:plank.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "/Users/gbolsinga/code/plank/Examples/PDK/everything.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/plank.xcodeproj/xcshareddata/xcschemes/plank.xcscheme
+++ b/plank.xcodeproj/xcshareddata/xcschemes/plank.xcscheme
@@ -62,12 +62,6 @@
             ReferencedContainer = "container:plank.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "/Users/gbolsinga/code/plank/Examples/PDK/everything.json"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
This will make Pinterest models smaller in the heap, which is useful since they live for the life of the application. This changes only the model, not the short lived builders, to use bitfields. It requires special handling of boolean properites throughout the process.

In Pinterest, PIPin has 25 BOOLs (currently stored as 200 bytes, which will only take 4 bytes afterwards), & PIUser has 40 (currently stored as 320 bytes, and will take 8 bytes afterwards). There may be even more wins, simply by grouping all the BOOLs near each other. If the layout of a class is a pointer, followed by a BOOL, followed by a pointer, the 64 bit alignment of fields will cause that BOOL to actually be 8 bytes!