### PR TITLE
Java model TypeAdapter should lazily instantiate its inner TypeAdapters

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -457,27 +457,29 @@ public class Board {
 
     public static class BoardTypeAdapter extends TypeAdapter<Board> {
 
-        final private TypeAdapter<Board> delegateTypeAdapter;
+        final private BoardTypeAdapterFactory factory;
+        final private Gson gson;
+        final private TypeToken typeToken;
+        private TypeAdapter<Board> delegateTypeAdapter;
 
-        final private TypeAdapter<Date> dateTypeAdapter;
-        final private TypeAdapter<Image> imageTypeAdapter;
-        final private TypeAdapter<Map<String, Integer>> map_String__Integer_TypeAdapter;
-        final private TypeAdapter<Map<String, String>> map_String__String_TypeAdapter;
-        final private TypeAdapter<Set<User>> set_User_TypeAdapter;
-        final private TypeAdapter<String> stringTypeAdapter;
+        private TypeAdapter<Date> dateTypeAdapter;
+        private TypeAdapter<Image> imageTypeAdapter;
+        private TypeAdapter<Map<String, Integer>> map_String__Integer_TypeAdapter;
+        private TypeAdapter<Map<String, String>> map_String__String_TypeAdapter;
+        private TypeAdapter<Set<User>> set_User_TypeAdapter;
+        private TypeAdapter<String> stringTypeAdapter;
 
         public BoardTypeAdapter(Gson gson, BoardTypeAdapterFactory factory, TypeToken typeToken) {
-            this.delegateTypeAdapter = gson.getDelegateAdapter(factory, typeToken);
-            this.dateTypeAdapter = gson.getAdapter(Date.class).nullSafe();
-            this.imageTypeAdapter = gson.getAdapter(Image.class).nullSafe();
-            this.map_String__Integer_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
-            this.map_String__String_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
-            this.set_User_TypeAdapter = gson.getAdapter(new TypeToken<Set<User>>(){}).nullSafe();
-            this.stringTypeAdapter = gson.getAdapter(String.class).nullSafe();
+            this.factory = factory;
+            this.gson = gson;
+            this.typeToken = typeToken;
         }
 
         @Override
         public void write(JsonWriter writer, Board value) throws IOException {
+            if (this.delegateTypeAdapter == null) {
+                this.delegateTypeAdapter = this.gson.getDelegateAdapter(this.factory, this.typeToken);
+            }
             writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
@@ -495,34 +497,64 @@ public class Board {
                 String name = reader.nextName();
                 switch (name) {
                     case ("id"):
-                        builder.setUid(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setUid(this.stringTypeAdapter.read(reader));
                         break;
                     case ("contributors"):
-                        builder.setContributors(set_User_TypeAdapter.read(reader));
+                        if (this.set_User_TypeAdapter == null) {
+                            this.set_User_TypeAdapter = this.gson.getAdapter(new TypeToken<Set<User>>(){}).nullSafe();
+                        }
+                        builder.setContributors(this.set_User_TypeAdapter.read(reader));
                         break;
                     case ("counts"):
-                        builder.setCounts(map_String__Integer_TypeAdapter.read(reader));
+                        if (this.map_String__Integer_TypeAdapter == null) {
+                            this.map_String__Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
+                        }
+                        builder.setCounts(this.map_String__Integer_TypeAdapter.read(reader));
                         break;
                     case ("created_at"):
-                        builder.setCreatedAt(dateTypeAdapter.read(reader));
+                        if (this.dateTypeAdapter == null) {
+                            this.dateTypeAdapter = this.gson.getAdapter(Date.class).nullSafe();
+                        }
+                        builder.setCreatedAt(this.dateTypeAdapter.read(reader));
                         break;
                     case ("creator"):
-                        builder.setCreator(map_String__String_TypeAdapter.read(reader));
+                        if (this.map_String__String_TypeAdapter == null) {
+                            this.map_String__String_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
+                        }
+                        builder.setCreator(this.map_String__String_TypeAdapter.read(reader));
                         break;
                     case ("creator_url"):
-                        builder.setCreatorURL(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setCreatorURL(this.stringTypeAdapter.read(reader));
                         break;
                     case ("description"):
-                        builder.setDescription(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setDescription(this.stringTypeAdapter.read(reader));
                         break;
                     case ("image"):
-                        builder.setImage(imageTypeAdapter.read(reader));
+                        if (this.imageTypeAdapter == null) {
+                            this.imageTypeAdapter = this.gson.getAdapter(Image.class).nullSafe();
+                        }
+                        builder.setImage(this.imageTypeAdapter.read(reader));
                         break;
                     case ("name"):
-                        builder.setName(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setName(this.stringTypeAdapter.read(reader));
                         break;
                     case ("url"):
-                        builder.setUrl(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setUrl(this.stringTypeAdapter.read(reader));
                         break;
                     case ("_bits"):
                         bits = new boolean[10];

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -1489,81 +1489,56 @@ public class Everything {
 
     public static class EverythingTypeAdapter extends TypeAdapter<Everything> {
 
-        final private TypeAdapter<Everything> delegateTypeAdapter;
+        final private EverythingTypeAdapterFactory factory;
+        final private Gson gson;
+        final private TypeToken typeToken;
+        private TypeAdapter<Everything> delegateTypeAdapter;
 
-        final private TypeAdapter<Boolean> booleanTypeAdapter;
-        final private TypeAdapter<Date> dateTypeAdapter;
-        final private TypeAdapter<Double> doubleTypeAdapter;
-        final private TypeAdapter<EverythingCharEnum> everythingCharEnumTypeAdapter;
-        final private TypeAdapter<EverythingIntEnum> everythingIntEnumTypeAdapter;
-        final private TypeAdapter<EverythingNsintegerEnum> everythingNsintegerEnumTypeAdapter;
-        final private TypeAdapter<EverythingNsuintegerEnum> everythingNsuintegerEnumTypeAdapter;
-        final private TypeAdapter<EverythingPolymorphicProp> everythingPolymorphicPropTypeAdapter;
-        final private TypeAdapter<EverythingShortEnum> everythingShortEnumTypeAdapter;
-        final private TypeAdapter<EverythingStringEnum> everythingStringEnumTypeAdapter;
-        final private TypeAdapter<EverythingUnsignedCharEnum> everythingUnsignedCharEnumTypeAdapter;
-        final private TypeAdapter<EverythingUnsignedIntEnum> everythingUnsignedIntEnumTypeAdapter;
-        final private TypeAdapter<EverythingUnsignedShortEnum> everythingUnsignedShortEnumTypeAdapter;
-        final private TypeAdapter<Integer> integerTypeAdapter;
-        final private TypeAdapter<List<Integer>> list_Integer_TypeAdapter;
-        final private TypeAdapter<List<List<User>>> list_List_User__TypeAdapter;
-        final private TypeAdapter<List<Map<String, User>>> list_Map_String__User__TypeAdapter;
-        final private TypeAdapter<List<Object>> list_Object_TypeAdapter;
-        final private TypeAdapter<List<String>> list_String_TypeAdapter;
-        final private TypeAdapter<List<User>> list_User_TypeAdapter;
-        final private TypeAdapter<Map<String, EverythingMapPolymorphicValues>> map_String__EverythingMapPolymorphicValues_TypeAdapter;
-        final private TypeAdapter<Map<String, Integer>> map_String__Integer_TypeAdapter;
-        final private TypeAdapter<Map<String, List<User>>> map_String__List_User__TypeAdapter;
-        final private TypeAdapter<Map<String, Map<String, Object>>> map_String__Map_String__Object__TypeAdapter;
-        final private TypeAdapter<Map<String, Object>> map_String__Object_TypeAdapter;
-        final private TypeAdapter<Map<String, String>> map_String__String_TypeAdapter;
-        final private TypeAdapter<Map<String, User>> map_String__User_TypeAdapter;
-        final private TypeAdapter<Set<Integer>> set_Integer_TypeAdapter;
-        final private TypeAdapter<Set<Object>> set_Object_TypeAdapter;
-        final private TypeAdapter<Set<String>> set_String_TypeAdapter;
-        final private TypeAdapter<Set<User>> set_User_TypeAdapter;
-        final private TypeAdapter<String> stringTypeAdapter;
-        final private TypeAdapter<User> userTypeAdapter;
+        private TypeAdapter<Boolean> booleanTypeAdapter;
+        private TypeAdapter<Date> dateTypeAdapter;
+        private TypeAdapter<Double> doubleTypeAdapter;
+        private TypeAdapter<EverythingCharEnum> everythingCharEnumTypeAdapter;
+        private TypeAdapter<EverythingIntEnum> everythingIntEnumTypeAdapter;
+        private TypeAdapter<EverythingNsintegerEnum> everythingNsintegerEnumTypeAdapter;
+        private TypeAdapter<EverythingNsuintegerEnum> everythingNsuintegerEnumTypeAdapter;
+        private TypeAdapter<EverythingPolymorphicProp> everythingPolymorphicPropTypeAdapter;
+        private TypeAdapter<EverythingShortEnum> everythingShortEnumTypeAdapter;
+        private TypeAdapter<EverythingStringEnum> everythingStringEnumTypeAdapter;
+        private TypeAdapter<EverythingUnsignedCharEnum> everythingUnsignedCharEnumTypeAdapter;
+        private TypeAdapter<EverythingUnsignedIntEnum> everythingUnsignedIntEnumTypeAdapter;
+        private TypeAdapter<EverythingUnsignedShortEnum> everythingUnsignedShortEnumTypeAdapter;
+        private TypeAdapter<Integer> integerTypeAdapter;
+        private TypeAdapter<List<Integer>> list_Integer_TypeAdapter;
+        private TypeAdapter<List<List<User>>> list_List_User__TypeAdapter;
+        private TypeAdapter<List<Map<String, User>>> list_Map_String__User__TypeAdapter;
+        private TypeAdapter<List<Object>> list_Object_TypeAdapter;
+        private TypeAdapter<List<String>> list_String_TypeAdapter;
+        private TypeAdapter<List<User>> list_User_TypeAdapter;
+        private TypeAdapter<Map<String, EverythingMapPolymorphicValues>> map_String__EverythingMapPolymorphicValues_TypeAdapter;
+        private TypeAdapter<Map<String, Integer>> map_String__Integer_TypeAdapter;
+        private TypeAdapter<Map<String, List<User>>> map_String__List_User__TypeAdapter;
+        private TypeAdapter<Map<String, Map<String, Object>>> map_String__Map_String__Object__TypeAdapter;
+        private TypeAdapter<Map<String, Object>> map_String__Object_TypeAdapter;
+        private TypeAdapter<Map<String, String>> map_String__String_TypeAdapter;
+        private TypeAdapter<Map<String, User>> map_String__User_TypeAdapter;
+        private TypeAdapter<Set<Integer>> set_Integer_TypeAdapter;
+        private TypeAdapter<Set<Object>> set_Object_TypeAdapter;
+        private TypeAdapter<Set<String>> set_String_TypeAdapter;
+        private TypeAdapter<Set<User>> set_User_TypeAdapter;
+        private TypeAdapter<String> stringTypeAdapter;
+        private TypeAdapter<User> userTypeAdapter;
 
         public EverythingTypeAdapter(Gson gson, EverythingTypeAdapterFactory factory, TypeToken typeToken) {
-            this.delegateTypeAdapter = gson.getDelegateAdapter(factory, typeToken);
-            this.booleanTypeAdapter = gson.getAdapter(Boolean.class).nullSafe();
-            this.dateTypeAdapter = gson.getAdapter(Date.class).nullSafe();
-            this.doubleTypeAdapter = gson.getAdapter(Double.class).nullSafe();
-            this.everythingCharEnumTypeAdapter = gson.getAdapter(EverythingCharEnum.class).nullSafe();
-            this.everythingIntEnumTypeAdapter = gson.getAdapter(EverythingIntEnum.class).nullSafe();
-            this.everythingNsintegerEnumTypeAdapter = gson.getAdapter(EverythingNsintegerEnum.class).nullSafe();
-            this.everythingNsuintegerEnumTypeAdapter = gson.getAdapter(EverythingNsuintegerEnum.class).nullSafe();
-            this.everythingPolymorphicPropTypeAdapter = gson.getAdapter(EverythingPolymorphicProp.class).nullSafe();
-            this.everythingShortEnumTypeAdapter = gson.getAdapter(EverythingShortEnum.class).nullSafe();
-            this.everythingStringEnumTypeAdapter = gson.getAdapter(EverythingStringEnum.class).nullSafe();
-            this.everythingUnsignedCharEnumTypeAdapter = gson.getAdapter(EverythingUnsignedCharEnum.class).nullSafe();
-            this.everythingUnsignedIntEnumTypeAdapter = gson.getAdapter(EverythingUnsignedIntEnum.class).nullSafe();
-            this.everythingUnsignedShortEnumTypeAdapter = gson.getAdapter(EverythingUnsignedShortEnum.class).nullSafe();
-            this.integerTypeAdapter = gson.getAdapter(Integer.class).nullSafe();
-            this.list_Integer_TypeAdapter = gson.getAdapter(new TypeToken<List<Integer>>(){}).nullSafe();
-            this.list_List_User__TypeAdapter = gson.getAdapter(new TypeToken<List<List<User>>>(){}).nullSafe();
-            this.list_Map_String__User__TypeAdapter = gson.getAdapter(new TypeToken<List<Map<String, User>>>(){}).nullSafe();
-            this.list_Object_TypeAdapter = gson.getAdapter(new TypeToken<List<Object>>(){}).nullSafe();
-            this.list_String_TypeAdapter = gson.getAdapter(new TypeToken<List<String>>(){}).nullSafe();
-            this.list_User_TypeAdapter = gson.getAdapter(new TypeToken<List<User>>(){}).nullSafe();
-            this.map_String__EverythingMapPolymorphicValues_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, EverythingMapPolymorphicValues>>(){}).nullSafe();
-            this.map_String__Integer_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
-            this.map_String__List_User__TypeAdapter = gson.getAdapter(new TypeToken<Map<String, List<User>>>(){}).nullSafe();
-            this.map_String__Map_String__Object__TypeAdapter = gson.getAdapter(new TypeToken<Map<String, Map<String, Object>>>(){}).nullSafe();
-            this.map_String__Object_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, Object>>(){}).nullSafe();
-            this.map_String__String_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
-            this.map_String__User_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, User>>(){}).nullSafe();
-            this.set_Integer_TypeAdapter = gson.getAdapter(new TypeToken<Set<Integer>>(){}).nullSafe();
-            this.set_Object_TypeAdapter = gson.getAdapter(new TypeToken<Set<Object>>(){}).nullSafe();
-            this.set_String_TypeAdapter = gson.getAdapter(new TypeToken<Set<String>>(){}).nullSafe();
-            this.set_User_TypeAdapter = gson.getAdapter(new TypeToken<Set<User>>(){}).nullSafe();
-            this.stringTypeAdapter = gson.getAdapter(String.class).nullSafe();
-            this.userTypeAdapter = gson.getAdapter(User.class).nullSafe();
+            this.factory = factory;
+            this.gson = gson;
+            this.typeToken = typeToken;
         }
 
         @Override
         public void write(JsonWriter writer, Everything value) throws IOException {
+            if (this.delegateTypeAdapter == null) {
+                this.delegateTypeAdapter = this.gson.getDelegateAdapter(this.factory, this.typeToken);
+            }
             writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
@@ -1581,112 +1556,220 @@ public class Everything {
                 String name = reader.nextName();
                 switch (name) {
                     case ("array_prop"):
-                        builder.setArrayProp(list_Object_TypeAdapter.read(reader));
+                        if (this.list_Object_TypeAdapter == null) {
+                            this.list_Object_TypeAdapter = this.gson.getAdapter(new TypeToken<List<Object>>(){}).nullSafe();
+                        }
+                        builder.setArrayProp(this.list_Object_TypeAdapter.read(reader));
                         break;
                     case ("boolean_prop"):
-                        builder.setBooleanProp(booleanTypeAdapter.read(reader));
+                        if (this.booleanTypeAdapter == null) {
+                            this.booleanTypeAdapter = this.gson.getAdapter(Boolean.class).nullSafe();
+                        }
+                        builder.setBooleanProp(this.booleanTypeAdapter.read(reader));
                         break;
                     case ("char_enum"):
-                        builder.setCharEnum(everythingCharEnumTypeAdapter.read(reader));
+                        if (this.everythingCharEnumTypeAdapter == null) {
+                            this.everythingCharEnumTypeAdapter = this.gson.getAdapter(EverythingCharEnum.class).nullSafe();
+                        }
+                        builder.setCharEnum(this.everythingCharEnumTypeAdapter.read(reader));
                         break;
                     case ("date_prop"):
-                        builder.setDateProp(dateTypeAdapter.read(reader));
+                        if (this.dateTypeAdapter == null) {
+                            this.dateTypeAdapter = this.gson.getAdapter(Date.class).nullSafe();
+                        }
+                        builder.setDateProp(this.dateTypeAdapter.read(reader));
                         break;
                     case ("int_enum"):
-                        builder.setIntEnum(everythingIntEnumTypeAdapter.read(reader));
+                        if (this.everythingIntEnumTypeAdapter == null) {
+                            this.everythingIntEnumTypeAdapter = this.gson.getAdapter(EverythingIntEnum.class).nullSafe();
+                        }
+                        builder.setIntEnum(this.everythingIntEnumTypeAdapter.read(reader));
                         break;
                     case ("int_prop"):
-                        builder.setIntProp(integerTypeAdapter.read(reader));
+                        if (this.integerTypeAdapter == null) {
+                            this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
+                        }
+                        builder.setIntProp(this.integerTypeAdapter.read(reader));
                         break;
                     case ("list_polymorphic_values"):
-                        builder.setListPolymorphicValues(list_Object_TypeAdapter.read(reader));
+                        if (this.list_Object_TypeAdapter == null) {
+                            this.list_Object_TypeAdapter = this.gson.getAdapter(new TypeToken<List<Object>>(){}).nullSafe();
+                        }
+                        builder.setListPolymorphicValues(this.list_Object_TypeAdapter.read(reader));
                         break;
                     case ("list_with_list_and_other_model_values"):
-                        builder.setListWithListAndOtherModelValues(list_List_User__TypeAdapter.read(reader));
+                        if (this.list_List_User__TypeAdapter == null) {
+                            this.list_List_User__TypeAdapter = this.gson.getAdapter(new TypeToken<List<List<User>>>(){}).nullSafe();
+                        }
+                        builder.setListWithListAndOtherModelValues(this.list_List_User__TypeAdapter.read(reader));
                         break;
                     case ("list_with_map_and_other_model_values"):
-                        builder.setListWithMapAndOtherModelValues(list_Map_String__User__TypeAdapter.read(reader));
+                        if (this.list_Map_String__User__TypeAdapter == null) {
+                            this.list_Map_String__User__TypeAdapter = this.gson.getAdapter(new TypeToken<List<Map<String, User>>>(){}).nullSafe();
+                        }
+                        builder.setListWithMapAndOtherModelValues(this.list_Map_String__User__TypeAdapter.read(reader));
                         break;
                     case ("list_with_object_values"):
-                        builder.setListWithObjectValues(list_String_TypeAdapter.read(reader));
+                        if (this.list_String_TypeAdapter == null) {
+                            this.list_String_TypeAdapter = this.gson.getAdapter(new TypeToken<List<String>>(){}).nullSafe();
+                        }
+                        builder.setListWithObjectValues(this.list_String_TypeAdapter.read(reader));
                         break;
                     case ("list_with_other_model_values"):
-                        builder.setListWithOtherModelValues(list_User_TypeAdapter.read(reader));
+                        if (this.list_User_TypeAdapter == null) {
+                            this.list_User_TypeAdapter = this.gson.getAdapter(new TypeToken<List<User>>(){}).nullSafe();
+                        }
+                        builder.setListWithOtherModelValues(this.list_User_TypeAdapter.read(reader));
                         break;
                     case ("list_with_primitive_values"):
-                        builder.setListWithPrimitiveValues(list_Integer_TypeAdapter.read(reader));
+                        if (this.list_Integer_TypeAdapter == null) {
+                            this.list_Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<List<Integer>>(){}).nullSafe();
+                        }
+                        builder.setListWithPrimitiveValues(this.list_Integer_TypeAdapter.read(reader));
                         break;
                     case ("map_polymorphic_values"):
-                        builder.setMapPolymorphicValues(map_String__EverythingMapPolymorphicValues_TypeAdapter.read(reader));
+                        if (this.map_String__EverythingMapPolymorphicValues_TypeAdapter == null) {
+                            this.map_String__EverythingMapPolymorphicValues_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, EverythingMapPolymorphicValues>>(){}).nullSafe();
+                        }
+                        builder.setMapPolymorphicValues(this.map_String__EverythingMapPolymorphicValues_TypeAdapter.read(reader));
                         break;
                     case ("map_prop"):
-                        builder.setMapProp(map_String__Object_TypeAdapter.read(reader));
+                        if (this.map_String__Object_TypeAdapter == null) {
+                            this.map_String__Object_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Object>>(){}).nullSafe();
+                        }
+                        builder.setMapProp(this.map_String__Object_TypeAdapter.read(reader));
                         break;
                     case ("map_with_list_and_other_model_values"):
-                        builder.setMapWithListAndOtherModelValues(map_String__List_User__TypeAdapter.read(reader));
+                        if (this.map_String__List_User__TypeAdapter == null) {
+                            this.map_String__List_User__TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, List<User>>>(){}).nullSafe();
+                        }
+                        builder.setMapWithListAndOtherModelValues(this.map_String__List_User__TypeAdapter.read(reader));
                         break;
                     case ("map_with_map_and_other_model_values"):
-                        builder.setMapWithMapAndOtherModelValues(map_String__Map_String__Object__TypeAdapter.read(reader));
+                        if (this.map_String__Map_String__Object__TypeAdapter == null) {
+                            this.map_String__Map_String__Object__TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Map<String, Object>>>(){}).nullSafe();
+                        }
+                        builder.setMapWithMapAndOtherModelValues(this.map_String__Map_String__Object__TypeAdapter.read(reader));
                         break;
                     case ("map_with_object_values"):
-                        builder.setMapWithObjectValues(map_String__String_TypeAdapter.read(reader));
+                        if (this.map_String__String_TypeAdapter == null) {
+                            this.map_String__String_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
+                        }
+                        builder.setMapWithObjectValues(this.map_String__String_TypeAdapter.read(reader));
                         break;
                     case ("map_with_other_model_values"):
-                        builder.setMapWithOtherModelValues(map_String__User_TypeAdapter.read(reader));
+                        if (this.map_String__User_TypeAdapter == null) {
+                            this.map_String__User_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, User>>(){}).nullSafe();
+                        }
+                        builder.setMapWithOtherModelValues(this.map_String__User_TypeAdapter.read(reader));
                         break;
                     case ("map_with_primitive_values"):
-                        builder.setMapWithPrimitiveValues(map_String__Integer_TypeAdapter.read(reader));
+                        if (this.map_String__Integer_TypeAdapter == null) {
+                            this.map_String__Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
+                        }
+                        builder.setMapWithPrimitiveValues(this.map_String__Integer_TypeAdapter.read(reader));
                         break;
                     case ("nsinteger_enum"):
-                        builder.setNsintegerEnum(everythingNsintegerEnumTypeAdapter.read(reader));
+                        if (this.everythingNsintegerEnumTypeAdapter == null) {
+                            this.everythingNsintegerEnumTypeAdapter = this.gson.getAdapter(EverythingNsintegerEnum.class).nullSafe();
+                        }
+                        builder.setNsintegerEnum(this.everythingNsintegerEnumTypeAdapter.read(reader));
                         break;
                     case ("nsuinteger_enum"):
-                        builder.setNsuintegerEnum(everythingNsuintegerEnumTypeAdapter.read(reader));
+                        if (this.everythingNsuintegerEnumTypeAdapter == null) {
+                            this.everythingNsuintegerEnumTypeAdapter = this.gson.getAdapter(EverythingNsuintegerEnum.class).nullSafe();
+                        }
+                        builder.setNsuintegerEnum(this.everythingNsuintegerEnumTypeAdapter.read(reader));
                         break;
                     case ("number_prop"):
-                        builder.setNumberProp(doubleTypeAdapter.read(reader));
+                        if (this.doubleTypeAdapter == null) {
+                            this.doubleTypeAdapter = this.gson.getAdapter(Double.class).nullSafe();
+                        }
+                        builder.setNumberProp(this.doubleTypeAdapter.read(reader));
                         break;
                     case ("other_model_prop"):
-                        builder.setOtherModelProp(userTypeAdapter.read(reader));
+                        if (this.userTypeAdapter == null) {
+                            this.userTypeAdapter = this.gson.getAdapter(User.class).nullSafe();
+                        }
+                        builder.setOtherModelProp(this.userTypeAdapter.read(reader));
                         break;
                     case ("polymorphic_prop"):
-                        builder.setPolymorphicProp(everythingPolymorphicPropTypeAdapter.read(reader));
+                        if (this.everythingPolymorphicPropTypeAdapter == null) {
+                            this.everythingPolymorphicPropTypeAdapter = this.gson.getAdapter(EverythingPolymorphicProp.class).nullSafe();
+                        }
+                        builder.setPolymorphicProp(this.everythingPolymorphicPropTypeAdapter.read(reader));
                         break;
                     case ("set_prop"):
-                        builder.setSetProp(set_Object_TypeAdapter.read(reader));
+                        if (this.set_Object_TypeAdapter == null) {
+                            this.set_Object_TypeAdapter = this.gson.getAdapter(new TypeToken<Set<Object>>(){}).nullSafe();
+                        }
+                        builder.setSetProp(this.set_Object_TypeAdapter.read(reader));
                         break;
                     case ("set_prop_with_other_model_values"):
-                        builder.setSetPropWithOtherModelValues(set_User_TypeAdapter.read(reader));
+                        if (this.set_User_TypeAdapter == null) {
+                            this.set_User_TypeAdapter = this.gson.getAdapter(new TypeToken<Set<User>>(){}).nullSafe();
+                        }
+                        builder.setSetPropWithOtherModelValues(this.set_User_TypeAdapter.read(reader));
                         break;
                     case ("set_prop_with_primitive_values"):
-                        builder.setSetPropWithPrimitiveValues(set_Integer_TypeAdapter.read(reader));
+                        if (this.set_Integer_TypeAdapter == null) {
+                            this.set_Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<Set<Integer>>(){}).nullSafe();
+                        }
+                        builder.setSetPropWithPrimitiveValues(this.set_Integer_TypeAdapter.read(reader));
                         break;
                     case ("set_prop_with_values"):
-                        builder.setSetPropWithValues(set_String_TypeAdapter.read(reader));
+                        if (this.set_String_TypeAdapter == null) {
+                            this.set_String_TypeAdapter = this.gson.getAdapter(new TypeToken<Set<String>>(){}).nullSafe();
+                        }
+                        builder.setSetPropWithValues(this.set_String_TypeAdapter.read(reader));
                         break;
                     case ("short_enum"):
-                        builder.setShortEnum(everythingShortEnumTypeAdapter.read(reader));
+                        if (this.everythingShortEnumTypeAdapter == null) {
+                            this.everythingShortEnumTypeAdapter = this.gson.getAdapter(EverythingShortEnum.class).nullSafe();
+                        }
+                        builder.setShortEnum(this.everythingShortEnumTypeAdapter.read(reader));
                         break;
                     case ("string_enum"):
-                        builder.setStringEnum(everythingStringEnumTypeAdapter.read(reader));
+                        if (this.everythingStringEnumTypeAdapter == null) {
+                            this.everythingStringEnumTypeAdapter = this.gson.getAdapter(EverythingStringEnum.class).nullSafe();
+                        }
+                        builder.setStringEnum(this.everythingStringEnumTypeAdapter.read(reader));
                         break;
                     case ("string_prop"):
-                        builder.setStringProp(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setStringProp(this.stringTypeAdapter.read(reader));
                         break;
                     case ("type"):
-                        builder.setType(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setType(this.stringTypeAdapter.read(reader));
                         break;
                     case ("unsigned_char_enum"):
-                        builder.setUnsignedCharEnum(everythingUnsignedCharEnumTypeAdapter.read(reader));
+                        if (this.everythingUnsignedCharEnumTypeAdapter == null) {
+                            this.everythingUnsignedCharEnumTypeAdapter = this.gson.getAdapter(EverythingUnsignedCharEnum.class).nullSafe();
+                        }
+                        builder.setUnsignedCharEnum(this.everythingUnsignedCharEnumTypeAdapter.read(reader));
                         break;
                     case ("unsigned_int_enum"):
-                        builder.setUnsignedIntEnum(everythingUnsignedIntEnumTypeAdapter.read(reader));
+                        if (this.everythingUnsignedIntEnumTypeAdapter == null) {
+                            this.everythingUnsignedIntEnumTypeAdapter = this.gson.getAdapter(EverythingUnsignedIntEnum.class).nullSafe();
+                        }
+                        builder.setUnsignedIntEnum(this.everythingUnsignedIntEnumTypeAdapter.read(reader));
                         break;
                     case ("unsigned_short_enum"):
-                        builder.setUnsignedShortEnum(everythingUnsignedShortEnumTypeAdapter.read(reader));
+                        if (this.everythingUnsignedShortEnumTypeAdapter == null) {
+                            this.everythingUnsignedShortEnumTypeAdapter = this.gson.getAdapter(EverythingUnsignedShortEnum.class).nullSafe();
+                        }
+                        builder.setUnsignedShortEnum(this.everythingUnsignedShortEnumTypeAdapter.read(reader));
                         break;
                     case ("uri_prop"):
-                        builder.setUriProp(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setUriProp(this.stringTypeAdapter.read(reader));
                         break;
                     case ("_bits"):
                         bits = new boolean[36];

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -214,19 +214,25 @@ public class Image {
 
     public static class ImageTypeAdapter extends TypeAdapter<Image> {
 
-        final private TypeAdapter<Image> delegateTypeAdapter;
+        final private ImageTypeAdapterFactory factory;
+        final private Gson gson;
+        final private TypeToken typeToken;
+        private TypeAdapter<Image> delegateTypeAdapter;
 
-        final private TypeAdapter<Integer> integerTypeAdapter;
-        final private TypeAdapter<String> stringTypeAdapter;
+        private TypeAdapter<Integer> integerTypeAdapter;
+        private TypeAdapter<String> stringTypeAdapter;
 
         public ImageTypeAdapter(Gson gson, ImageTypeAdapterFactory factory, TypeToken typeToken) {
-            this.delegateTypeAdapter = gson.getDelegateAdapter(factory, typeToken);
-            this.integerTypeAdapter = gson.getAdapter(Integer.class).nullSafe();
-            this.stringTypeAdapter = gson.getAdapter(String.class).nullSafe();
+            this.factory = factory;
+            this.gson = gson;
+            this.typeToken = typeToken;
         }
 
         @Override
         public void write(JsonWriter writer, Image value) throws IOException {
+            if (this.delegateTypeAdapter == null) {
+                this.delegateTypeAdapter = this.gson.getDelegateAdapter(this.factory, this.typeToken);
+            }
             writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
@@ -244,13 +250,22 @@ public class Image {
                 String name = reader.nextName();
                 switch (name) {
                     case ("height"):
-                        builder.setHeight(integerTypeAdapter.read(reader));
+                        if (this.integerTypeAdapter == null) {
+                            this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
+                        }
+                        builder.setHeight(this.integerTypeAdapter.read(reader));
                         break;
                     case ("url"):
-                        builder.setUrl(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setUrl(this.stringTypeAdapter.read(reader));
                         break;
                     case ("width"):
-                        builder.setWidth(integerTypeAdapter.read(reader));
+                        if (this.integerTypeAdapter == null) {
+                            this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
+                        }
+                        builder.setWidth(this.integerTypeAdapter.read(reader));
                         break;
                     case ("_bits"):
                         bits = new boolean[3];

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -142,17 +142,24 @@ public class Model {
 
     public static class ModelTypeAdapter extends TypeAdapter<Model> {
 
-        final private TypeAdapter<Model> delegateTypeAdapter;
+        final private ModelTypeAdapterFactory factory;
+        final private Gson gson;
+        final private TypeToken typeToken;
+        private TypeAdapter<Model> delegateTypeAdapter;
 
-        final private TypeAdapter<String> stringTypeAdapter;
+        private TypeAdapter<String> stringTypeAdapter;
 
         public ModelTypeAdapter(Gson gson, ModelTypeAdapterFactory factory, TypeToken typeToken) {
-            this.delegateTypeAdapter = gson.getDelegateAdapter(factory, typeToken);
-            this.stringTypeAdapter = gson.getAdapter(String.class).nullSafe();
+            this.factory = factory;
+            this.gson = gson;
+            this.typeToken = typeToken;
         }
 
         @Override
         public void write(JsonWriter writer, Model value) throws IOException {
+            if (this.delegateTypeAdapter == null) {
+                this.delegateTypeAdapter = this.gson.getDelegateAdapter(this.factory, this.typeToken);
+            }
             writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
@@ -170,7 +177,10 @@ public class Model {
                 String name = reader.nextName();
                 switch (name) {
                     case ("id"):
-                        builder.setUid(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setUid(this.stringTypeAdapter.read(reader));
                         break;
                     case ("_bits"):
                         bits = new boolean[1];

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -720,37 +720,34 @@ public class Pin {
 
     public static class PinTypeAdapter extends TypeAdapter<Pin> {
 
-        final private TypeAdapter<Pin> delegateTypeAdapter;
+        final private PinTypeAdapterFactory factory;
+        final private Gson gson;
+        final private TypeToken typeToken;
+        private TypeAdapter<Pin> delegateTypeAdapter;
 
-        final private TypeAdapter<Board> boardTypeAdapter;
-        final private TypeAdapter<Date> dateTypeAdapter;
-        final private TypeAdapter<Image> imageTypeAdapter;
-        final private TypeAdapter<List<Map<String, Object>>> list_Map_String__Object__TypeAdapter;
-        final private TypeAdapter<List<PinAttributionObjects>> list_PinAttributionObjects_TypeAdapter;
-        final private TypeAdapter<Map<String, Integer>> map_String__Integer_TypeAdapter;
-        final private TypeAdapter<Map<String, Object>> map_String__Object_TypeAdapter;
-        final private TypeAdapter<Map<String, String>> map_String__String_TypeAdapter;
-        final private TypeAdapter<Map<String, User>> map_String__User_TypeAdapter;
-        final private TypeAdapter<PinInStock> pinInStockTypeAdapter;
-        final private TypeAdapter<String> stringTypeAdapter;
+        private TypeAdapter<Board> boardTypeAdapter;
+        private TypeAdapter<Date> dateTypeAdapter;
+        private TypeAdapter<Image> imageTypeAdapter;
+        private TypeAdapter<List<Map<String, Object>>> list_Map_String__Object__TypeAdapter;
+        private TypeAdapter<List<PinAttributionObjects>> list_PinAttributionObjects_TypeAdapter;
+        private TypeAdapter<Map<String, Integer>> map_String__Integer_TypeAdapter;
+        private TypeAdapter<Map<String, Object>> map_String__Object_TypeAdapter;
+        private TypeAdapter<Map<String, String>> map_String__String_TypeAdapter;
+        private TypeAdapter<Map<String, User>> map_String__User_TypeAdapter;
+        private TypeAdapter<PinInStock> pinInStockTypeAdapter;
+        private TypeAdapter<String> stringTypeAdapter;
 
         public PinTypeAdapter(Gson gson, PinTypeAdapterFactory factory, TypeToken typeToken) {
-            this.delegateTypeAdapter = gson.getDelegateAdapter(factory, typeToken);
-            this.boardTypeAdapter = gson.getAdapter(Board.class).nullSafe();
-            this.dateTypeAdapter = gson.getAdapter(Date.class).nullSafe();
-            this.imageTypeAdapter = gson.getAdapter(Image.class).nullSafe();
-            this.list_Map_String__Object__TypeAdapter = gson.getAdapter(new TypeToken<List<Map<String, Object>>>(){}).nullSafe();
-            this.list_PinAttributionObjects_TypeAdapter = gson.getAdapter(new TypeToken<List<PinAttributionObjects>>(){}).nullSafe();
-            this.map_String__Integer_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
-            this.map_String__Object_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, Object>>(){}).nullSafe();
-            this.map_String__String_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
-            this.map_String__User_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, User>>(){}).nullSafe();
-            this.pinInStockTypeAdapter = gson.getAdapter(PinInStock.class).nullSafe();
-            this.stringTypeAdapter = gson.getAdapter(String.class).nullSafe();
+            this.factory = factory;
+            this.gson = gson;
+            this.typeToken = typeToken;
         }
 
         @Override
         public void write(JsonWriter writer, Pin value) throws IOException {
+            if (this.delegateTypeAdapter == null) {
+                this.delegateTypeAdapter = this.gson.getDelegateAdapter(this.factory, this.typeToken);
+            }
             writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
@@ -768,55 +765,106 @@ public class Pin {
                 String name = reader.nextName();
                 switch (name) {
                     case ("attribution"):
-                        builder.setAttribution(map_String__String_TypeAdapter.read(reader));
+                        if (this.map_String__String_TypeAdapter == null) {
+                            this.map_String__String_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
+                        }
+                        builder.setAttribution(this.map_String__String_TypeAdapter.read(reader));
                         break;
                     case ("attribution_objects"):
-                        builder.setAttributionObjects(list_PinAttributionObjects_TypeAdapter.read(reader));
+                        if (this.list_PinAttributionObjects_TypeAdapter == null) {
+                            this.list_PinAttributionObjects_TypeAdapter = this.gson.getAdapter(new TypeToken<List<PinAttributionObjects>>(){}).nullSafe();
+                        }
+                        builder.setAttributionObjects(this.list_PinAttributionObjects_TypeAdapter.read(reader));
                         break;
                     case ("board"):
-                        builder.setBoard(boardTypeAdapter.read(reader));
+                        if (this.boardTypeAdapter == null) {
+                            this.boardTypeAdapter = this.gson.getAdapter(Board.class).nullSafe();
+                        }
+                        builder.setBoard(this.boardTypeAdapter.read(reader));
                         break;
                     case ("color"):
-                        builder.setColor(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setColor(this.stringTypeAdapter.read(reader));
                         break;
                     case ("counts"):
-                        builder.setCounts(map_String__Integer_TypeAdapter.read(reader));
+                        if (this.map_String__Integer_TypeAdapter == null) {
+                            this.map_String__Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
+                        }
+                        builder.setCounts(this.map_String__Integer_TypeAdapter.read(reader));
                         break;
                     case ("created_at"):
-                        builder.setCreatedAt(dateTypeAdapter.read(reader));
+                        if (this.dateTypeAdapter == null) {
+                            this.dateTypeAdapter = this.gson.getAdapter(Date.class).nullSafe();
+                        }
+                        builder.setCreatedAt(this.dateTypeAdapter.read(reader));
                         break;
                     case ("creator"):
-                        builder.setCreator(map_String__User_TypeAdapter.read(reader));
+                        if (this.map_String__User_TypeAdapter == null) {
+                            this.map_String__User_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, User>>(){}).nullSafe();
+                        }
+                        builder.setCreator(this.map_String__User_TypeAdapter.read(reader));
                         break;
                     case ("description"):
-                        builder.setDescription(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setDescription(this.stringTypeAdapter.read(reader));
                         break;
                     case ("id"):
-                        builder.setUid(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setUid(this.stringTypeAdapter.read(reader));
                         break;
                     case ("image"):
-                        builder.setImage(imageTypeAdapter.read(reader));
+                        if (this.imageTypeAdapter == null) {
+                            this.imageTypeAdapter = this.gson.getAdapter(Image.class).nullSafe();
+                        }
+                        builder.setImage(this.imageTypeAdapter.read(reader));
                         break;
                     case ("in_stock"):
-                        builder.setInStock(pinInStockTypeAdapter.read(reader));
+                        if (this.pinInStockTypeAdapter == null) {
+                            this.pinInStockTypeAdapter = this.gson.getAdapter(PinInStock.class).nullSafe();
+                        }
+                        builder.setInStock(this.pinInStockTypeAdapter.read(reader));
                         break;
                     case ("link"):
-                        builder.setLink(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setLink(this.stringTypeAdapter.read(reader));
                         break;
                     case ("media"):
-                        builder.setMedia(map_String__String_TypeAdapter.read(reader));
+                        if (this.map_String__String_TypeAdapter == null) {
+                            this.map_String__String_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
+                        }
+                        builder.setMedia(this.map_String__String_TypeAdapter.read(reader));
                         break;
                     case ("note"):
-                        builder.setNote(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setNote(this.stringTypeAdapter.read(reader));
                         break;
                     case ("tags"):
-                        builder.setTags(list_Map_String__Object__TypeAdapter.read(reader));
+                        if (this.list_Map_String__Object__TypeAdapter == null) {
+                            this.list_Map_String__Object__TypeAdapter = this.gson.getAdapter(new TypeToken<List<Map<String, Object>>>(){}).nullSafe();
+                        }
+                        builder.setTags(this.list_Map_String__Object__TypeAdapter.read(reader));
                         break;
                     case ("url"):
-                        builder.setUrl(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setUrl(this.stringTypeAdapter.read(reader));
                         break;
                     case ("visual_search_attrs"):
-                        builder.setVisualSearchAttrs(map_String__Object_TypeAdapter.read(reader));
+                        if (this.map_String__Object_TypeAdapter == null) {
+                            this.map_String__Object_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Object>>(){}).nullSafe();
+                        }
+                        builder.setVisualSearchAttrs(this.map_String__Object_TypeAdapter.read(reader));
                         break;
                     case ("_bits"):
                         bits = new boolean[17];

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -461,25 +461,28 @@ public class User {
 
     public static class UserTypeAdapter extends TypeAdapter<User> {
 
-        final private TypeAdapter<User> delegateTypeAdapter;
+        final private UserTypeAdapterFactory factory;
+        final private Gson gson;
+        final private TypeToken typeToken;
+        private TypeAdapter<User> delegateTypeAdapter;
 
-        final private TypeAdapter<Date> dateTypeAdapter;
-        final private TypeAdapter<Image> imageTypeAdapter;
-        final private TypeAdapter<Map<String, Integer>> map_String__Integer_TypeAdapter;
-        final private TypeAdapter<String> stringTypeAdapter;
-        final private TypeAdapter<UserEmailFrequency> userEmailFrequencyTypeAdapter;
+        private TypeAdapter<Date> dateTypeAdapter;
+        private TypeAdapter<Image> imageTypeAdapter;
+        private TypeAdapter<Map<String, Integer>> map_String__Integer_TypeAdapter;
+        private TypeAdapter<String> stringTypeAdapter;
+        private TypeAdapter<UserEmailFrequency> userEmailFrequencyTypeAdapter;
 
         public UserTypeAdapter(Gson gson, UserTypeAdapterFactory factory, TypeToken typeToken) {
-            this.delegateTypeAdapter = gson.getDelegateAdapter(factory, typeToken);
-            this.dateTypeAdapter = gson.getAdapter(Date.class).nullSafe();
-            this.imageTypeAdapter = gson.getAdapter(Image.class).nullSafe();
-            this.map_String__Integer_TypeAdapter = gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
-            this.stringTypeAdapter = gson.getAdapter(String.class).nullSafe();
-            this.userEmailFrequencyTypeAdapter = gson.getAdapter(UserEmailFrequency.class).nullSafe();
+            this.factory = factory;
+            this.gson = gson;
+            this.typeToken = typeToken;
         }
 
         @Override
         public void write(JsonWriter writer, User value) throws IOException {
+            if (this.delegateTypeAdapter == null) {
+                this.delegateTypeAdapter = this.gson.getDelegateAdapter(this.factory, this.typeToken);
+            }
             writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
@@ -497,34 +500,64 @@ public class User {
                 String name = reader.nextName();
                 switch (name) {
                     case ("bio"):
-                        builder.setBio(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setBio(this.stringTypeAdapter.read(reader));
                         break;
                     case ("counts"):
-                        builder.setCounts(map_String__Integer_TypeAdapter.read(reader));
+                        if (this.map_String__Integer_TypeAdapter == null) {
+                            this.map_String__Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
+                        }
+                        builder.setCounts(this.map_String__Integer_TypeAdapter.read(reader));
                         break;
                     case ("created_at"):
-                        builder.setCreatedAt(dateTypeAdapter.read(reader));
+                        if (this.dateTypeAdapter == null) {
+                            this.dateTypeAdapter = this.gson.getAdapter(Date.class).nullSafe();
+                        }
+                        builder.setCreatedAt(this.dateTypeAdapter.read(reader));
                         break;
                     case ("email_frequency"):
-                        builder.setEmailFrequency(userEmailFrequencyTypeAdapter.read(reader));
+                        if (this.userEmailFrequencyTypeAdapter == null) {
+                            this.userEmailFrequencyTypeAdapter = this.gson.getAdapter(UserEmailFrequency.class).nullSafe();
+                        }
+                        builder.setEmailFrequency(this.userEmailFrequencyTypeAdapter.read(reader));
                         break;
                     case ("first_name"):
-                        builder.setFirstName(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setFirstName(this.stringTypeAdapter.read(reader));
                         break;
                     case ("id"):
-                        builder.setUid(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setUid(this.stringTypeAdapter.read(reader));
                         break;
                     case ("image"):
-                        builder.setImage(imageTypeAdapter.read(reader));
+                        if (this.imageTypeAdapter == null) {
+                            this.imageTypeAdapter = this.gson.getAdapter(Image.class).nullSafe();
+                        }
+                        builder.setImage(this.imageTypeAdapter.read(reader));
                         break;
                     case ("last_name"):
-                        builder.setLastName(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setLastName(this.stringTypeAdapter.read(reader));
                         break;
                     case ("type"):
-                        builder.setType(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setType(this.stringTypeAdapter.read(reader));
                         break;
                     case ("username"):
-                        builder.setUsername(stringTypeAdapter.read(reader));
+                        if (this.stringTypeAdapter == null) {
+                            this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
+                        }
+                        builder.setUsername(this.stringTypeAdapter.read(reader));
                         break;
                     case ("_bits"):
                         bits = new boolean[10];

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -251,17 +251,24 @@ public class VariableSubtitution {
 
     public static class VariableSubtitutionTypeAdapter extends TypeAdapter<VariableSubtitution> {
 
-        final private TypeAdapter<VariableSubtitution> delegateTypeAdapter;
+        final private VariableSubtitutionTypeAdapterFactory factory;
+        final private Gson gson;
+        final private TypeToken typeToken;
+        private TypeAdapter<VariableSubtitution> delegateTypeAdapter;
 
-        final private TypeAdapter<Integer> integerTypeAdapter;
+        private TypeAdapter<Integer> integerTypeAdapter;
 
         public VariableSubtitutionTypeAdapter(Gson gson, VariableSubtitutionTypeAdapterFactory factory, TypeToken typeToken) {
-            this.delegateTypeAdapter = gson.getDelegateAdapter(factory, typeToken);
-            this.integerTypeAdapter = gson.getAdapter(Integer.class).nullSafe();
+            this.factory = factory;
+            this.gson = gson;
+            this.typeToken = typeToken;
         }
 
         @Override
         public void write(JsonWriter writer, VariableSubtitution value) throws IOException {
+            if (this.delegateTypeAdapter == null) {
+                this.delegateTypeAdapter = this.gson.getDelegateAdapter(this.factory, this.typeToken);
+            }
             writer.setSerializeNulls(false);
             this.delegateTypeAdapter.write(writer, value);
         }
@@ -279,16 +286,28 @@ public class VariableSubtitution {
                 String name = reader.nextName();
                 switch (name) {
                     case ("alloc_prop"):
-                        builder.setAllocProp(integerTypeAdapter.read(reader));
+                        if (this.integerTypeAdapter == null) {
+                            this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
+                        }
+                        builder.setAllocProp(this.integerTypeAdapter.read(reader));
                         break;
                     case ("copy_prop"):
-                        builder.setCopyProp(integerTypeAdapter.read(reader));
+                        if (this.integerTypeAdapter == null) {
+                            this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
+                        }
+                        builder.setCopyProp(this.integerTypeAdapter.read(reader));
                         break;
                     case ("mutable_copy_prop"):
-                        builder.setMutableCopyProp(integerTypeAdapter.read(reader));
+                        if (this.integerTypeAdapter == null) {
+                            this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
+                        }
+                        builder.setMutableCopyProp(this.integerTypeAdapter.read(reader));
                         break;
                     case ("new_prop"):
-                        builder.setNewProp(integerTypeAdapter.read(reader));
+                        if (this.integerTypeAdapter == null) {
+                            this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
+                        }
+                        builder.setNewProp(this.integerTypeAdapter.read(reader));
                         break;
                     case ("_bits"):
                         bits = new boolean[4];


### PR DESCRIPTION
Loading each inner TypeAdapter can take time, and so doing that upon construction leads to a significant penalty.