### PR TITLE
Missing call to set tracking isSet-bit in Java model merging

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -382,33 +382,63 @@ public class Board {
         public void mergeFrom(Board model) {
             if (model.getUidIsSet()) {
                 this.uid = model.uid;
+                if (this._bits.length > ID_INDEX) {
+                    this._bits[ID_INDEX] = true;
+                }
             }
             if (model.getContributorsIsSet()) {
                 this.contributors = model.contributors;
+                if (this._bits.length > CONTRIBUTORS_INDEX) {
+                    this._bits[CONTRIBUTORS_INDEX] = true;
+                }
             }
             if (model.getCountsIsSet()) {
                 this.counts = model.counts;
+                if (this._bits.length > COUNTS_INDEX) {
+                    this._bits[COUNTS_INDEX] = true;
+                }
             }
             if (model.getCreatedAtIsSet()) {
                 this.createdAt = model.createdAt;
+                if (this._bits.length > CREATED_AT_INDEX) {
+                    this._bits[CREATED_AT_INDEX] = true;
+                }
             }
             if (model.getCreatorIsSet()) {
                 this.creator = model.creator;
+                if (this._bits.length > CREATOR_INDEX) {
+                    this._bits[CREATOR_INDEX] = true;
+                }
             }
             if (model.getCreatorURLIsSet()) {
                 this.creatorURL = model.creatorURL;
+                if (this._bits.length > CREATOR_URL_INDEX) {
+                    this._bits[CREATOR_URL_INDEX] = true;
+                }
             }
             if (model.getDescriptionIsSet()) {
                 this.description = model.description;
+                if (this._bits.length > DESCRIPTION_INDEX) {
+                    this._bits[DESCRIPTION_INDEX] = true;
+                }
             }
             if (model.getImageIsSet()) {
                 this.image = model.image;
+                if (this._bits.length > IMAGE_INDEX) {
+                    this._bits[IMAGE_INDEX] = true;
+                }
             }
             if (model.getNameIsSet()) {
                 this.name = model.name;
+                if (this._bits.length > NAME_INDEX) {
+                    this._bits[NAME_INDEX] = true;
+                }
             }
             if (model.getUrlIsSet()) {
                 this.url = model.url;
+                if (this._bits.length > URL_INDEX) {
+                    this._bits[URL_INDEX] = true;
+                }
             }
         }
     }

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -1255,111 +1255,219 @@ public class Everything {
         public void mergeFrom(Everything model) {
             if (model.getArrayPropIsSet()) {
                 this.arrayProp = model.arrayProp;
+                if (this._bits.length > ARRAY_PROP_INDEX) {
+                    this._bits[ARRAY_PROP_INDEX] = true;
+                }
             }
             if (model.getBooleanPropIsSet()) {
                 this.booleanProp = model.booleanProp;
+                if (this._bits.length > BOOLEAN_PROP_INDEX) {
+                    this._bits[BOOLEAN_PROP_INDEX] = true;
+                }
             }
             if (model.getCharEnumIsSet()) {
                 this.charEnum = model.charEnum;
+                if (this._bits.length > CHAR_ENUM_INDEX) {
+                    this._bits[CHAR_ENUM_INDEX] = true;
+                }
             }
             if (model.getDatePropIsSet()) {
                 this.dateProp = model.dateProp;
+                if (this._bits.length > DATE_PROP_INDEX) {
+                    this._bits[DATE_PROP_INDEX] = true;
+                }
             }
             if (model.getIntEnumIsSet()) {
                 this.intEnum = model.intEnum;
+                if (this._bits.length > INT_ENUM_INDEX) {
+                    this._bits[INT_ENUM_INDEX] = true;
+                }
             }
             if (model.getIntPropIsSet()) {
                 this.intProp = model.intProp;
+                if (this._bits.length > INT_PROP_INDEX) {
+                    this._bits[INT_PROP_INDEX] = true;
+                }
             }
             if (model.getListPolymorphicValuesIsSet()) {
                 this.listPolymorphicValues = model.listPolymorphicValues;
+                if (this._bits.length > LIST_POLYMORPHIC_VALUES_INDEX) {
+                    this._bits[LIST_POLYMORPHIC_VALUES_INDEX] = true;
+                }
             }
             if (model.getListWithListAndOtherModelValuesIsSet()) {
                 this.listWithListAndOtherModelValues = model.listWithListAndOtherModelValues;
+                if (this._bits.length > LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX) {
+                    this._bits[LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX] = true;
+                }
             }
             if (model.getListWithMapAndOtherModelValuesIsSet()) {
                 this.listWithMapAndOtherModelValues = model.listWithMapAndOtherModelValues;
+                if (this._bits.length > LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX) {
+                    this._bits[LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX] = true;
+                }
             }
             if (model.getListWithObjectValuesIsSet()) {
                 this.listWithObjectValues = model.listWithObjectValues;
+                if (this._bits.length > LIST_WITH_OBJECT_VALUES_INDEX) {
+                    this._bits[LIST_WITH_OBJECT_VALUES_INDEX] = true;
+                }
             }
             if (model.getListWithOtherModelValuesIsSet()) {
                 this.listWithOtherModelValues = model.listWithOtherModelValues;
+                if (this._bits.length > LIST_WITH_OTHER_MODEL_VALUES_INDEX) {
+                    this._bits[LIST_WITH_OTHER_MODEL_VALUES_INDEX] = true;
+                }
             }
             if (model.getListWithPrimitiveValuesIsSet()) {
                 this.listWithPrimitiveValues = model.listWithPrimitiveValues;
+                if (this._bits.length > LIST_WITH_PRIMITIVE_VALUES_INDEX) {
+                    this._bits[LIST_WITH_PRIMITIVE_VALUES_INDEX] = true;
+                }
             }
             if (model.getMapPolymorphicValuesIsSet()) {
                 this.mapPolymorphicValues = model.mapPolymorphicValues;
+                if (this._bits.length > MAP_POLYMORPHIC_VALUES_INDEX) {
+                    this._bits[MAP_POLYMORPHIC_VALUES_INDEX] = true;
+                }
             }
             if (model.getMapPropIsSet()) {
                 this.mapProp = model.mapProp;
+                if (this._bits.length > MAP_PROP_INDEX) {
+                    this._bits[MAP_PROP_INDEX] = true;
+                }
             }
             if (model.getMapWithListAndOtherModelValuesIsSet()) {
                 this.mapWithListAndOtherModelValues = model.mapWithListAndOtherModelValues;
+                if (this._bits.length > MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX) {
+                    this._bits[MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX] = true;
+                }
             }
             if (model.getMapWithMapAndOtherModelValuesIsSet()) {
                 this.mapWithMapAndOtherModelValues = model.mapWithMapAndOtherModelValues;
+                if (this._bits.length > MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX) {
+                    this._bits[MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX] = true;
+                }
             }
             if (model.getMapWithObjectValuesIsSet()) {
                 this.mapWithObjectValues = model.mapWithObjectValues;
+                if (this._bits.length > MAP_WITH_OBJECT_VALUES_INDEX) {
+                    this._bits[MAP_WITH_OBJECT_VALUES_INDEX] = true;
+                }
             }
             if (model.getMapWithOtherModelValuesIsSet()) {
                 this.mapWithOtherModelValues = model.mapWithOtherModelValues;
+                if (this._bits.length > MAP_WITH_OTHER_MODEL_VALUES_INDEX) {
+                    this._bits[MAP_WITH_OTHER_MODEL_VALUES_INDEX] = true;
+                }
             }
             if (model.getMapWithPrimitiveValuesIsSet()) {
                 this.mapWithPrimitiveValues = model.mapWithPrimitiveValues;
+                if (this._bits.length > MAP_WITH_PRIMITIVE_VALUES_INDEX) {
+                    this._bits[MAP_WITH_PRIMITIVE_VALUES_INDEX] = true;
+                }
             }
             if (model.getNsintegerEnumIsSet()) {
                 this.nsintegerEnum = model.nsintegerEnum;
+                if (this._bits.length > NSINTEGER_ENUM_INDEX) {
+                    this._bits[NSINTEGER_ENUM_INDEX] = true;
+                }
             }
             if (model.getNsuintegerEnumIsSet()) {
                 this.nsuintegerEnum = model.nsuintegerEnum;
+                if (this._bits.length > NSUINTEGER_ENUM_INDEX) {
+                    this._bits[NSUINTEGER_ENUM_INDEX] = true;
+                }
             }
             if (model.getNumberPropIsSet()) {
                 this.numberProp = model.numberProp;
+                if (this._bits.length > NUMBER_PROP_INDEX) {
+                    this._bits[NUMBER_PROP_INDEX] = true;
+                }
             }
             if (model.getOtherModelPropIsSet()) {
                 this.otherModelProp = model.otherModelProp;
+                if (this._bits.length > OTHER_MODEL_PROP_INDEX) {
+                    this._bits[OTHER_MODEL_PROP_INDEX] = true;
+                }
             }
             if (model.getPolymorphicPropIsSet()) {
                 this.polymorphicProp = model.polymorphicProp;
+                if (this._bits.length > POLYMORPHIC_PROP_INDEX) {
+                    this._bits[POLYMORPHIC_PROP_INDEX] = true;
+                }
             }
             if (model.getSetPropIsSet()) {
                 this.setProp = model.setProp;
+                if (this._bits.length > SET_PROP_INDEX) {
+                    this._bits[SET_PROP_INDEX] = true;
+                }
             }
             if (model.getSetPropWithOtherModelValuesIsSet()) {
                 this.setPropWithOtherModelValues = model.setPropWithOtherModelValues;
+                if (this._bits.length > SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX) {
+                    this._bits[SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX] = true;
+                }
             }
             if (model.getSetPropWithPrimitiveValuesIsSet()) {
                 this.setPropWithPrimitiveValues = model.setPropWithPrimitiveValues;
+                if (this._bits.length > SET_PROP_WITH_PRIMITIVE_VALUES_INDEX) {
+                    this._bits[SET_PROP_WITH_PRIMITIVE_VALUES_INDEX] = true;
+                }
             }
             if (model.getSetPropWithValuesIsSet()) {
                 this.setPropWithValues = model.setPropWithValues;
+                if (this._bits.length > SET_PROP_WITH_VALUES_INDEX) {
+                    this._bits[SET_PROP_WITH_VALUES_INDEX] = true;
+                }
             }
             if (model.getShortEnumIsSet()) {
                 this.shortEnum = model.shortEnum;
+                if (this._bits.length > SHORT_ENUM_INDEX) {
+                    this._bits[SHORT_ENUM_INDEX] = true;
+                }
             }
             if (model.getStringEnumIsSet()) {
                 this.stringEnum = model.stringEnum;
+                if (this._bits.length > STRING_ENUM_INDEX) {
+                    this._bits[STRING_ENUM_INDEX] = true;
+                }
             }
             if (model.getStringPropIsSet()) {
                 this.stringProp = model.stringProp;
+                if (this._bits.length > STRING_PROP_INDEX) {
+                    this._bits[STRING_PROP_INDEX] = true;
+                }
             }
             if (model.getTypeIsSet()) {
                 this.type = model.type;
+                if (this._bits.length > TYPE_INDEX) {
+                    this._bits[TYPE_INDEX] = true;
+                }
             }
             if (model.getUnsignedCharEnumIsSet()) {
                 this.unsignedCharEnum = model.unsignedCharEnum;
+                if (this._bits.length > UNSIGNED_CHAR_ENUM_INDEX) {
+                    this._bits[UNSIGNED_CHAR_ENUM_INDEX] = true;
+                }
             }
             if (model.getUnsignedIntEnumIsSet()) {
                 this.unsignedIntEnum = model.unsignedIntEnum;
+                if (this._bits.length > UNSIGNED_INT_ENUM_INDEX) {
+                    this._bits[UNSIGNED_INT_ENUM_INDEX] = true;
+                }
             }
             if (model.getUnsignedShortEnumIsSet()) {
                 this.unsignedShortEnum = model.unsignedShortEnum;
+                if (this._bits.length > UNSIGNED_SHORT_ENUM_INDEX) {
+                    this._bits[UNSIGNED_SHORT_ENUM_INDEX] = true;
+                }
             }
             if (model.getUriPropIsSet()) {
                 this.uriProp = model.uriProp;
+                if (this._bits.length > URI_PROP_INDEX) {
+                    this._bits[URI_PROP_INDEX] = true;
+                }
             }
         }
     }

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -179,12 +179,21 @@ public class Image {
         public void mergeFrom(Image model) {
             if (model.getHeightIsSet()) {
                 this.height = model.height;
+                if (this._bits.length > HEIGHT_INDEX) {
+                    this._bits[HEIGHT_INDEX] = true;
+                }
             }
             if (model.getUrlIsSet()) {
                 this.url = model.url;
+                if (this._bits.length > URL_INDEX) {
+                    this._bits[URL_INDEX] = true;
+                }
             }
             if (model.getWidthIsSet()) {
                 this.width = model.width;
+                if (this._bits.length > WIDTH_INDEX) {
+                    this._bits[WIDTH_INDEX] = true;
+                }
             }
         }
     }

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -121,6 +121,9 @@ public class Model {
         public void mergeFrom(Model model) {
             if (model.getUidIsSet()) {
                 this.uid = model.uid;
+                if (this._bits.length > ID_INDEX) {
+                    this._bits[ID_INDEX] = true;
+                }
             }
         }
     }

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -603,54 +603,105 @@ public class Pin {
         public void mergeFrom(Pin model) {
             if (model.getAttributionIsSet()) {
                 this.attribution = model.attribution;
+                if (this._bits.length > ATTRIBUTION_INDEX) {
+                    this._bits[ATTRIBUTION_INDEX] = true;
+                }
             }
             if (model.getAttributionObjectsIsSet()) {
                 this.attributionObjects = model.attributionObjects;
+                if (this._bits.length > ATTRIBUTION_OBJECTS_INDEX) {
+                    this._bits[ATTRIBUTION_OBJECTS_INDEX] = true;
+                }
             }
             if (model.getBoardIsSet()) {
                 this.board = model.board;
+                if (this._bits.length > BOARD_INDEX) {
+                    this._bits[BOARD_INDEX] = true;
+                }
             }
             if (model.getColorIsSet()) {
                 this.color = model.color;
+                if (this._bits.length > COLOR_INDEX) {
+                    this._bits[COLOR_INDEX] = true;
+                }
             }
             if (model.getCountsIsSet()) {
                 this.counts = model.counts;
+                if (this._bits.length > COUNTS_INDEX) {
+                    this._bits[COUNTS_INDEX] = true;
+                }
             }
             if (model.getCreatedAtIsSet()) {
                 this.createdAt = model.createdAt;
+                if (this._bits.length > CREATED_AT_INDEX) {
+                    this._bits[CREATED_AT_INDEX] = true;
+                }
             }
             if (model.getCreatorIsSet()) {
                 this.creator = model.creator;
+                if (this._bits.length > CREATOR_INDEX) {
+                    this._bits[CREATOR_INDEX] = true;
+                }
             }
             if (model.getDescriptionIsSet()) {
                 this.description = model.description;
+                if (this._bits.length > DESCRIPTION_INDEX) {
+                    this._bits[DESCRIPTION_INDEX] = true;
+                }
             }
             if (model.getUidIsSet()) {
                 this.uid = model.uid;
+                if (this._bits.length > ID_INDEX) {
+                    this._bits[ID_INDEX] = true;
+                }
             }
             if (model.getImageIsSet()) {
                 this.image = model.image;
+                if (this._bits.length > IMAGE_INDEX) {
+                    this._bits[IMAGE_INDEX] = true;
+                }
             }
             if (model.getInStockIsSet()) {
                 this.inStock = model.inStock;
+                if (this._bits.length > IN_STOCK_INDEX) {
+                    this._bits[IN_STOCK_INDEX] = true;
+                }
             }
             if (model.getLinkIsSet()) {
                 this.link = model.link;
+                if (this._bits.length > LINK_INDEX) {
+                    this._bits[LINK_INDEX] = true;
+                }
             }
             if (model.getMediaIsSet()) {
                 this.media = model.media;
+                if (this._bits.length > MEDIA_INDEX) {
+                    this._bits[MEDIA_INDEX] = true;
+                }
             }
             if (model.getNoteIsSet()) {
                 this.note = model.note;
+                if (this._bits.length > NOTE_INDEX) {
+                    this._bits[NOTE_INDEX] = true;
+                }
             }
             if (model.getTagsIsSet()) {
                 this.tags = model.tags;
+                if (this._bits.length > TAGS_INDEX) {
+                    this._bits[TAGS_INDEX] = true;
+                }
             }
             if (model.getUrlIsSet()) {
                 this.url = model.url;
+                if (this._bits.length > URL_INDEX) {
+                    this._bits[URL_INDEX] = true;
+                }
             }
             if (model.getVisualSearchAttrsIsSet()) {
                 this.visualSearchAttrs = model.visualSearchAttrs;
+                if (this._bits.length > VISUAL_SEARCH_ATTRS_INDEX) {
+                    this._bits[VISUAL_SEARCH_ATTRS_INDEX] = true;
+                }
             }
         }
     }

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -386,33 +386,63 @@ public class User {
         public void mergeFrom(User model) {
             if (model.getBioIsSet()) {
                 this.bio = model.bio;
+                if (this._bits.length > BIO_INDEX) {
+                    this._bits[BIO_INDEX] = true;
+                }
             }
             if (model.getCountsIsSet()) {
                 this.counts = model.counts;
+                if (this._bits.length > COUNTS_INDEX) {
+                    this._bits[COUNTS_INDEX] = true;
+                }
             }
             if (model.getCreatedAtIsSet()) {
                 this.createdAt = model.createdAt;
+                if (this._bits.length > CREATED_AT_INDEX) {
+                    this._bits[CREATED_AT_INDEX] = true;
+                }
             }
             if (model.getEmailFrequencyIsSet()) {
                 this.emailFrequency = model.emailFrequency;
+                if (this._bits.length > EMAIL_FREQUENCY_INDEX) {
+                    this._bits[EMAIL_FREQUENCY_INDEX] = true;
+                }
             }
             if (model.getFirstNameIsSet()) {
                 this.firstName = model.firstName;
+                if (this._bits.length > FIRST_NAME_INDEX) {
+                    this._bits[FIRST_NAME_INDEX] = true;
+                }
             }
             if (model.getUidIsSet()) {
                 this.uid = model.uid;
+                if (this._bits.length > ID_INDEX) {
+                    this._bits[ID_INDEX] = true;
+                }
             }
             if (model.getImageIsSet()) {
                 this.image = model.image;
+                if (this._bits.length > IMAGE_INDEX) {
+                    this._bits[IMAGE_INDEX] = true;
+                }
             }
             if (model.getLastNameIsSet()) {
                 this.lastName = model.lastName;
+                if (this._bits.length > LAST_NAME_INDEX) {
+                    this._bits[LAST_NAME_INDEX] = true;
+                }
             }
             if (model.getTypeIsSet()) {
                 this.type = model.type;
+                if (this._bits.length > TYPE_INDEX) {
+                    this._bits[TYPE_INDEX] = true;
+                }
             }
             if (model.getUsernameIsSet()) {
                 this.username = model.username;
+                if (this._bits.length > USERNAME_INDEX) {
+                    this._bits[USERNAME_INDEX] = true;
+                }
             }
         }
     }

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -208,15 +208,27 @@ public class VariableSubtitution {
         public void mergeFrom(VariableSubtitution model) {
             if (model.getAllocPropIsSet()) {
                 this.allocProp = model.allocProp;
+                if (this._bits.length > ALLOC_PROP_INDEX) {
+                    this._bits[ALLOC_PROP_INDEX] = true;
+                }
             }
             if (model.getCopyPropIsSet()) {
                 this.copyProp = model.copyProp;
+                if (this._bits.length > COPY_PROP_INDEX) {
+                    this._bits[COPY_PROP_INDEX] = true;
+                }
             }
             if (model.getMutableCopyPropIsSet()) {
                 this.mutableCopyProp = model.mutableCopyProp;
+                if (this._bits.length > MUTABLE_COPY_PROP_INDEX) {
+                    this._bits[MUTABLE_COPY_PROP_INDEX] = true;
+                }
             }
             if (model.getNewPropIsSet()) {
                 this.newProp = model.newProp;
+                if (this._bits.length > NEW_PROP_INDEX) {
+                    this._bits[NEW_PROP_INDEX] = true;
+                }
             }
         }
     }

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -205,9 +205,12 @@ public struct JavaModelRenderer: JavaFileRenderer {
 
     func renderBuilderMerge() -> JavaIR.Method {
         let body = (transitiveProperties.map { param, _ in
-            JavaIR.ifBlock(condition: "model.get" + Languages.java.snakeCaseToCapitalizedPropertyName(param) + "IsSet()") {
-                ["this." + Languages.java.snakeCaseToPropertyName(param) + " = model." + Languages.java.snakeCaseToPropertyName(param) + ";"]
-            }
+            JavaIR.ifBlock(condition: "model.get" + Languages.java.snakeCaseToCapitalizedPropertyName(param) + "IsSet()") { [
+                "this." + Languages.java.snakeCaseToPropertyName(param) + " = model." + Languages.java.snakeCaseToPropertyName(param) + ";",
+                JavaIR.ifBlock(condition: "this._bits.length > " + param.uppercased() + "_INDEX") { [
+                    "this._bits[" + param.uppercased() + "_INDEX] = true;",
+                ] },
+            ] }
         })
         return JavaIR.method([.public], "void mergeFrom(" + className + " model)") { body }
     }


### PR DESCRIPTION
When merging models, the model that is being merged into should have its is-set bit marked as true.

Otherwise the newly created merged-model can incorrectly believe that the fields is still not set.