### PR TITLE
Java Model Decorators (beta)

### DIFF
--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -410,7 +410,8 @@ public class Everything {
         return this.arrayProp;
     }
 
-    public @NonNull Boolean getBooleanProp() {
+    @NonNull
+    public Boolean getBooleanProp() {
         return this.booleanProp == null ? Boolean.FALSE : this.booleanProp;
     }
 
@@ -426,7 +427,8 @@ public class Everything {
         return this.intEnum;
     }
 
-    public @NonNull Integer getIntProp() {
+    @NonNull
+    public Integer getIntProp() {
         return this.intProp == null ? 0 : this.intProp;
     }
 
@@ -490,7 +492,8 @@ public class Everything {
         return this.nsuintegerEnum;
     }
 
-    public @NonNull Double getNumberProp() {
+    @NonNull
+    public Double getNumberProp() {
         return this.numberProp == null ? 0 : this.numberProp;
     }
 

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -89,7 +89,8 @@ public class Image {
         width);
     }
 
-    public @NonNull Integer getHeight() {
+    @NonNull
+    public Integer getHeight() {
         return this.height == null ? 0 : this.height;
     }
 
@@ -97,7 +98,8 @@ public class Image {
         return this.url;
     }
 
-    public @NonNull Integer getWidth() {
+    @NonNull
+    public Integer getWidth() {
         return this.width == null ? 0 : this.width;
     }
 

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -95,19 +95,23 @@ public class VariableSubtitution {
         newProp);
     }
 
-    public @NonNull Integer getAllocProp() {
+    @NonNull
+    public Integer getAllocProp() {
         return this.allocProp == null ? 0 : this.allocProp;
     }
 
-    public @NonNull Integer getCopyProp() {
+    @NonNull
+    public Integer getCopyProp() {
         return this.copyProp == null ? 0 : this.copyProp;
     }
 
-    public @NonNull Integer getMutableCopyProp() {
+    @NonNull
+    public Integer getMutableCopyProp() {
         return this.mutableCopyProp == null ? 0 : this.mutableCopyProp;
     }
 
-    public @NonNull Integer getNewProp() {
+    @NonNull
+    public Integer getNewProp() {
         return this.newProp == null ? 0 : this.newProp;
     }
 

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -21,6 +21,7 @@ public enum GenerationParameterType {
     case packageName
     case javaNullabilityAnnotationType
     case javaGeneratePackagePrivateSetters
+    case javaDecorations
 }
 
 // Most of these are derived from https://www.binpress.com/tutorial/objective-c-reserved-keywords/43

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -19,6 +19,7 @@ enum FlagOptions: String {
     case javaPackageName = "java_package_name"
     case javaNullabilityAnnotationType = "java_nullability_annotation_type"
     case javaGeneratePackagePrivateSetters = "java_generate_package_private_setters_beta"
+    case javaDecorations = "java_decorations_beta"
     case printDeps = "print_deps"
     case noRecursive = "no_recursive"
     case noRuntime = "no_runtime"
@@ -43,6 +44,7 @@ enum FlagOptions: String {
         case .javaPackageName: return true
         case .javaNullabilityAnnotationType: return true
         case .javaGeneratePackagePrivateSetters: return false
+        case .javaDecorations: return true
         }
     }
 }
@@ -67,6 +69,7 @@ extension FlagOptions: HelpCommandOutput {
             "    --\(FlagOptions.javaPackageName.rawValue) - The package name to associate with generated Java sources",
             "    --\(FlagOptions.javaNullabilityAnnotationType.rawValue) - The type of nullability annotations to use. Can be either \"android-support\" (default) or \"androidx\".",
             "    --\(FlagOptions.javaGeneratePackagePrivateSetters.rawValue) - Generate package-private setter methods (beta)",
+            "    --\(FlagOptions.javaDecorations.rawValue) - Custom decorations to apply to the generated Java model (beta).",
         ].joined(separator: "\n")
     }
 }
@@ -152,6 +155,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     let packageName: String? = flags[.javaPackageName]
     let javaNullabilityAnnotationType: String? = flags[.javaNullabilityAnnotationType]
     let javaGeneratePackagePrivateSetters: String? = (flags[.javaGeneratePackagePrivateSetters] == nil) ? .none : .some("")
+    let javaDecorations: String? = flags[.javaDecorations]
 
     let generationParameters: GenerationParameters = [
         (.recursive, recursive),
@@ -161,6 +165,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
         (.packageName, packageName),
         (.javaNullabilityAnnotationType, javaNullabilityAnnotationType),
         (.javaGeneratePackagePrivateSetters, javaGeneratePackagePrivateSetters),
+        (.javaDecorations, javaDecorations),
     ].reduce([:]) { (dict: GenerationParameters, tuple: (GenerationParameterType, String?)) in
         var mutableDict = dict
         if let val = tuple.1 {


### PR DESCRIPTION
Adds the ability to pass in an accompanying decorations file for:
- Extending a class
- Implementing interfaces
- Adding annotations to the class, property variables, property getters, other methods
- Specifying additional imports

Example usage:
`plank --lang=java --java_decorations_beta=decorations.json my_model.json`

**decorations.json:**

```
{
    "class": {
        "extends": "BaseModel",
        "implements": ["ModelInterface"],
        "annotations": ["CustomAnnotation"]
    },
    "constructor" : {
        "annotations": ["CustomAnnotation"]
    },
    "properties": {
        "my_property": {
            "variable": {
                "annotations": ["CustomAnnotation"]
            },
            "getter": {
                "annotations": ["CustomAnnotation"]
            }
        }
    },
    "methods": {
        "mergeFrom": {
            "annotations": ["CustomAnnotation"]
        }
    },
    "imports": [
        "com.test.package.BaseModel",
        "com.test.package.ModelInterface",
        "com.test.package.CustomAnnotation"
    ]
}
```