### PR TITLE
Allow Java model deserialization to continue if a field cannot be parsed

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -412,31 +412,76 @@ public class Board {
                 String name = reader.nextName();
                 switch (name) {
                     case ("id"):
-                        builder.setUid(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setUid(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("contributors"):
-                        builder.setContributors(set_User_TypeAdapter.read(reader));
+                        try {
+                            builder.setContributors(set_User_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("counts"):
-                        builder.setCounts(map_String__Integer_TypeAdapter.read(reader));
+                        try {
+                            builder.setCounts(map_String__Integer_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("created_at"):
-                        builder.setCreatedAt(dateTypeAdapter.read(reader));
+                        try {
+                            builder.setCreatedAt(dateTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("creator"):
-                        builder.setCreator(map_String__String_TypeAdapter.read(reader));
+                        try {
+                            builder.setCreator(map_String__String_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("description"):
-                        builder.setDescription(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setDescription(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("image"):
-                        builder.setImage(imageTypeAdapter.read(reader));
+                        try {
+                            builder.setImage(imageTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("name"):
-                        builder.setName(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setName(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("url"):
-                        builder.setUrl(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setUrl(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     default:
                         reader.skipValue();

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -1093,91 +1093,236 @@ public class Everything {
                 String name = reader.nextName();
                 switch (name) {
                     case ("array_prop"):
-                        builder.setArrayProp(list_Object_TypeAdapter.read(reader));
+                        try {
+                            builder.setArrayProp(list_Object_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("boolean_prop"):
-                        builder.setBooleanProp(booleanTypeAdapter.read(reader));
+                        try {
+                            builder.setBooleanProp(booleanTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("date_prop"):
-                        builder.setDateProp(dateTypeAdapter.read(reader));
+                        try {
+                            builder.setDateProp(dateTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("int_enum"):
-                        builder.setIntEnum(everythingIntEnumTypeAdapter.read(reader));
+                        try {
+                            builder.setIntEnum(everythingIntEnumTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("int_prop"):
-                        builder.setIntProp(integerTypeAdapter.read(reader));
+                        try {
+                            builder.setIntProp(integerTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("list_polymorphic_values"):
-                        builder.setListPolymorphicValues(list_Object_TypeAdapter.read(reader));
+                        try {
+                            builder.setListPolymorphicValues(list_Object_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("list_with_list_and_other_model_values"):
-                        builder.setListWithListAndOtherModelValues(list_List_User__TypeAdapter.read(reader));
+                        try {
+                            builder.setListWithListAndOtherModelValues(list_List_User__TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("list_with_map_and_other_model_values"):
-                        builder.setListWithMapAndOtherModelValues(list_Map_String__User__TypeAdapter.read(reader));
+                        try {
+                            builder.setListWithMapAndOtherModelValues(list_Map_String__User__TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("list_with_object_values"):
-                        builder.setListWithObjectValues(list_String_TypeAdapter.read(reader));
+                        try {
+                            builder.setListWithObjectValues(list_String_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("list_with_other_model_values"):
-                        builder.setListWithOtherModelValues(list_User_TypeAdapter.read(reader));
+                        try {
+                            builder.setListWithOtherModelValues(list_User_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("list_with_primitive_values"):
-                        builder.setListWithPrimitiveValues(list_Integer_TypeAdapter.read(reader));
+                        try {
+                            builder.setListWithPrimitiveValues(list_Integer_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("map_polymorphic_values"):
-                        builder.setMapPolymorphicValues(map_String__EverythingMapPolymorphicValues_TypeAdapter.read(reader));
+                        try {
+                            builder.setMapPolymorphicValues(map_String__EverythingMapPolymorphicValues_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("map_prop"):
-                        builder.setMapProp(map_String__Object_TypeAdapter.read(reader));
+                        try {
+                            builder.setMapProp(map_String__Object_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("map_with_list_and_other_model_values"):
-                        builder.setMapWithListAndOtherModelValues(map_String__List_User__TypeAdapter.read(reader));
+                        try {
+                            builder.setMapWithListAndOtherModelValues(map_String__List_User__TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("map_with_map_and_other_model_values"):
-                        builder.setMapWithMapAndOtherModelValues(map_String__Map_String__Object__TypeAdapter.read(reader));
+                        try {
+                            builder.setMapWithMapAndOtherModelValues(map_String__Map_String__Object__TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("map_with_object_values"):
-                        builder.setMapWithObjectValues(map_String__String_TypeAdapter.read(reader));
+                        try {
+                            builder.setMapWithObjectValues(map_String__String_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("map_with_other_model_values"):
-                        builder.setMapWithOtherModelValues(map_String__User_TypeAdapter.read(reader));
+                        try {
+                            builder.setMapWithOtherModelValues(map_String__User_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("map_with_primitive_values"):
-                        builder.setMapWithPrimitiveValues(map_String__Integer_TypeAdapter.read(reader));
+                        try {
+                            builder.setMapWithPrimitiveValues(map_String__Integer_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("number_prop"):
-                        builder.setNumberProp(doubleTypeAdapter.read(reader));
+                        try {
+                            builder.setNumberProp(doubleTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("other_model_prop"):
-                        builder.setOtherModelProp(userTypeAdapter.read(reader));
+                        try {
+                            builder.setOtherModelProp(userTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("polymorphic_prop"):
-                        builder.setPolymorphicProp(everythingPolymorphicPropTypeAdapter.read(reader));
+                        try {
+                            builder.setPolymorphicProp(everythingPolymorphicPropTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("set_prop"):
-                        builder.setSetProp(set_Object_TypeAdapter.read(reader));
+                        try {
+                            builder.setSetProp(set_Object_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("set_prop_with_other_model_values"):
-                        builder.setSetPropWithOtherModelValues(set_User_TypeAdapter.read(reader));
+                        try {
+                            builder.setSetPropWithOtherModelValues(set_User_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("set_prop_with_primitive_values"):
-                        builder.setSetPropWithPrimitiveValues(set_Integer_TypeAdapter.read(reader));
+                        try {
+                            builder.setSetPropWithPrimitiveValues(set_Integer_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("set_prop_with_values"):
-                        builder.setSetPropWithValues(set_String_TypeAdapter.read(reader));
+                        try {
+                            builder.setSetPropWithValues(set_String_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("string_enum"):
-                        builder.setStringEnum(everythingStringEnumTypeAdapter.read(reader));
+                        try {
+                            builder.setStringEnum(everythingStringEnumTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("string_prop"):
-                        builder.setStringProp(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setStringProp(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("type"):
-                        builder.setType(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setType(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("uri_prop"):
-                        builder.setUriProp(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setUriProp(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     default:
                         reader.skipValue();

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -224,13 +224,28 @@ public class Image {
                 String name = reader.nextName();
                 switch (name) {
                     case ("height"):
-                        builder.setHeight(integerTypeAdapter.read(reader));
+                        try {
+                            builder.setHeight(integerTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("url"):
-                        builder.setUrl(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setUrl(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("width"):
-                        builder.setWidth(integerTypeAdapter.read(reader));
+                        try {
+                            builder.setWidth(integerTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     default:
                         reader.skipValue();

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -162,7 +162,12 @@ public class Model {
                 String name = reader.nextName();
                 switch (name) {
                     case ("id"):
-                        builder.setUid(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setUid(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     default:
                         reader.skipValue();

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -680,55 +680,140 @@ public class Pin {
                 String name = reader.nextName();
                 switch (name) {
                     case ("attribution"):
-                        builder.setAttribution(map_String__String_TypeAdapter.read(reader));
+                        try {
+                            builder.setAttribution(map_String__String_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("attribution_objects"):
-                        builder.setAttributionObjects(list_PinAttributionObjects_TypeAdapter.read(reader));
+                        try {
+                            builder.setAttributionObjects(list_PinAttributionObjects_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("board"):
-                        builder.setBoard(boardTypeAdapter.read(reader));
+                        try {
+                            builder.setBoard(boardTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("color"):
-                        builder.setColor(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setColor(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("counts"):
-                        builder.setCounts(map_String__Integer_TypeAdapter.read(reader));
+                        try {
+                            builder.setCounts(map_String__Integer_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("created_at"):
-                        builder.setCreatedAt(dateTypeAdapter.read(reader));
+                        try {
+                            builder.setCreatedAt(dateTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("creator"):
-                        builder.setCreator(map_String__User_TypeAdapter.read(reader));
+                        try {
+                            builder.setCreator(map_String__User_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("description"):
-                        builder.setDescription(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setDescription(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("id"):
-                        builder.setUid(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setUid(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("image"):
-                        builder.setImage(imageTypeAdapter.read(reader));
+                        try {
+                            builder.setImage(imageTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("in_stock"):
-                        builder.setInStock(pinInStockTypeAdapter.read(reader));
+                        try {
+                            builder.setInStock(pinInStockTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("link"):
-                        builder.setLink(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setLink(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("media"):
-                        builder.setMedia(map_String__String_TypeAdapter.read(reader));
+                        try {
+                            builder.setMedia(map_String__String_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("note"):
-                        builder.setNote(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setNote(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("tags"):
-                        builder.setTags(list_Map_String__Object__TypeAdapter.read(reader));
+                        try {
+                            builder.setTags(list_Map_String__Object__TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("url"):
-                        builder.setUrl(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setUrl(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("visual_search_attrs"):
-                        builder.setVisualSearchAttrs(map_String__Object_TypeAdapter.read(reader));
+                        try {
+                            builder.setVisualSearchAttrs(map_String__Object_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     default:
                         reader.skipValue();

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -444,34 +444,84 @@ public class User {
                 String name = reader.nextName();
                 switch (name) {
                     case ("bio"):
-                        builder.setBio(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setBio(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("counts"):
-                        builder.setCounts(map_String__Integer_TypeAdapter.read(reader));
+                        try {
+                            builder.setCounts(map_String__Integer_TypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("created_at"):
-                        builder.setCreatedAt(dateTypeAdapter.read(reader));
+                        try {
+                            builder.setCreatedAt(dateTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("email_frequency"):
-                        builder.setEmailFrequency(userEmailFrequencyTypeAdapter.read(reader));
+                        try {
+                            builder.setEmailFrequency(userEmailFrequencyTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("first_name"):
-                        builder.setFirstName(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setFirstName(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("id"):
-                        builder.setUid(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setUid(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("image"):
-                        builder.setImage(imageTypeAdapter.read(reader));
+                        try {
+                            builder.setImage(imageTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("last_name"):
-                        builder.setLastName(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setLastName(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("type"):
-                        builder.setType(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setType(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("username"):
-                        builder.setUsername(stringTypeAdapter.read(reader));
+                        try {
+                            builder.setUsername(stringTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     default:
                         reader.skipValue();

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -252,16 +252,36 @@ public class VariableSubtitution {
                 String name = reader.nextName();
                 switch (name) {
                     case ("alloc_prop"):
-                        builder.setAllocProp(integerTypeAdapter.read(reader));
+                        try {
+                            builder.setAllocProp(integerTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("copy_prop"):
-                        builder.setCopyProp(integerTypeAdapter.read(reader));
+                        try {
+                            builder.setCopyProp(integerTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("mutable_copy_prop"):
-                        builder.setMutableCopyProp(integerTypeAdapter.read(reader));
+                        try {
+                            builder.setMutableCopyProp(integerTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     case ("new_prop"):
-                        builder.setNewProp(integerTypeAdapter.read(reader));
+                        try {
+                            builder.setNewProp(integerTypeAdapter.read(reader));
+                        }
+                        catch (IllegalStateException e) {
+                            // TODO Log Error
+                        }
                         break;
                     default:
                         reader.skipValue();

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -178,6 +178,31 @@ public struct JavaIR {
         }
     }
 
+    static func tryCatch(tryBody: [String], catches: () -> [Catch]) -> String {
+        return ([
+            "try {",
+            -->tryBody,
+            "}",
+        ] +
+            catches().map { catchBlock in
+                catchBlock.render().joined(separator: "\n")
+        }).joined(separator: "\n")
+    }
+
+    struct Catch {
+        let exceptionClass: String
+        let exceptionVariable: String
+        let body: [String]
+
+        func render() -> [String] {
+            return [
+                "catch (" + exceptionClass + " " + exceptionVariable + ") {",
+                -->body,
+                "}",
+            ]
+        }
+    }
+
     struct Enum {
         let name: String
         let values: EnumType

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -292,7 +292,9 @@ public struct JavaModelRenderer: JavaFileRenderer {
                         JavaIR.Case(
                             variableEquals: "\"\(param)\"",
                             body: [
-                                "builder.set" + Languages.java.snakeCaseToCapitalizedPropertyName(param) + "(" + typeAdapterVariableNameForType(unwrappedTypeFromSchema(param, schemaObj.schema)) + ".read(reader));",
+                                JavaIR.tryCatch(tryBody: ["builder.set" + Languages.java.snakeCaseToCapitalizedPropertyName(param) + "(" + typeAdapterVariableNameForType(unwrappedTypeFromSchema(param, schemaObj.schema)) + ".read(reader));"]) { [
+                                    JavaIR.Catch(exceptionClass: "IllegalStateException", exceptionVariable: "e", body: ["// TODO Log Error"]),
+                                ] },
                             ]
                         )
                     }


### PR DESCRIPTION
This allows a partial model to be returned even if there's an error parsing one of the fields.

This may be good in scenarios where there are bugs in the Json response, or if you have to make breaking changes to your API.

Open questions:
1. Should this fault-tolerance only be enabled if a config is set? Allowing partial models can potentially do more damage so not everyone may want this.
2. I'm unsure what to do with the exception.