### PR TITLE
Fix integer overflow when tracking set fields

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -43,18 +43,18 @@ public class Board {
     @SerializedName("name") private @Nullable String name;
     @SerializedName("url") private @Nullable String url;
 
-    static final private int ID_SET = 1 << 0;
-    static final private int CONTRIBUTORS_SET = 1 << 1;
-    static final private int COUNTS_SET = 1 << 2;
-    static final private int CREATED_AT_SET = 1 << 3;
-    static final private int CREATOR_SET = 1 << 4;
-    static final private int CREATOR_URL_SET = 1 << 5;
-    static final private int DESCRIPTION_SET = 1 << 6;
-    static final private int IMAGE_SET = 1 << 7;
-    static final private int NAME_SET = 1 << 8;
-    static final private int URL_SET = 1 << 9;
+    static final private int ID_INDEX = 0;
+    static final private int CONTRIBUTORS_INDEX = 1;
+    static final private int COUNTS_INDEX = 2;
+    static final private int CREATED_AT_INDEX = 3;
+    static final private int CREATOR_INDEX = 4;
+    static final private int CREATOR_URL_INDEX = 5;
+    static final private int DESCRIPTION_INDEX = 6;
+    static final private int IMAGE_INDEX = 7;
+    static final private int NAME_INDEX = 8;
+    static final private int URL_INDEX = 9;
 
-    private int _bits = 0;
+    private boolean[] _bits = new boolean[10];
 
     private Board(
         @Nullable String uid,
@@ -67,7 +67,7 @@ public class Board {
         @NonNull Image image,
         @Nullable String name,
         @Nullable String url,
-        int _bits
+        boolean[] _bits
     ) {
         this.uid = uid;
         this.contributors = contributors;
@@ -172,43 +172,43 @@ public class Board {
     }
 
     public boolean getUidIsSet() {
-        return (this._bits & ID_SET) == ID_SET;
+        return this._bits.length > ID_INDEX && this._bits[ID_INDEX];
     }
 
     public boolean getContributorsIsSet() {
-        return (this._bits & CONTRIBUTORS_SET) == CONTRIBUTORS_SET;
+        return this._bits.length > CONTRIBUTORS_INDEX && this._bits[CONTRIBUTORS_INDEX];
     }
 
     public boolean getCountsIsSet() {
-        return (this._bits & COUNTS_SET) == COUNTS_SET;
+        return this._bits.length > COUNTS_INDEX && this._bits[COUNTS_INDEX];
     }
 
     public boolean getCreatedAtIsSet() {
-        return (this._bits & CREATED_AT_SET) == CREATED_AT_SET;
+        return this._bits.length > CREATED_AT_INDEX && this._bits[CREATED_AT_INDEX];
     }
 
     public boolean getCreatorIsSet() {
-        return (this._bits & CREATOR_SET) == CREATOR_SET;
+        return this._bits.length > CREATOR_INDEX && this._bits[CREATOR_INDEX];
     }
 
     public boolean getCreatorURLIsSet() {
-        return (this._bits & CREATOR_URL_SET) == CREATOR_URL_SET;
+        return this._bits.length > CREATOR_URL_INDEX && this._bits[CREATOR_URL_INDEX];
     }
 
     public boolean getDescriptionIsSet() {
-        return (this._bits & DESCRIPTION_SET) == DESCRIPTION_SET;
+        return this._bits.length > DESCRIPTION_INDEX && this._bits[DESCRIPTION_INDEX];
     }
 
     public boolean getImageIsSet() {
-        return (this._bits & IMAGE_SET) == IMAGE_SET;
+        return this._bits.length > IMAGE_INDEX && this._bits[IMAGE_INDEX];
     }
 
     public boolean getNameIsSet() {
-        return (this._bits & NAME_SET) == NAME_SET;
+        return this._bits.length > NAME_INDEX && this._bits[NAME_INDEX];
     }
 
     public boolean getUrlIsSet() {
-        return (this._bits & URL_SET) == URL_SET;
+        return this._bits.length > URL_INDEX && this._bits[URL_INDEX];
     }
 
     public static class Builder {
@@ -224,7 +224,7 @@ public class Board {
         @SerializedName("name") private @Nullable String name;
         @SerializedName("url") private @Nullable String url;
 
-        private int _bits = 0;
+        private boolean[] _bits = new boolean[10];
 
         private Builder() {
         }
@@ -245,61 +245,81 @@ public class Board {
 
         public Builder setUid(@Nullable String value) {
             this.uid = value;
-            this._bits |= ID_SET;
+            if (this._bits.length > ID_INDEX) {
+                this._bits[ID_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setContributors(@Nullable Set<User> value) {
             this.contributors = value;
-            this._bits |= CONTRIBUTORS_SET;
+            if (this._bits.length > CONTRIBUTORS_INDEX) {
+                this._bits[CONTRIBUTORS_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setCounts(@Nullable Map<String, Integer> value) {
             this.counts = value;
-            this._bits |= COUNTS_SET;
+            if (this._bits.length > COUNTS_INDEX) {
+                this._bits[COUNTS_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setCreatedAt(@Nullable Date value) {
             this.createdAt = value;
-            this._bits |= CREATED_AT_SET;
+            if (this._bits.length > CREATED_AT_INDEX) {
+                this._bits[CREATED_AT_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setCreator(@Nullable Map<String, String> value) {
             this.creator = value;
-            this._bits |= CREATOR_SET;
+            if (this._bits.length > CREATOR_INDEX) {
+                this._bits[CREATOR_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setCreatorURL(@Nullable String value) {
             this.creatorURL = value;
-            this._bits |= CREATOR_URL_SET;
+            if (this._bits.length > CREATOR_URL_INDEX) {
+                this._bits[CREATOR_URL_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setDescription(@Nullable String value) {
             this.description = value;
-            this._bits |= DESCRIPTION_SET;
+            if (this._bits.length > DESCRIPTION_INDEX) {
+                this._bits[DESCRIPTION_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setImage(@NonNull Image value) {
             this.image = value;
-            this._bits |= IMAGE_SET;
+            if (this._bits.length > IMAGE_INDEX) {
+                this._bits[IMAGE_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setName(@Nullable String value) {
             this.name = value;
-            this._bits |= NAME_SET;
+            if (this._bits.length > NAME_INDEX) {
+                this._bits[NAME_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setUrl(@Nullable String value) {
             this.url = value;
-            this._bits |= URL_SET;
+            if (this._bits.length > URL_INDEX) {
+                this._bits[URL_INDEX] = true;
+            }
             return this;
         }
 

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -103,37 +103,37 @@ public class Everything {
     @SerializedName("type") private @Nullable String type;
     @SerializedName("uri_prop") private @Nullable String uriProp;
 
-    static final private int ARRAY_PROP_SET = 1 << 0;
-    static final private int BOOLEAN_PROP_SET = 1 << 1;
-    static final private int DATE_PROP_SET = 1 << 2;
-    static final private int INT_ENUM_SET = 1 << 3;
-    static final private int INT_PROP_SET = 1 << 4;
-    static final private int LIST_POLYMORPHIC_VALUES_SET = 1 << 5;
-    static final private int LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_SET = 1 << 6;
-    static final private int LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_SET = 1 << 7;
-    static final private int LIST_WITH_OBJECT_VALUES_SET = 1 << 8;
-    static final private int LIST_WITH_OTHER_MODEL_VALUES_SET = 1 << 9;
-    static final private int LIST_WITH_PRIMITIVE_VALUES_SET = 1 << 10;
-    static final private int MAP_POLYMORPHIC_VALUES_SET = 1 << 11;
-    static final private int MAP_PROP_SET = 1 << 12;
-    static final private int MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_SET = 1 << 13;
-    static final private int MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_SET = 1 << 14;
-    static final private int MAP_WITH_OBJECT_VALUES_SET = 1 << 15;
-    static final private int MAP_WITH_OTHER_MODEL_VALUES_SET = 1 << 16;
-    static final private int MAP_WITH_PRIMITIVE_VALUES_SET = 1 << 17;
-    static final private int NUMBER_PROP_SET = 1 << 18;
-    static final private int OTHER_MODEL_PROP_SET = 1 << 19;
-    static final private int POLYMORPHIC_PROP_SET = 1 << 20;
-    static final private int SET_PROP_SET = 1 << 21;
-    static final private int SET_PROP_WITH_OTHER_MODEL_VALUES_SET = 1 << 22;
-    static final private int SET_PROP_WITH_PRIMITIVE_VALUES_SET = 1 << 23;
-    static final private int SET_PROP_WITH_VALUES_SET = 1 << 24;
-    static final private int STRING_ENUM_SET = 1 << 25;
-    static final private int STRING_PROP_SET = 1 << 26;
-    static final private int TYPE_SET = 1 << 27;
-    static final private int URI_PROP_SET = 1 << 28;
+    static final private int ARRAY_PROP_INDEX = 0;
+    static final private int BOOLEAN_PROP_INDEX = 1;
+    static final private int DATE_PROP_INDEX = 2;
+    static final private int INT_ENUM_INDEX = 3;
+    static final private int INT_PROP_INDEX = 4;
+    static final private int LIST_POLYMORPHIC_VALUES_INDEX = 5;
+    static final private int LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX = 6;
+    static final private int LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX = 7;
+    static final private int LIST_WITH_OBJECT_VALUES_INDEX = 8;
+    static final private int LIST_WITH_OTHER_MODEL_VALUES_INDEX = 9;
+    static final private int LIST_WITH_PRIMITIVE_VALUES_INDEX = 10;
+    static final private int MAP_POLYMORPHIC_VALUES_INDEX = 11;
+    static final private int MAP_PROP_INDEX = 12;
+    static final private int MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX = 13;
+    static final private int MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX = 14;
+    static final private int MAP_WITH_OBJECT_VALUES_INDEX = 15;
+    static final private int MAP_WITH_OTHER_MODEL_VALUES_INDEX = 16;
+    static final private int MAP_WITH_PRIMITIVE_VALUES_INDEX = 17;
+    static final private int NUMBER_PROP_INDEX = 18;
+    static final private int OTHER_MODEL_PROP_INDEX = 19;
+    static final private int POLYMORPHIC_PROP_INDEX = 20;
+    static final private int SET_PROP_INDEX = 21;
+    static final private int SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX = 22;
+    static final private int SET_PROP_WITH_PRIMITIVE_VALUES_INDEX = 23;
+    static final private int SET_PROP_WITH_VALUES_INDEX = 24;
+    static final private int STRING_ENUM_INDEX = 25;
+    static final private int STRING_PROP_INDEX = 26;
+    static final private int TYPE_INDEX = 27;
+    static final private int URI_PROP_INDEX = 28;
 
-    private int _bits = 0;
+    private boolean[] _bits = new boolean[29];
 
     private Everything(
         @Nullable List<Object> arrayProp,
@@ -165,7 +165,7 @@ public class Everything {
         @Nullable String stringProp,
         @Nullable String type,
         @Nullable String uriProp,
-        int _bits
+        boolean[] _bits
     ) {
         this.arrayProp = arrayProp;
         this.booleanProp = booleanProp;
@@ -403,119 +403,119 @@ public class Everything {
     }
 
     public boolean getArrayPropIsSet() {
-        return (this._bits & ARRAY_PROP_SET) == ARRAY_PROP_SET;
+        return this._bits.length > ARRAY_PROP_INDEX && this._bits[ARRAY_PROP_INDEX];
     }
 
     public boolean getBooleanPropIsSet() {
-        return (this._bits & BOOLEAN_PROP_SET) == BOOLEAN_PROP_SET;
+        return this._bits.length > BOOLEAN_PROP_INDEX && this._bits[BOOLEAN_PROP_INDEX];
     }
 
     public boolean getDatePropIsSet() {
-        return (this._bits & DATE_PROP_SET) == DATE_PROP_SET;
+        return this._bits.length > DATE_PROP_INDEX && this._bits[DATE_PROP_INDEX];
     }
 
     public boolean getIntEnumIsSet() {
-        return (this._bits & INT_ENUM_SET) == INT_ENUM_SET;
+        return this._bits.length > INT_ENUM_INDEX && this._bits[INT_ENUM_INDEX];
     }
 
     public boolean getIntPropIsSet() {
-        return (this._bits & INT_PROP_SET) == INT_PROP_SET;
+        return this._bits.length > INT_PROP_INDEX && this._bits[INT_PROP_INDEX];
     }
 
     public boolean getListPolymorphicValuesIsSet() {
-        return (this._bits & LIST_POLYMORPHIC_VALUES_SET) == LIST_POLYMORPHIC_VALUES_SET;
+        return this._bits.length > LIST_POLYMORPHIC_VALUES_INDEX && this._bits[LIST_POLYMORPHIC_VALUES_INDEX];
     }
 
     public boolean getListWithListAndOtherModelValuesIsSet() {
-        return (this._bits & LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_SET) == LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_SET;
+        return this._bits.length > LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX && this._bits[LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX];
     }
 
     public boolean getListWithMapAndOtherModelValuesIsSet() {
-        return (this._bits & LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_SET) == LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_SET;
+        return this._bits.length > LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX && this._bits[LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX];
     }
 
     public boolean getListWithObjectValuesIsSet() {
-        return (this._bits & LIST_WITH_OBJECT_VALUES_SET) == LIST_WITH_OBJECT_VALUES_SET;
+        return this._bits.length > LIST_WITH_OBJECT_VALUES_INDEX && this._bits[LIST_WITH_OBJECT_VALUES_INDEX];
     }
 
     public boolean getListWithOtherModelValuesIsSet() {
-        return (this._bits & LIST_WITH_OTHER_MODEL_VALUES_SET) == LIST_WITH_OTHER_MODEL_VALUES_SET;
+        return this._bits.length > LIST_WITH_OTHER_MODEL_VALUES_INDEX && this._bits[LIST_WITH_OTHER_MODEL_VALUES_INDEX];
     }
 
     public boolean getListWithPrimitiveValuesIsSet() {
-        return (this._bits & LIST_WITH_PRIMITIVE_VALUES_SET) == LIST_WITH_PRIMITIVE_VALUES_SET;
+        return this._bits.length > LIST_WITH_PRIMITIVE_VALUES_INDEX && this._bits[LIST_WITH_PRIMITIVE_VALUES_INDEX];
     }
 
     public boolean getMapPolymorphicValuesIsSet() {
-        return (this._bits & MAP_POLYMORPHIC_VALUES_SET) == MAP_POLYMORPHIC_VALUES_SET;
+        return this._bits.length > MAP_POLYMORPHIC_VALUES_INDEX && this._bits[MAP_POLYMORPHIC_VALUES_INDEX];
     }
 
     public boolean getMapPropIsSet() {
-        return (this._bits & MAP_PROP_SET) == MAP_PROP_SET;
+        return this._bits.length > MAP_PROP_INDEX && this._bits[MAP_PROP_INDEX];
     }
 
     public boolean getMapWithListAndOtherModelValuesIsSet() {
-        return (this._bits & MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_SET) == MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_SET;
+        return this._bits.length > MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX && this._bits[MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX];
     }
 
     public boolean getMapWithMapAndOtherModelValuesIsSet() {
-        return (this._bits & MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_SET) == MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_SET;
+        return this._bits.length > MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX && this._bits[MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX];
     }
 
     public boolean getMapWithObjectValuesIsSet() {
-        return (this._bits & MAP_WITH_OBJECT_VALUES_SET) == MAP_WITH_OBJECT_VALUES_SET;
+        return this._bits.length > MAP_WITH_OBJECT_VALUES_INDEX && this._bits[MAP_WITH_OBJECT_VALUES_INDEX];
     }
 
     public boolean getMapWithOtherModelValuesIsSet() {
-        return (this._bits & MAP_WITH_OTHER_MODEL_VALUES_SET) == MAP_WITH_OTHER_MODEL_VALUES_SET;
+        return this._bits.length > MAP_WITH_OTHER_MODEL_VALUES_INDEX && this._bits[MAP_WITH_OTHER_MODEL_VALUES_INDEX];
     }
 
     public boolean getMapWithPrimitiveValuesIsSet() {
-        return (this._bits & MAP_WITH_PRIMITIVE_VALUES_SET) == MAP_WITH_PRIMITIVE_VALUES_SET;
+        return this._bits.length > MAP_WITH_PRIMITIVE_VALUES_INDEX && this._bits[MAP_WITH_PRIMITIVE_VALUES_INDEX];
     }
 
     public boolean getNumberPropIsSet() {
-        return (this._bits & NUMBER_PROP_SET) == NUMBER_PROP_SET;
+        return this._bits.length > NUMBER_PROP_INDEX && this._bits[NUMBER_PROP_INDEX];
     }
 
     public boolean getOtherModelPropIsSet() {
-        return (this._bits & OTHER_MODEL_PROP_SET) == OTHER_MODEL_PROP_SET;
+        return this._bits.length > OTHER_MODEL_PROP_INDEX && this._bits[OTHER_MODEL_PROP_INDEX];
     }
 
     public boolean getPolymorphicPropIsSet() {
-        return (this._bits & POLYMORPHIC_PROP_SET) == POLYMORPHIC_PROP_SET;
+        return this._bits.length > POLYMORPHIC_PROP_INDEX && this._bits[POLYMORPHIC_PROP_INDEX];
     }
 
     public boolean getSetPropIsSet() {
-        return (this._bits & SET_PROP_SET) == SET_PROP_SET;
+        return this._bits.length > SET_PROP_INDEX && this._bits[SET_PROP_INDEX];
     }
 
     public boolean getSetPropWithOtherModelValuesIsSet() {
-        return (this._bits & SET_PROP_WITH_OTHER_MODEL_VALUES_SET) == SET_PROP_WITH_OTHER_MODEL_VALUES_SET;
+        return this._bits.length > SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX && this._bits[SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX];
     }
 
     public boolean getSetPropWithPrimitiveValuesIsSet() {
-        return (this._bits & SET_PROP_WITH_PRIMITIVE_VALUES_SET) == SET_PROP_WITH_PRIMITIVE_VALUES_SET;
+        return this._bits.length > SET_PROP_WITH_PRIMITIVE_VALUES_INDEX && this._bits[SET_PROP_WITH_PRIMITIVE_VALUES_INDEX];
     }
 
     public boolean getSetPropWithValuesIsSet() {
-        return (this._bits & SET_PROP_WITH_VALUES_SET) == SET_PROP_WITH_VALUES_SET;
+        return this._bits.length > SET_PROP_WITH_VALUES_INDEX && this._bits[SET_PROP_WITH_VALUES_INDEX];
     }
 
     public boolean getStringEnumIsSet() {
-        return (this._bits & STRING_ENUM_SET) == STRING_ENUM_SET;
+        return this._bits.length > STRING_ENUM_INDEX && this._bits[STRING_ENUM_INDEX];
     }
 
     public boolean getStringPropIsSet() {
-        return (this._bits & STRING_PROP_SET) == STRING_PROP_SET;
+        return this._bits.length > STRING_PROP_INDEX && this._bits[STRING_PROP_INDEX];
     }
 
     public boolean getTypeIsSet() {
-        return (this._bits & TYPE_SET) == TYPE_SET;
+        return this._bits.length > TYPE_INDEX && this._bits[TYPE_INDEX];
     }
 
     public boolean getUriPropIsSet() {
-        return (this._bits & URI_PROP_SET) == URI_PROP_SET;
+        return this._bits.length > URI_PROP_INDEX && this._bits[URI_PROP_INDEX];
     }
 
     public static class Builder {
@@ -550,7 +550,7 @@ public class Everything {
         @SerializedName("type") private @Nullable String type;
         @SerializedName("uri_prop") private @Nullable String uriProp;
 
-        private int _bits = 0;
+        private boolean[] _bits = new boolean[29];
 
         private Builder() {
         }
@@ -590,175 +590,233 @@ public class Everything {
 
         public Builder setArrayProp(@Nullable List<Object> value) {
             this.arrayProp = value;
-            this._bits |= ARRAY_PROP_SET;
+            if (this._bits.length > ARRAY_PROP_INDEX) {
+                this._bits[ARRAY_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setBooleanProp(@Nullable Boolean value) {
             this.booleanProp = value;
-            this._bits |= BOOLEAN_PROP_SET;
+            if (this._bits.length > BOOLEAN_PROP_INDEX) {
+                this._bits[BOOLEAN_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setDateProp(@Nullable Date value) {
             this.dateProp = value;
-            this._bits |= DATE_PROP_SET;
+            if (this._bits.length > DATE_PROP_INDEX) {
+                this._bits[DATE_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setIntEnum(@Nullable EverythingIntEnum value) {
             this.intEnum = value;
-            this._bits |= INT_ENUM_SET;
+            if (this._bits.length > INT_ENUM_INDEX) {
+                this._bits[INT_ENUM_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setIntProp(@Nullable Integer value) {
             this.intProp = value;
-            this._bits |= INT_PROP_SET;
+            if (this._bits.length > INT_PROP_INDEX) {
+                this._bits[INT_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setListPolymorphicValues(@Nullable List<Object> value) {
             this.listPolymorphicValues = value;
-            this._bits |= LIST_POLYMORPHIC_VALUES_SET;
+            if (this._bits.length > LIST_POLYMORPHIC_VALUES_INDEX) {
+                this._bits[LIST_POLYMORPHIC_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setListWithListAndOtherModelValues(@Nullable List<List<User>> value) {
             this.listWithListAndOtherModelValues = value;
-            this._bits |= LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_SET;
+            if (this._bits.length > LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX) {
+                this._bits[LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setListWithMapAndOtherModelValues(@Nullable List<Map<String, User>> value) {
             this.listWithMapAndOtherModelValues = value;
-            this._bits |= LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_SET;
+            if (this._bits.length > LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX) {
+                this._bits[LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setListWithObjectValues(@Nullable List<String> value) {
             this.listWithObjectValues = value;
-            this._bits |= LIST_WITH_OBJECT_VALUES_SET;
+            if (this._bits.length > LIST_WITH_OBJECT_VALUES_INDEX) {
+                this._bits[LIST_WITH_OBJECT_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setListWithOtherModelValues(@Nullable List<User> value) {
             this.listWithOtherModelValues = value;
-            this._bits |= LIST_WITH_OTHER_MODEL_VALUES_SET;
+            if (this._bits.length > LIST_WITH_OTHER_MODEL_VALUES_INDEX) {
+                this._bits[LIST_WITH_OTHER_MODEL_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setListWithPrimitiveValues(@Nullable List<Integer> value) {
             this.listWithPrimitiveValues = value;
-            this._bits |= LIST_WITH_PRIMITIVE_VALUES_SET;
+            if (this._bits.length > LIST_WITH_PRIMITIVE_VALUES_INDEX) {
+                this._bits[LIST_WITH_PRIMITIVE_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setMapPolymorphicValues(@Nullable Map<String, EverythingMapPolymorphicValues> value) {
             this.mapPolymorphicValues = value;
-            this._bits |= MAP_POLYMORPHIC_VALUES_SET;
+            if (this._bits.length > MAP_POLYMORPHIC_VALUES_INDEX) {
+                this._bits[MAP_POLYMORPHIC_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setMapProp(@Nullable Map<String, Object> value) {
             this.mapProp = value;
-            this._bits |= MAP_PROP_SET;
+            if (this._bits.length > MAP_PROP_INDEX) {
+                this._bits[MAP_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setMapWithListAndOtherModelValues(@Nullable Map<String, List<User>> value) {
             this.mapWithListAndOtherModelValues = value;
-            this._bits |= MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_SET;
+            if (this._bits.length > MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX) {
+                this._bits[MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setMapWithMapAndOtherModelValues(@Nullable Map<String, Map<String, Object>> value) {
             this.mapWithMapAndOtherModelValues = value;
-            this._bits |= MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_SET;
+            if (this._bits.length > MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX) {
+                this._bits[MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setMapWithObjectValues(@Nullable Map<String, String> value) {
             this.mapWithObjectValues = value;
-            this._bits |= MAP_WITH_OBJECT_VALUES_SET;
+            if (this._bits.length > MAP_WITH_OBJECT_VALUES_INDEX) {
+                this._bits[MAP_WITH_OBJECT_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setMapWithOtherModelValues(@Nullable Map<String, User> value) {
             this.mapWithOtherModelValues = value;
-            this._bits |= MAP_WITH_OTHER_MODEL_VALUES_SET;
+            if (this._bits.length > MAP_WITH_OTHER_MODEL_VALUES_INDEX) {
+                this._bits[MAP_WITH_OTHER_MODEL_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setMapWithPrimitiveValues(@Nullable Map<String, Integer> value) {
             this.mapWithPrimitiveValues = value;
-            this._bits |= MAP_WITH_PRIMITIVE_VALUES_SET;
+            if (this._bits.length > MAP_WITH_PRIMITIVE_VALUES_INDEX) {
+                this._bits[MAP_WITH_PRIMITIVE_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setNumberProp(@Nullable Double value) {
             this.numberProp = value;
-            this._bits |= NUMBER_PROP_SET;
+            if (this._bits.length > NUMBER_PROP_INDEX) {
+                this._bits[NUMBER_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setOtherModelProp(@Nullable User value) {
             this.otherModelProp = value;
-            this._bits |= OTHER_MODEL_PROP_SET;
+            if (this._bits.length > OTHER_MODEL_PROP_INDEX) {
+                this._bits[OTHER_MODEL_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setPolymorphicProp(@Nullable EverythingPolymorphicProp value) {
             this.polymorphicProp = value;
-            this._bits |= POLYMORPHIC_PROP_SET;
+            if (this._bits.length > POLYMORPHIC_PROP_INDEX) {
+                this._bits[POLYMORPHIC_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setSetProp(@Nullable Set<Object> value) {
             this.setProp = value;
-            this._bits |= SET_PROP_SET;
+            if (this._bits.length > SET_PROP_INDEX) {
+                this._bits[SET_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setSetPropWithOtherModelValues(@Nullable Set<User> value) {
             this.setPropWithOtherModelValues = value;
-            this._bits |= SET_PROP_WITH_OTHER_MODEL_VALUES_SET;
+            if (this._bits.length > SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX) {
+                this._bits[SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setSetPropWithPrimitiveValues(@Nullable Set<Integer> value) {
             this.setPropWithPrimitiveValues = value;
-            this._bits |= SET_PROP_WITH_PRIMITIVE_VALUES_SET;
+            if (this._bits.length > SET_PROP_WITH_PRIMITIVE_VALUES_INDEX) {
+                this._bits[SET_PROP_WITH_PRIMITIVE_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setSetPropWithValues(@Nullable Set<String> value) {
             this.setPropWithValues = value;
-            this._bits |= SET_PROP_WITH_VALUES_SET;
+            if (this._bits.length > SET_PROP_WITH_VALUES_INDEX) {
+                this._bits[SET_PROP_WITH_VALUES_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setStringEnum(@Nullable EverythingStringEnum value) {
             this.stringEnum = value;
-            this._bits |= STRING_ENUM_SET;
+            if (this._bits.length > STRING_ENUM_INDEX) {
+                this._bits[STRING_ENUM_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setStringProp(@Nullable String value) {
             this.stringProp = value;
-            this._bits |= STRING_PROP_SET;
+            if (this._bits.length > STRING_PROP_INDEX) {
+                this._bits[STRING_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setType(@Nullable String value) {
             this.type = value;
-            this._bits |= TYPE_SET;
+            if (this._bits.length > TYPE_INDEX) {
+                this._bits[TYPE_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setUriProp(@Nullable String value) {
             this.uriProp = value;
-            this._bits |= URI_PROP_SET;
+            if (this._bits.length > URI_PROP_INDEX) {
+                this._bits[URI_PROP_INDEX] = true;
+            }
             return this;
         }
 

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -36,17 +36,17 @@ public class Image {
     @SerializedName("url") private @Nullable String url;
     @SerializedName("width") private @Nullable Integer width;
 
-    static final private int HEIGHT_SET = 1 << 0;
-    static final private int URL_SET = 1 << 1;
-    static final private int WIDTH_SET = 1 << 2;
+    static final private int HEIGHT_INDEX = 0;
+    static final private int URL_INDEX = 1;
+    static final private int WIDTH_INDEX = 2;
 
-    private int _bits = 0;
+    private boolean[] _bits = new boolean[3];
 
     private Image(
         @Nullable Integer height,
         @Nullable String url,
         @Nullable Integer width,
-        int _bits
+        boolean[] _bits
     ) {
         this.height = height;
         this.url = url;
@@ -102,15 +102,15 @@ public class Image {
     }
 
     public boolean getHeightIsSet() {
-        return (this._bits & HEIGHT_SET) == HEIGHT_SET;
+        return this._bits.length > HEIGHT_INDEX && this._bits[HEIGHT_INDEX];
     }
 
     public boolean getUrlIsSet() {
-        return (this._bits & URL_SET) == URL_SET;
+        return this._bits.length > URL_INDEX && this._bits[URL_INDEX];
     }
 
     public boolean getWidthIsSet() {
-        return (this._bits & WIDTH_SET) == WIDTH_SET;
+        return this._bits.length > WIDTH_INDEX && this._bits[WIDTH_INDEX];
     }
 
     public static class Builder {
@@ -119,7 +119,7 @@ public class Image {
         @SerializedName("url") private @Nullable String url;
         @SerializedName("width") private @Nullable Integer width;
 
-        private int _bits = 0;
+        private boolean[] _bits = new boolean[3];
 
         private Builder() {
         }
@@ -133,19 +133,25 @@ public class Image {
 
         public Builder setHeight(@Nullable Integer value) {
             this.height = value;
-            this._bits |= HEIGHT_SET;
+            if (this._bits.length > HEIGHT_INDEX) {
+                this._bits[HEIGHT_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setUrl(@Nullable String value) {
             this.url = value;
-            this._bits |= URL_SET;
+            if (this._bits.length > URL_INDEX) {
+                this._bits[URL_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setWidth(@Nullable Integer value) {
             this.width = value;
-            this._bits |= WIDTH_SET;
+            if (this._bits.length > WIDTH_INDEX) {
+                this._bits[WIDTH_INDEX] = true;
+            }
             return this;
         }
 

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -34,13 +34,13 @@ public class Model {
 
     @SerializedName("id") private @Nullable String uid;
 
-    static final private int ID_SET = 1 << 0;
+    static final private int ID_INDEX = 0;
 
-    private int _bits = 0;
+    private boolean[] _bits = new boolean[1];
 
     private Model(
         @Nullable String uid,
-        int _bits
+        boolean[] _bits
     ) {
         this.uid = uid;
         this._bits = _bits;
@@ -82,14 +82,14 @@ public class Model {
     }
 
     public boolean getUidIsSet() {
-        return (this._bits & ID_SET) == ID_SET;
+        return this._bits.length > ID_INDEX && this._bits[ID_INDEX];
     }
 
     public static class Builder {
 
         @SerializedName("id") private @Nullable String uid;
 
-        private int _bits = 0;
+        private boolean[] _bits = new boolean[1];
 
         private Builder() {
         }
@@ -101,7 +101,9 @@ public class Model {
 
         public Builder setUid(@Nullable String value) {
             this.uid = value;
-            this._bits |= ID_SET;
+            if (this._bits.length > ID_INDEX) {
+                this._bits[ID_INDEX] = true;
+            }
             return this;
         }
 

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -68,25 +68,25 @@ public class Pin {
     @SerializedName("url") private @Nullable String url;
     @SerializedName("visual_search_attrs") private @Nullable Map<String, Object> visualSearchAttrs;
 
-    static final private int ATTRIBUTION_SET = 1 << 0;
-    static final private int ATTRIBUTION_OBJECTS_SET = 1 << 1;
-    static final private int BOARD_SET = 1 << 2;
-    static final private int COLOR_SET = 1 << 3;
-    static final private int COUNTS_SET = 1 << 4;
-    static final private int CREATED_AT_SET = 1 << 5;
-    static final private int CREATOR_SET = 1 << 6;
-    static final private int DESCRIPTION_SET = 1 << 7;
-    static final private int ID_SET = 1 << 8;
-    static final private int IMAGE_SET = 1 << 9;
-    static final private int IN_STOCK_SET = 1 << 10;
-    static final private int LINK_SET = 1 << 11;
-    static final private int MEDIA_SET = 1 << 12;
-    static final private int NOTE_SET = 1 << 13;
-    static final private int TAGS_SET = 1 << 14;
-    static final private int URL_SET = 1 << 15;
-    static final private int VISUAL_SEARCH_ATTRS_SET = 1 << 16;
+    static final private int ATTRIBUTION_INDEX = 0;
+    static final private int ATTRIBUTION_OBJECTS_INDEX = 1;
+    static final private int BOARD_INDEX = 2;
+    static final private int COLOR_INDEX = 3;
+    static final private int COUNTS_INDEX = 4;
+    static final private int CREATED_AT_INDEX = 5;
+    static final private int CREATOR_INDEX = 6;
+    static final private int DESCRIPTION_INDEX = 7;
+    static final private int ID_INDEX = 8;
+    static final private int IMAGE_INDEX = 9;
+    static final private int IN_STOCK_INDEX = 10;
+    static final private int LINK_INDEX = 11;
+    static final private int MEDIA_INDEX = 12;
+    static final private int NOTE_INDEX = 13;
+    static final private int TAGS_INDEX = 14;
+    static final private int URL_INDEX = 15;
+    static final private int VISUAL_SEARCH_ATTRS_INDEX = 16;
 
-    private int _bits = 0;
+    private boolean[] _bits = new boolean[17];
 
     private Pin(
         @Nullable Map<String, String> attribution,
@@ -106,7 +106,7 @@ public class Pin {
         @Nullable List<Map<String, Object>> tags,
         @Nullable String url,
         @Nullable Map<String, Object> visualSearchAttrs,
-        int _bits
+        boolean[] _bits
     ) {
         this.attribution = attribution;
         this.attributionObjects = attributionObjects;
@@ -260,71 +260,71 @@ public class Pin {
     }
 
     public boolean getAttributionIsSet() {
-        return (this._bits & ATTRIBUTION_SET) == ATTRIBUTION_SET;
+        return this._bits.length > ATTRIBUTION_INDEX && this._bits[ATTRIBUTION_INDEX];
     }
 
     public boolean getAttributionObjectsIsSet() {
-        return (this._bits & ATTRIBUTION_OBJECTS_SET) == ATTRIBUTION_OBJECTS_SET;
+        return this._bits.length > ATTRIBUTION_OBJECTS_INDEX && this._bits[ATTRIBUTION_OBJECTS_INDEX];
     }
 
     public boolean getBoardIsSet() {
-        return (this._bits & BOARD_SET) == BOARD_SET;
+        return this._bits.length > BOARD_INDEX && this._bits[BOARD_INDEX];
     }
 
     public boolean getColorIsSet() {
-        return (this._bits & COLOR_SET) == COLOR_SET;
+        return this._bits.length > COLOR_INDEX && this._bits[COLOR_INDEX];
     }
 
     public boolean getCountsIsSet() {
-        return (this._bits & COUNTS_SET) == COUNTS_SET;
+        return this._bits.length > COUNTS_INDEX && this._bits[COUNTS_INDEX];
     }
 
     public boolean getCreatedAtIsSet() {
-        return (this._bits & CREATED_AT_SET) == CREATED_AT_SET;
+        return this._bits.length > CREATED_AT_INDEX && this._bits[CREATED_AT_INDEX];
     }
 
     public boolean getCreatorIsSet() {
-        return (this._bits & CREATOR_SET) == CREATOR_SET;
+        return this._bits.length > CREATOR_INDEX && this._bits[CREATOR_INDEX];
     }
 
     public boolean getDescriptionIsSet() {
-        return (this._bits & DESCRIPTION_SET) == DESCRIPTION_SET;
+        return this._bits.length > DESCRIPTION_INDEX && this._bits[DESCRIPTION_INDEX];
     }
 
     public boolean getUidIsSet() {
-        return (this._bits & ID_SET) == ID_SET;
+        return this._bits.length > ID_INDEX && this._bits[ID_INDEX];
     }
 
     public boolean getImageIsSet() {
-        return (this._bits & IMAGE_SET) == IMAGE_SET;
+        return this._bits.length > IMAGE_INDEX && this._bits[IMAGE_INDEX];
     }
 
     public boolean getInStockIsSet() {
-        return (this._bits & IN_STOCK_SET) == IN_STOCK_SET;
+        return this._bits.length > IN_STOCK_INDEX && this._bits[IN_STOCK_INDEX];
     }
 
     public boolean getLinkIsSet() {
-        return (this._bits & LINK_SET) == LINK_SET;
+        return this._bits.length > LINK_INDEX && this._bits[LINK_INDEX];
     }
 
     public boolean getMediaIsSet() {
-        return (this._bits & MEDIA_SET) == MEDIA_SET;
+        return this._bits.length > MEDIA_INDEX && this._bits[MEDIA_INDEX];
     }
 
     public boolean getNoteIsSet() {
-        return (this._bits & NOTE_SET) == NOTE_SET;
+        return this._bits.length > NOTE_INDEX && this._bits[NOTE_INDEX];
     }
 
     public boolean getTagsIsSet() {
-        return (this._bits & TAGS_SET) == TAGS_SET;
+        return this._bits.length > TAGS_INDEX && this._bits[TAGS_INDEX];
     }
 
     public boolean getUrlIsSet() {
-        return (this._bits & URL_SET) == URL_SET;
+        return this._bits.length > URL_INDEX && this._bits[URL_INDEX];
     }
 
     public boolean getVisualSearchAttrsIsSet() {
-        return (this._bits & VISUAL_SEARCH_ATTRS_SET) == VISUAL_SEARCH_ATTRS_SET;
+        return this._bits.length > VISUAL_SEARCH_ATTRS_INDEX && this._bits[VISUAL_SEARCH_ATTRS_INDEX];
     }
 
     public static class Builder {
@@ -347,7 +347,7 @@ public class Pin {
         @SerializedName("url") private @Nullable String url;
         @SerializedName("visual_search_attrs") private @Nullable Map<String, Object> visualSearchAttrs;
 
-        private int _bits = 0;
+        private boolean[] _bits = new boolean[17];
 
         private Builder() {
         }
@@ -375,103 +375,137 @@ public class Pin {
 
         public Builder setAttribution(@Nullable Map<String, String> value) {
             this.attribution = value;
-            this._bits |= ATTRIBUTION_SET;
+            if (this._bits.length > ATTRIBUTION_INDEX) {
+                this._bits[ATTRIBUTION_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setAttributionObjects(@Nullable List<PinAttributionObjects> value) {
             this.attributionObjects = value;
-            this._bits |= ATTRIBUTION_OBJECTS_SET;
+            if (this._bits.length > ATTRIBUTION_OBJECTS_INDEX) {
+                this._bits[ATTRIBUTION_OBJECTS_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setBoard(@Nullable Board value) {
             this.board = value;
-            this._bits |= BOARD_SET;
+            if (this._bits.length > BOARD_INDEX) {
+                this._bits[BOARD_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setColor(@Nullable String value) {
             this.color = value;
-            this._bits |= COLOR_SET;
+            if (this._bits.length > COLOR_INDEX) {
+                this._bits[COLOR_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setCounts(@Nullable Map<String, Integer> value) {
             this.counts = value;
-            this._bits |= COUNTS_SET;
+            if (this._bits.length > COUNTS_INDEX) {
+                this._bits[COUNTS_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setCreatedAt(@NonNull Date value) {
             this.createdAt = value;
-            this._bits |= CREATED_AT_SET;
+            if (this._bits.length > CREATED_AT_INDEX) {
+                this._bits[CREATED_AT_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setCreator(@NonNull Map<String, User> value) {
             this.creator = value;
-            this._bits |= CREATOR_SET;
+            if (this._bits.length > CREATOR_INDEX) {
+                this._bits[CREATOR_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setDescription(@Nullable String value) {
             this.description = value;
-            this._bits |= DESCRIPTION_SET;
+            if (this._bits.length > DESCRIPTION_INDEX) {
+                this._bits[DESCRIPTION_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setUid(@NonNull String value) {
             this.uid = value;
-            this._bits |= ID_SET;
+            if (this._bits.length > ID_INDEX) {
+                this._bits[ID_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setImage(@Nullable Image value) {
             this.image = value;
-            this._bits |= IMAGE_SET;
+            if (this._bits.length > IMAGE_INDEX) {
+                this._bits[IMAGE_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setInStock(@Nullable PinInStock value) {
             this.inStock = value;
-            this._bits |= IN_STOCK_SET;
+            if (this._bits.length > IN_STOCK_INDEX) {
+                this._bits[IN_STOCK_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setLink(@Nullable String value) {
             this.link = value;
-            this._bits |= LINK_SET;
+            if (this._bits.length > LINK_INDEX) {
+                this._bits[LINK_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setMedia(@Nullable Map<String, String> value) {
             this.media = value;
-            this._bits |= MEDIA_SET;
+            if (this._bits.length > MEDIA_INDEX) {
+                this._bits[MEDIA_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setNote(@Nullable String value) {
             this.note = value;
-            this._bits |= NOTE_SET;
+            if (this._bits.length > NOTE_INDEX) {
+                this._bits[NOTE_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setTags(@Nullable List<Map<String, Object>> value) {
             this.tags = value;
-            this._bits |= TAGS_SET;
+            if (this._bits.length > TAGS_INDEX) {
+                this._bits[TAGS_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setUrl(@Nullable String value) {
             this.url = value;
-            this._bits |= URL_SET;
+            if (this._bits.length > URL_INDEX) {
+                this._bits[URL_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setVisualSearchAttrs(@Nullable Map<String, Object> value) {
             this.visualSearchAttrs = value;
-            this._bits |= VISUAL_SEARCH_ATTRS_SET;
+            if (this._bits.length > VISUAL_SEARCH_ATTRS_INDEX) {
+                this._bits[VISUAL_SEARCH_ATTRS_INDEX] = true;
+            }
             return this;
         }
 

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -47,18 +47,18 @@ public class User {
     @SerializedName("type") private @Nullable String type;
     @SerializedName("username") private @Nullable String username;
 
-    static final private int BIO_SET = 1 << 0;
-    static final private int COUNTS_SET = 1 << 1;
-    static final private int CREATED_AT_SET = 1 << 2;
-    static final private int EMAIL_FREQUENCY_SET = 1 << 3;
-    static final private int FIRST_NAME_SET = 1 << 4;
-    static final private int ID_SET = 1 << 5;
-    static final private int IMAGE_SET = 1 << 6;
-    static final private int LAST_NAME_SET = 1 << 7;
-    static final private int TYPE_SET = 1 << 8;
-    static final private int USERNAME_SET = 1 << 9;
+    static final private int BIO_INDEX = 0;
+    static final private int COUNTS_INDEX = 1;
+    static final private int CREATED_AT_INDEX = 2;
+    static final private int EMAIL_FREQUENCY_INDEX = 3;
+    static final private int FIRST_NAME_INDEX = 4;
+    static final private int ID_INDEX = 5;
+    static final private int IMAGE_INDEX = 6;
+    static final private int LAST_NAME_INDEX = 7;
+    static final private int TYPE_INDEX = 8;
+    static final private int USERNAME_INDEX = 9;
 
-    private int _bits = 0;
+    private boolean[] _bits = new boolean[10];
 
     private User(
         @Nullable String bio,
@@ -71,7 +71,7 @@ public class User {
         @Nullable String lastName,
         @Nullable String type,
         @Nullable String username,
-        int _bits
+        boolean[] _bits
     ) {
         this.bio = bio;
         this.counts = counts;
@@ -176,43 +176,43 @@ public class User {
     }
 
     public boolean getBioIsSet() {
-        return (this._bits & BIO_SET) == BIO_SET;
+        return this._bits.length > BIO_INDEX && this._bits[BIO_INDEX];
     }
 
     public boolean getCountsIsSet() {
-        return (this._bits & COUNTS_SET) == COUNTS_SET;
+        return this._bits.length > COUNTS_INDEX && this._bits[COUNTS_INDEX];
     }
 
     public boolean getCreatedAtIsSet() {
-        return (this._bits & CREATED_AT_SET) == CREATED_AT_SET;
+        return this._bits.length > CREATED_AT_INDEX && this._bits[CREATED_AT_INDEX];
     }
 
     public boolean getEmailFrequencyIsSet() {
-        return (this._bits & EMAIL_FREQUENCY_SET) == EMAIL_FREQUENCY_SET;
+        return this._bits.length > EMAIL_FREQUENCY_INDEX && this._bits[EMAIL_FREQUENCY_INDEX];
     }
 
     public boolean getFirstNameIsSet() {
-        return (this._bits & FIRST_NAME_SET) == FIRST_NAME_SET;
+        return this._bits.length > FIRST_NAME_INDEX && this._bits[FIRST_NAME_INDEX];
     }
 
     public boolean getUidIsSet() {
-        return (this._bits & ID_SET) == ID_SET;
+        return this._bits.length > ID_INDEX && this._bits[ID_INDEX];
     }
 
     public boolean getImageIsSet() {
-        return (this._bits & IMAGE_SET) == IMAGE_SET;
+        return this._bits.length > IMAGE_INDEX && this._bits[IMAGE_INDEX];
     }
 
     public boolean getLastNameIsSet() {
-        return (this._bits & LAST_NAME_SET) == LAST_NAME_SET;
+        return this._bits.length > LAST_NAME_INDEX && this._bits[LAST_NAME_INDEX];
     }
 
     public boolean getTypeIsSet() {
-        return (this._bits & TYPE_SET) == TYPE_SET;
+        return this._bits.length > TYPE_INDEX && this._bits[TYPE_INDEX];
     }
 
     public boolean getUsernameIsSet() {
-        return (this._bits & USERNAME_SET) == USERNAME_SET;
+        return this._bits.length > USERNAME_INDEX && this._bits[USERNAME_INDEX];
     }
 
     public static class Builder {
@@ -228,7 +228,7 @@ public class User {
         @SerializedName("type") private @Nullable String type;
         @SerializedName("username") private @Nullable String username;
 
-        private int _bits = 0;
+        private boolean[] _bits = new boolean[10];
 
         private Builder() {
         }
@@ -249,61 +249,81 @@ public class User {
 
         public Builder setBio(@Nullable String value) {
             this.bio = value;
-            this._bits |= BIO_SET;
+            if (this._bits.length > BIO_INDEX) {
+                this._bits[BIO_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setCounts(@Nullable Map<String, Integer> value) {
             this.counts = value;
-            this._bits |= COUNTS_SET;
+            if (this._bits.length > COUNTS_INDEX) {
+                this._bits[COUNTS_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setCreatedAt(@Nullable Date value) {
             this.createdAt = value;
-            this._bits |= CREATED_AT_SET;
+            if (this._bits.length > CREATED_AT_INDEX) {
+                this._bits[CREATED_AT_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setEmailFrequency(@Nullable UserEmailFrequency value) {
             this.emailFrequency = value;
-            this._bits |= EMAIL_FREQUENCY_SET;
+            if (this._bits.length > EMAIL_FREQUENCY_INDEX) {
+                this._bits[EMAIL_FREQUENCY_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setFirstName(@Nullable String value) {
             this.firstName = value;
-            this._bits |= FIRST_NAME_SET;
+            if (this._bits.length > FIRST_NAME_INDEX) {
+                this._bits[FIRST_NAME_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setUid(@Nullable String value) {
             this.uid = value;
-            this._bits |= ID_SET;
+            if (this._bits.length > ID_INDEX) {
+                this._bits[ID_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setImage(@Nullable Image value) {
             this.image = value;
-            this._bits |= IMAGE_SET;
+            if (this._bits.length > IMAGE_INDEX) {
+                this._bits[IMAGE_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setLastName(@Nullable String value) {
             this.lastName = value;
-            this._bits |= LAST_NAME_SET;
+            if (this._bits.length > LAST_NAME_INDEX) {
+                this._bits[LAST_NAME_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setType(@Nullable String value) {
             this.type = value;
-            this._bits |= TYPE_SET;
+            if (this._bits.length > TYPE_INDEX) {
+                this._bits[TYPE_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setUsername(@Nullable String value) {
             this.username = value;
-            this._bits |= USERNAME_SET;
+            if (this._bits.length > USERNAME_INDEX) {
+                this._bits[USERNAME_INDEX] = true;
+            }
             return this;
         }
 

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -37,19 +37,19 @@ public class VariableSubtitution {
     @SerializedName("mutable_copy_prop") private @Nullable Integer mutableCopyProp;
     @SerializedName("new_prop") private @Nullable Integer newProp;
 
-    static final private int ALLOC_PROP_SET = 1 << 0;
-    static final private int COPY_PROP_SET = 1 << 1;
-    static final private int MUTABLE_COPY_PROP_SET = 1 << 2;
-    static final private int NEW_PROP_SET = 1 << 3;
+    static final private int ALLOC_PROP_INDEX = 0;
+    static final private int COPY_PROP_INDEX = 1;
+    static final private int MUTABLE_COPY_PROP_INDEX = 2;
+    static final private int NEW_PROP_INDEX = 3;
 
-    private int _bits = 0;
+    private boolean[] _bits = new boolean[4];
 
     private VariableSubtitution(
         @Nullable Integer allocProp,
         @Nullable Integer copyProp,
         @Nullable Integer mutableCopyProp,
         @Nullable Integer newProp,
-        int _bits
+        boolean[] _bits
     ) {
         this.allocProp = allocProp;
         this.copyProp = copyProp;
@@ -112,19 +112,19 @@ public class VariableSubtitution {
     }
 
     public boolean getAllocPropIsSet() {
-        return (this._bits & ALLOC_PROP_SET) == ALLOC_PROP_SET;
+        return this._bits.length > ALLOC_PROP_INDEX && this._bits[ALLOC_PROP_INDEX];
     }
 
     public boolean getCopyPropIsSet() {
-        return (this._bits & COPY_PROP_SET) == COPY_PROP_SET;
+        return this._bits.length > COPY_PROP_INDEX && this._bits[COPY_PROP_INDEX];
     }
 
     public boolean getMutableCopyPropIsSet() {
-        return (this._bits & MUTABLE_COPY_PROP_SET) == MUTABLE_COPY_PROP_SET;
+        return this._bits.length > MUTABLE_COPY_PROP_INDEX && this._bits[MUTABLE_COPY_PROP_INDEX];
     }
 
     public boolean getNewPropIsSet() {
-        return (this._bits & NEW_PROP_SET) == NEW_PROP_SET;
+        return this._bits.length > NEW_PROP_INDEX && this._bits[NEW_PROP_INDEX];
     }
 
     public static class Builder {
@@ -134,7 +134,7 @@ public class VariableSubtitution {
         @SerializedName("mutable_copy_prop") private @Nullable Integer mutableCopyProp;
         @SerializedName("new_prop") private @Nullable Integer newProp;
 
-        private int _bits = 0;
+        private boolean[] _bits = new boolean[4];
 
         private Builder() {
         }
@@ -149,25 +149,33 @@ public class VariableSubtitution {
 
         public Builder setAllocProp(@Nullable Integer value) {
             this.allocProp = value;
-            this._bits |= ALLOC_PROP_SET;
+            if (this._bits.length > ALLOC_PROP_INDEX) {
+                this._bits[ALLOC_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setCopyProp(@Nullable Integer value) {
             this.copyProp = value;
-            this._bits |= COPY_PROP_SET;
+            if (this._bits.length > COPY_PROP_INDEX) {
+                this._bits[COPY_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setMutableCopyProp(@Nullable Integer value) {
             this.mutableCopyProp = value;
-            this._bits |= MUTABLE_COPY_PROP_SET;
+            if (this._bits.length > MUTABLE_COPY_PROP_INDEX) {
+                this._bits[MUTABLE_COPY_PROP_INDEX] = true;
+            }
             return this;
         }
 
         public Builder setNewProp(@Nullable Integer value) {
             this.newProp = value;
-            this._bits |= NEW_PROP_SET;
+            if (this._bits.length > NEW_PROP_INDEX) {
+                this._bits[NEW_PROP_INDEX] = true;
+            }
             return this;
         }
 

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -14,6 +14,7 @@ struct JavaModifier: OptionSet {
     static let final = JavaModifier(rawValue: 1 << 2)
     static let `static` = JavaModifier(rawValue: 1 << 3)
     static let `private` = JavaModifier(rawValue: 1 << 4)
+    static let transient = JavaModifier(rawValue: 1 << 5)
 
     func render() -> String {
         return [
@@ -22,6 +23,7 @@ struct JavaModifier: OptionSet {
             self.contains(.static) ? "static" : "",
             self.contains(.final) ? "final" : "",
             self.contains(.private) ? "private" : "",
+            self.contains(.transient) ? "transient" : "",
         ].filter { $0 != "" }.joined(separator: " ")
     }
 }

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -21,7 +21,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
     func renderModelConstructor() -> JavaIR.Method {
         let args = -->(transitiveProperties.map { param, schemaObj in
             self.typeFromSchema(param, schemaObj) + " " + Languages.java.snakeCaseToPropertyName(param) + ","
-        } + ["int _bits"])
+        } + ["boolean[] _bits"])
 
         return JavaIR.method([.private], className + "(\n" + args + "\n)") {
             self.transitiveProperties.map { param, _ in
@@ -68,12 +68,12 @@ public struct JavaModelRenderer: JavaFileRenderer {
             JavaIR.Property(annotations: [.serializedName(name: param)], modifiers: [.private], type: self.typeFromSchema(param, schemaObj), name: Languages.java.snakeCaseToPropertyName(param), initialValue: "")
         }
 
-        let bits = JavaIR.Property(annotations: [], modifiers: [.private], type: "int", name: "_bits", initialValue: "0")
+        let bits = JavaIR.Property(annotations: [], modifiers: [.private], type: "boolean[]", name: "_bits", initialValue: "new boolean[" + String(props.count) + "]")
 
         var bitmasks: [JavaIR.Property] = []
         var index = 0
         transitiveProperties.forEach { param, _ in
-            bitmasks.append(JavaIR.Property(annotations: [], modifiers: [.private, .static, .final], type: "int", name: param.uppercased() + "_SET", initialValue: "1 << " + String(index)))
+            bitmasks.append(JavaIR.Property(annotations: [], modifiers: [.private, .static, .final], type: "int", name: param.uppercased() + "_INDEX", initialValue: String(index)))
             index += 1
         }
 
@@ -120,7 +120,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
     func renderModelIsSetCheckers(modifiers: JavaModifier = [.public]) -> [JavaIR.Method] {
         let getters = transitiveProperties.map { param, _ in
             JavaIR.method(modifiers, "boolean get" + Languages.java.snakeCaseToCapitalizedPropertyName(param) + "IsSet()") { [
-                "return (this._bits & " + param.uppercased() + "_SET) == " + param.uppercased() + "_SET;",
+                "return this._bits.length > " + param.uppercased() + "_INDEX && this._bits[" + param.uppercased() + "_INDEX];",
             ] }
         }
         return getters
@@ -178,7 +178,9 @@ public struct JavaModelRenderer: JavaFileRenderer {
         let setters = transitiveProperties.map { param, schemaObj in
             JavaIR.method(modifiers, "Builder set\(Languages.java.snakeCaseToCapitalizedPropertyName(param))(\(self.typeFromSchema(param, schemaObj)) value)") { [
                 "this." + Languages.java.snakeCaseToPropertyName(param) + " = value;",
-                "this._bits |= " + param.uppercased() + "_SET;",
+                JavaIR.ifBlock(condition: "this._bits.length > " + param.uppercased() + "_INDEX") { [
+                    "this._bits[" + param.uppercased() + "_INDEX] = true;",
+                ] },
                 "return this;",
             ] }
         }
@@ -199,7 +201,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
             JavaIR.Property(annotations: [.serializedName(name: param)], modifiers: [.private], type: self.typeFromSchema(param, schemaObj), name: Languages.java.snakeCaseToPropertyName(param), initialValue: "")
         }
 
-        let bits = JavaIR.Property(annotations: [], modifiers: [.private], type: "int", name: "_bits", initialValue: "0")
+        let bits = JavaIR.Property(annotations: [], modifiers: [.private], type: "boolean[]", name: "_bits", initialValue: "new boolean[" + String(props.count) + "]")
 
         return [props, [bits]]
     }


### PR DESCRIPTION
Replaces an implementation based on a bitmask on `int _bits` which overflows once there are more than 32 properties.

I've replaced it with a `boolean[]`.

I initially wanted to use a `BitSet` but test libraries such as `Podam` are having bad interactions with it. 