### PR TITLE
Java model - _bits field should be deserialized if it's present in the JSON

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -487,6 +487,7 @@ public class Board {
                 return null;
             }
             Builder builder = Board.builder();
+            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -521,11 +522,24 @@ public class Board {
                     case ("url"):
                         builder.setUrl(stringTypeAdapter.read(reader));
                         break;
+                    case ("_bits"):
+                        bits = new boolean[10];
+                        int i = 0;
+                        reader.beginArray();
+                        while (reader.hasNext() && i < 10) {
+                            bits[i] = reader.nextBoolean();
+                            i++;
+                        }
+                        reader.endArray();
+                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
+            if (bits != null) {
+                builder._bits = bits;
+            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -1573,6 +1573,7 @@ public class Everything {
                 return null;
             }
             Builder builder = Everything.builder();
+            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -1685,11 +1686,24 @@ public class Everything {
                     case ("uri_prop"):
                         builder.setUriProp(stringTypeAdapter.read(reader));
                         break;
+                    case ("_bits"):
+                        bits = new boolean[36];
+                        int i = 0;
+                        reader.beginArray();
+                        while (reader.hasNext() && i < 36) {
+                            bits[i] = reader.nextBoolean();
+                            i++;
+                        }
+                        reader.endArray();
+                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
+            if (bits != null) {
+                builder._bits = bits;
+            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -236,6 +236,7 @@ public class Image {
                 return null;
             }
             Builder builder = Image.builder();
+            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -249,11 +250,24 @@ public class Image {
                     case ("width"):
                         builder.setWidth(integerTypeAdapter.read(reader));
                         break;
+                    case ("_bits"):
+                        bits = new boolean[3];
+                        int i = 0;
+                        reader.beginArray();
+                        while (reader.hasNext() && i < 3) {
+                            bits[i] = reader.nextBoolean();
+                            i++;
+                        }
+                        reader.endArray();
+                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
+            if (bits != null) {
+                builder._bits = bits;
+            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -162,6 +162,7 @@ public class Model {
                 return null;
             }
             Builder builder = Model.builder();
+            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -169,11 +170,24 @@ public class Model {
                     case ("id"):
                         builder.setUid(stringTypeAdapter.read(reader));
                         break;
+                    case ("_bits"):
+                        bits = new boolean[1];
+                        int i = 0;
+                        reader.beginArray();
+                        while (reader.hasNext() && i < 1) {
+                            bits[i] = reader.nextBoolean();
+                            i++;
+                        }
+                        reader.endArray();
+                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
+            if (bits != null) {
+                builder._bits = bits;
+            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -760,6 +760,7 @@ public class Pin {
                 return null;
             }
             Builder builder = Pin.builder();
+            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -815,11 +816,24 @@ public class Pin {
                     case ("visual_search_attrs"):
                         builder.setVisualSearchAttrs(map_String__Object_TypeAdapter.read(reader));
                         break;
+                    case ("_bits"):
+                        bits = new boolean[17];
+                        int i = 0;
+                        reader.beginArray();
+                        while (reader.hasNext() && i < 17) {
+                            bits[i] = reader.nextBoolean();
+                            i++;
+                        }
+                        reader.endArray();
+                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
+            if (bits != null) {
+                builder._bits = bits;
+            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -489,6 +489,7 @@ public class User {
                 return null;
             }
             Builder builder = User.builder();
+            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -523,11 +524,24 @@ public class User {
                     case ("username"):
                         builder.setUsername(stringTypeAdapter.read(reader));
                         break;
+                    case ("_bits"):
+                        bits = new boolean[10];
+                        int i = 0;
+                        reader.beginArray();
+                        while (reader.hasNext() && i < 10) {
+                            bits[i] = reader.nextBoolean();
+                            i++;
+                        }
+                        reader.endArray();
+                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
+            if (bits != null) {
+                builder._bits = bits;
+            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -271,6 +271,7 @@ public class VariableSubtitution {
                 return null;
             }
             Builder builder = VariableSubtitution.builder();
+            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -287,11 +288,24 @@ public class VariableSubtitution {
                     case ("new_prop"):
                         builder.setNewProp(integerTypeAdapter.read(reader));
                         break;
+                    case ("_bits"):
+                        bits = new boolean[4];
+                        int i = 0;
+                        reader.beginArray();
+                        while (reader.hasNext() && i < 4) {
+                            bits[i] = reader.nextBoolean();
+                            i++;
+                        }
+                        reader.endArray();
+                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
+            if (bits != null) {
+                builder._bits = bits;
+            }
             return builder.build();
         }
     }


### PR DESCRIPTION
If the model is serialized to JSON, the `_bits` field will be included in the output, unless an exclusion strategy is applied (no exclusion strategy is applied by default). When deserializing, we should respect the value of the `_bits` field if it's present in the JSON.