### PR TITLE
Only import the necessary set of types

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -20,7 +20,6 @@ import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -19,11 +19,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class Image {
 

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -19,11 +19,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class Model {
 

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -23,7 +23,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 interface PinAttributionObjectsMatcher<R> {
     R match(@Nullable Board value0);

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -20,10 +20,8 @@ import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class User {
 

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -19,11 +19,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 public class VariableSubtitution {
 

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -389,6 +389,16 @@ public struct JavaModelRenderer: JavaFileRenderer {
             fatalError("java_nullability_annotation_type must be either android-support or androidx. Invalid type provided: " + params[.javaNullabilityAnnotationType]!)
         }
 
+        let propertyTypeImports = properties.compactMap { (_, prop) -> String? in
+            switch prop.schema {
+            case .array: return "java.util.List"
+            case .map: return "java.util.Map"
+            case .set: return "java.util.Set"
+            case .string(format: .some(.dateTime)): return "java.util.Date"
+            default: return nil
+            }
+        }
+
         let imports = [
             JavaIR.Root.imports(names: Set([
                 "com.google.gson.Gson",
@@ -400,14 +410,10 @@ public struct JavaModelRenderer: JavaFileRenderer {
                 "com.google.gson.stream.JsonToken",
                 "com.google.gson.stream.JsonWriter",
                 "java.io.IOException",
-                "java.util.Date",
-                "java.util.Map",
-                "java.util.Set",
-                "java.util.List",
                 "java.util.Objects",
                 nullabilityAnnotationType.package + ".NonNull",
                 nullabilityAnnotationType.package + ".Nullable",
-            ] + (self.decorations.imports ?? []))),
+            ] + propertyTypeImports + (self.decorations.imports ?? []))),
         ]
 
         let enumProps = properties.flatMap { (param, prop) -> [JavaIR.Enum] in


### PR DESCRIPTION
We were previously importing the `java.util.{Date,List,Map,Set}` types
unconditionally. We now detect which types are needed based on walking
the schema and only emitting imports for the types that are actually
used.