### PR TITLE
Only allocate _bits when necessary

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -50,7 +50,7 @@ public class Board {
     static final private int NAME_INDEX = 8;
     static final private int URL_INDEX = 9;
 
-    private boolean[] _bits = new boolean[10];
+    private boolean[] _bits;
 
     private Board(
         @Nullable String uid,
@@ -223,9 +223,10 @@ public class Board {
         private @Nullable String name;
         private @Nullable String url;
 
-        private boolean[] _bits = new boolean[10];
+        private boolean[] _bits;
 
         private Builder() {
+            this._bits = new boolean[10];
         }
 
         private Builder(@NonNull Board model) {
@@ -557,7 +558,6 @@ public class Board {
                 return null;
             }
             Builder builder = Board.builder();
-            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -622,24 +622,11 @@ public class Board {
                         }
                         builder.setUrl(this.stringTypeAdapter.read(reader));
                         break;
-                    case ("_bits"):
-                        bits = new boolean[10];
-                        int i = 0;
-                        reader.beginArray();
-                        while (reader.hasNext() && i < 10) {
-                            bits[i] = reader.nextBoolean();
-                            i++;
-                        }
-                        reader.endArray();
-                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
-            if (bits != null) {
-                builder._bits = bits;
-            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -222,7 +222,7 @@ public class Everything {
     static final private int UNSIGNED_SHORT_ENUM_INDEX = 34;
     static final private int URI_PROP_INDEX = 35;
 
-    private boolean[] _bits = new boolean[36];
+    private boolean[] _bits;
 
     private Everything(
         @Nullable List<Object> arrayProp,
@@ -736,9 +736,10 @@ public class Everything {
         private @Nullable EverythingUnsignedShortEnum unsignedShortEnum;
         private @Nullable String uriProp;
 
-        private boolean[] _bits = new boolean[36];
+        private boolean[] _bits;
 
         private Builder() {
+            this._bits = new boolean[36];
         }
 
         private Builder(@NonNull Everything model) {
@@ -1799,7 +1800,6 @@ public class Everything {
                 return null;
             }
             Builder builder = Everything.builder();
-            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -2020,24 +2020,11 @@ public class Everything {
                         }
                         builder.setUriProp(this.stringTypeAdapter.read(reader));
                         break;
-                    case ("_bits"):
-                        bits = new boolean[36];
-                        int i = 0;
-                        reader.beginArray();
-                        while (reader.hasNext() && i < 36) {
-                            bits[i] = reader.nextBoolean();
-                            i++;
-                        }
-                        reader.endArray();
-                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
-            if (bits != null) {
-                builder._bits = bits;
-            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -33,7 +33,7 @@ public class Image {
     static final private int URL_INDEX = 1;
     static final private int WIDTH_INDEX = 2;
 
-    private boolean[] _bits = new boolean[3];
+    private boolean[] _bits;
 
     private Image(
         @Nullable Integer height,
@@ -117,9 +117,10 @@ public class Image {
         private @Nullable String url;
         private @Nullable Integer width;
 
-        private boolean[] _bits = new boolean[3];
+        private boolean[] _bits;
 
         private Builder() {
+            this._bits = new boolean[3];
         }
 
         private Builder(@NonNull Image model) {
@@ -258,7 +259,6 @@ public class Image {
                 return null;
             }
             Builder builder = Image.builder();
-            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -281,24 +281,11 @@ public class Image {
                         }
                         builder.setWidth(this.integerTypeAdapter.read(reader));
                         break;
-                    case ("_bits"):
-                        bits = new boolean[3];
-                        int i = 0;
-                        reader.beginArray();
-                        while (reader.hasNext() && i < 3) {
-                            bits[i] = reader.nextBoolean();
-                            i++;
-                        }
-                        reader.endArray();
-                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
-            if (bits != null) {
-                builder._bits = bits;
-            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -29,7 +29,7 @@ public class Model {
 
     static final private int ID_INDEX = 0;
 
-    private boolean[] _bits = new boolean[1];
+    private boolean[] _bits;
 
     private Model(
         @Nullable String uid,
@@ -85,9 +85,10 @@ public class Model {
 
         private @Nullable String uid;
 
-        private boolean[] _bits = new boolean[1];
+        private boolean[] _bits;
 
         private Builder() {
+            this._bits = new boolean[1];
         }
 
         private Builder(@NonNull Model model) {
@@ -171,7 +172,6 @@ public class Model {
                 return null;
             }
             Builder builder = Model.builder();
-            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -182,24 +182,11 @@ public class Model {
                         }
                         builder.setUid(this.stringTypeAdapter.read(reader));
                         break;
-                    case ("_bits"):
-                        bits = new boolean[1];
-                        int i = 0;
-                        reader.beginArray();
-                        while (reader.hasNext() && i < 1) {
-                            bits[i] = reader.nextBoolean();
-                            i++;
-                        }
-                        reader.endArray();
-                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
-            if (bits != null) {
-                builder._bits = bits;
-            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -82,7 +82,7 @@ public class Pin {
     static final private int URL_INDEX = 15;
     static final private int VISUAL_SEARCH_ATTRS_INDEX = 16;
 
-    private boolean[] _bits = new boolean[17];
+    private boolean[] _bits;
 
     private Pin(
         @Nullable Map<String, String> attribution,
@@ -346,9 +346,10 @@ public class Pin {
         private @Nullable String url;
         private @Nullable Map<String, Object> visualSearchAttrs;
 
-        private boolean[] _bits = new boolean[17];
+        private boolean[] _bits;
 
         private Builder() {
+            this._bits = new boolean[17];
         }
 
         private Builder(@NonNull Pin model) {
@@ -874,7 +875,6 @@ public class Pin {
                 return null;
             }
             Builder builder = Pin.builder();
-            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -981,24 +981,11 @@ public class Pin {
                         }
                         builder.setVisualSearchAttrs(this.map_String__Object_TypeAdapter.read(reader));
                         break;
-                    case ("_bits"):
-                        bits = new boolean[17];
-                        int i = 0;
-                        reader.beginArray();
-                        while (reader.hasNext() && i < 17) {
-                            bits[i] = reader.nextBoolean();
-                            i++;
-                        }
-                        reader.endArray();
-                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
-            if (bits != null) {
-                builder._bits = bits;
-            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -53,7 +53,7 @@ public class User {
     static final private int TYPE_INDEX = 8;
     static final private int USERNAME_INDEX = 9;
 
-    private boolean[] _bits = new boolean[10];
+    private boolean[] _bits;
 
     private User(
         @Nullable String bio,
@@ -226,9 +226,10 @@ public class User {
         private @Nullable String type;
         private @Nullable String username;
 
-        private boolean[] _bits = new boolean[10];
+        private boolean[] _bits;
 
         private Builder() {
+            this._bits = new boolean[10];
         }
 
         private Builder(@NonNull User model) {
@@ -559,7 +560,6 @@ public class User {
                 return null;
             }
             Builder builder = User.builder();
-            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -624,24 +624,11 @@ public class User {
                         }
                         builder.setUsername(this.stringTypeAdapter.read(reader));
                         break;
-                    case ("_bits"):
-                        bits = new boolean[10];
-                        int i = 0;
-                        reader.beginArray();
-                        while (reader.hasNext() && i < 10) {
-                            bits[i] = reader.nextBoolean();
-                            i++;
-                        }
-                        reader.endArray();
-                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
-            if (bits != null) {
-                builder._bits = bits;
-            }
             return builder.build();
         }
     }

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -35,7 +35,7 @@ public class VariableSubtitution {
     static final private int MUTABLE_COPY_PROP_INDEX = 2;
     static final private int NEW_PROP_INDEX = 3;
 
-    private boolean[] _bits = new boolean[4];
+    private boolean[] _bits;
 
     private VariableSubtitution(
         @Nullable Integer allocProp,
@@ -134,9 +134,10 @@ public class VariableSubtitution {
         private @Nullable Integer mutableCopyProp;
         private @Nullable Integer newProp;
 
-        private boolean[] _bits = new boolean[4];
+        private boolean[] _bits;
 
         private Builder() {
+            this._bits = new boolean[4];
         }
 
         private Builder(@NonNull VariableSubtitution model) {
@@ -301,7 +302,6 @@ public class VariableSubtitution {
                 return null;
             }
             Builder builder = VariableSubtitution.builder();
-            boolean[] bits = null;
             reader.beginObject();
             while (reader.hasNext()) {
                 String name = reader.nextName();
@@ -330,24 +330,11 @@ public class VariableSubtitution {
                         }
                         builder.setNewProp(this.integerTypeAdapter.read(reader));
                         break;
-                    case ("_bits"):
-                        bits = new boolean[4];
-                        int i = 0;
-                        reader.beginArray();
-                        while (reader.hasNext() && i < 4) {
-                            bits[i] = reader.nextBoolean();
-                            i++;
-                        }
-                        reader.endArray();
-                        break;
                     default:
                         reader.skipValue();
                 }
             }
             reader.endObject();
-            if (bits != null) {
-                builder._bits = bits;
-            }
             return builder.build();
         }
     }


### PR DESCRIPTION
We were previously allocating the _bits array as part of its
declaration. In many cases, we wouldn't use this memory; we would
just reassign _bits in the non-default constructors and builders.

Instead, we now only allocate _bits in the default Builder constructor.
We also now generate a default public model constructor when package-
private setters are enabled so that there's some backing storage to
support those set methods. (Note that we don't currently appear to
actually update _bits in those methods, which may be a separate issue.)

Lastly, we no longer need to read the "_bits" array in TypeAdapter#read,
so remove that case entirely.