### PR TITLE
Add ability for custom annotations on Java models

### DIFF
--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -290,7 +290,8 @@ public class Everything {
         return this.arrayProp;
     }
 
-    public @NonNull Boolean getBooleanProp() {
+    @NonNull
+    public Boolean getBooleanProp() {
         return this.booleanProp == null ? Boolean.FALSE : this.booleanProp;
     }
 
@@ -302,7 +303,8 @@ public class Everything {
         return this.intEnum;
     }
 
-    public @NonNull Integer getIntProp() {
+    @NonNull
+    public Integer getIntProp() {
         return this.intProp == null ? 0 : this.intProp;
     }
 
@@ -358,7 +360,8 @@ public class Everything {
         return this.mapWithPrimitiveValues;
     }
 
-    public @NonNull Double getNumberProp() {
+    @NonNull
+    public Double getNumberProp() {
         return this.numberProp == null ? 0 : this.numberProp;
     }
 

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -89,7 +89,8 @@ public class Image {
         width);
     }
 
-    public @NonNull Integer getHeight() {
+    @NonNull
+    public Integer getHeight() {
         return this.height == null ? 0 : this.height;
     }
 
@@ -97,7 +98,8 @@ public class Image {
         return this.url;
     }
 
-    public @NonNull Integer getWidth() {
+    @NonNull
+    public Integer getWidth() {
         return this.width == null ? 0 : this.width;
     }
 

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -95,19 +95,23 @@ public class VariableSubtitution {
         newProp);
     }
 
-    public @NonNull Integer getAllocProp() {
+    @NonNull
+    public Integer getAllocProp() {
         return this.allocProp == null ? 0 : this.allocProp;
     }
 
-    public @NonNull Integer getCopyProp() {
+    @NonNull
+    public Integer getCopyProp() {
         return this.copyProp == null ? 0 : this.copyProp;
     }
 
-    public @NonNull Integer getMutableCopyProp() {
+    @NonNull
+    public Integer getMutableCopyProp() {
         return this.mutableCopyProp == null ? 0 : this.mutableCopyProp;
     }
 
-    public @NonNull Integer getNewProp() {
+    @NonNull
+    public Integer getNewProp() {
         return this.newProp == null ? 0 : this.newProp;
     }
 

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -20,6 +20,7 @@ public enum GenerationParameterType {
     case indent
     case packageName
     case javaNullabilityAnnotationType
+    case javaAnnotations
 }
 
 // Most of these are derived from https://www.binpress.com/tutorial/objective-c-reserved-keywords/43

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -18,6 +18,7 @@ enum FlagOptions: String {
     case objectiveCClassPrefix = "objc_class_prefix"
     case javaPackageName = "java_package_name"
     case javaNullabilityAnnotationType = "java_nullability_annotation_type"
+    case javaAnnotations = "java_annotations"
     case printDeps = "print_deps"
     case noRecursive = "no_recursive"
     case noRuntime = "no_runtime"
@@ -41,6 +42,7 @@ enum FlagOptions: String {
         case .version: return false
         case .javaPackageName: return true
         case .javaNullabilityAnnotationType: return true
+        case .javaAnnotations: return true
         }
     }
 }
@@ -64,6 +66,7 @@ extension FlagOptions: HelpCommandOutput {
             "    Java:",
             "    --\(FlagOptions.javaPackageName.rawValue) - The package name to associate with generated Java sources",
             "    --\(FlagOptions.javaNullabilityAnnotationType.rawValue) - The type of nullability annotations to use. Can be either \"android-support\" (default) or \"androidx\".",
+            "    --\(FlagOptions.javaAnnotations.rawValue) - Custom annotations to apply to the generated Java model.",
         ].joined(separator: "\n")
     }
 }
@@ -148,6 +151,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     let indent: String? = flags[.indent]
     let packageName: String? = flags[.javaPackageName]
     let javaNullabilityAnnotationType: String? = flags[.javaNullabilityAnnotationType]
+    let javaAnnotations: String? = flags[.javaAnnotations]
 
     let generationParameters: GenerationParameters = [
         (.recursive, recursive),
@@ -156,6 +160,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
         (.indent, indent),
         (.packageName, packageName),
         (.javaNullabilityAnnotationType, javaNullabilityAnnotationType),
+        (.javaAnnotations, javaAnnotations),
     ].reduce([:]) { (dict: GenerationParameters, tuple: (GenerationParameterType, String?)) in
         var mutableDict = dict
         if let val = tuple.1 {


### PR DESCRIPTION
A json file is passed in through the CLI which allows for applying annotations to the Java model's property variables, property getters, class definition, constructor, and other methods.

Example:

`plank --lang=java --java_annotations=my_model_annotations.json my_model.json`

**model.json**

```
{
    "id": "my_model.json",
    "title": "my_model",
    "description" : "Schema definition of MyModel",
    "$schema": "http://json-schema.org/schema#",
    "type": "object",
    "properties": {
        "color": { "type": "string" }, 
        "size": { "type": "string" }
    },
    "required": []
}
```

**my_model_annotations.json** passed in through `--java_annotations=my_model_annotations.java`
```
{
  "class": ["Entity"],
  "constructor": ["Generated"],
  "properties": {
    "color": {
      "variable": ["Color"],
      "getter": ["Color"]
    },
    "size": {
      "variable": ["Size"],
      "getter": ["Size"]
    }
  },
  "methods": {
    "mergeFrom": ["Override"]
  },
  "imports": [
    "com.test.package.anotations.Color",
    "com.test.package.anotations.Size"
  ]
}
```

Generated **MyModel.java**
```
@Entity
class MyModel {
	
	import com.test.package.anotations.Color;
	import com.test.package.anotations.Size;
	...
	
	@Generated
	private MyModel( ... ) { ... }
	
	@Color
	@SerializedName("color") private String color;
	
	@Size
	@SerializedName("size") private String size;
	
	@Color
	@Nullable
	public String getColor() { return color; }
	
	@Size
	@Nullable
	public String getSize() { return size; }
	
	@Override
	public MyModel mergeFrom(MyModel model) { ... }
}
```