### PR TITLE
Java models should not include null fields when serialized into Json

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -478,6 +478,7 @@ public class Board {
 
         @Override
         public void write(JsonWriter writer, Board value) throws IOException {
+            writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
 

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -1564,6 +1564,7 @@ public class Everything {
 
         @Override
         public void write(JsonWriter writer, Everything value) throws IOException {
+            writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
 

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -227,6 +227,7 @@ public class Image {
 
         @Override
         public void write(JsonWriter writer, Image value) throws IOException {
+            writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
 

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -153,6 +153,7 @@ public class Model {
 
         @Override
         public void write(JsonWriter writer, Model value) throws IOException {
+            writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
 

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -751,6 +751,7 @@ public class Pin {
 
         @Override
         public void write(JsonWriter writer, Pin value) throws IOException {
+            writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
 

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -480,6 +480,7 @@ public class User {
 
         @Override
         public void write(JsonWriter writer, User value) throws IOException {
+            writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
 

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -262,6 +262,7 @@ public class VariableSubtitution {
 
         @Override
         public void write(JsonWriter writer, VariableSubtitution value) throws IOException {
+            writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
 

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -306,6 +306,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
             "void write(JsonWriter writer, " + className + " value)",
             ["IOException"]
         ) { [
+            "writer.setSerializeNulls(false);",
             "this.delegateTypeAdapter.write(writer, value);",
         ] }
 


### PR DESCRIPTION
This makes the output JSON significantly more compact for models with many fields, wherein only a few of them are set.