### PR TITLE
Check _bits directly in internal calls

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -391,65 +391,45 @@ public class Board {
         }
 
         public void mergeFrom(@NonNull Board model) {
-            if (model.getUidIsSet()) {
+            if (model._bits.length > ID_INDEX && model._bits[ID_INDEX]) {
                 this.uid = model.uid;
-                if (this._bits.length > ID_INDEX) {
-                    this._bits[ID_INDEX] = true;
-                }
+                this._bits[ID_INDEX] = true;
             }
-            if (model.getContributorsIsSet()) {
+            if (model._bits.length > CONTRIBUTORS_INDEX && model._bits[CONTRIBUTORS_INDEX]) {
                 this.contributors = model.contributors;
-                if (this._bits.length > CONTRIBUTORS_INDEX) {
-                    this._bits[CONTRIBUTORS_INDEX] = true;
-                }
+                this._bits[CONTRIBUTORS_INDEX] = true;
             }
-            if (model.getCountsIsSet()) {
+            if (model._bits.length > COUNTS_INDEX && model._bits[COUNTS_INDEX]) {
                 this.counts = model.counts;
-                if (this._bits.length > COUNTS_INDEX) {
-                    this._bits[COUNTS_INDEX] = true;
-                }
+                this._bits[COUNTS_INDEX] = true;
             }
-            if (model.getCreatedAtIsSet()) {
+            if (model._bits.length > CREATED_AT_INDEX && model._bits[CREATED_AT_INDEX]) {
                 this.createdAt = model.createdAt;
-                if (this._bits.length > CREATED_AT_INDEX) {
-                    this._bits[CREATED_AT_INDEX] = true;
-                }
+                this._bits[CREATED_AT_INDEX] = true;
             }
-            if (model.getCreatorIsSet()) {
+            if (model._bits.length > CREATOR_INDEX && model._bits[CREATOR_INDEX]) {
                 this.creator = model.creator;
-                if (this._bits.length > CREATOR_INDEX) {
-                    this._bits[CREATOR_INDEX] = true;
-                }
+                this._bits[CREATOR_INDEX] = true;
             }
-            if (model.getCreatorURLIsSet()) {
+            if (model._bits.length > CREATOR_URL_INDEX && model._bits[CREATOR_URL_INDEX]) {
                 this.creatorURL = model.creatorURL;
-                if (this._bits.length > CREATOR_URL_INDEX) {
-                    this._bits[CREATOR_URL_INDEX] = true;
-                }
+                this._bits[CREATOR_URL_INDEX] = true;
             }
-            if (model.getDescriptionIsSet()) {
+            if (model._bits.length > DESCRIPTION_INDEX && model._bits[DESCRIPTION_INDEX]) {
                 this.description = model.description;
-                if (this._bits.length > DESCRIPTION_INDEX) {
-                    this._bits[DESCRIPTION_INDEX] = true;
-                }
+                this._bits[DESCRIPTION_INDEX] = true;
             }
-            if (model.getImageIsSet()) {
+            if (model._bits.length > IMAGE_INDEX && model._bits[IMAGE_INDEX]) {
                 this.image = model.image;
-                if (this._bits.length > IMAGE_INDEX) {
-                    this._bits[IMAGE_INDEX] = true;
-                }
+                this._bits[IMAGE_INDEX] = true;
             }
-            if (model.getNameIsSet()) {
+            if (model._bits.length > NAME_INDEX && model._bits[NAME_INDEX]) {
                 this.name = model.name;
-                if (this._bits.length > NAME_INDEX) {
-                    this._bits[NAME_INDEX] = true;
-                }
+                this._bits[NAME_INDEX] = true;
             }
-            if (model.getUrlIsSet()) {
+            if (model._bits.length > URL_INDEX && model._bits[URL_INDEX]) {
                 this.url = model.url;
-                if (this._bits.length > URL_INDEX) {
-                    this._bits[URL_INDEX] = true;
-                }
+                this._bits[URL_INDEX] = true;
             }
         }
     }
@@ -487,61 +467,61 @@ public class Board {
                 return;
             }
             writer.beginObject();
-            if (value.getUidIsSet()) {
+            if (value._bits.length > ID_INDEX && value._bits[ID_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("id"), value.uid);
             }
-            if (value.getContributorsIsSet()) {
+            if (value._bits.length > CONTRIBUTORS_INDEX && value._bits[CONTRIBUTORS_INDEX]) {
                 if (this.set_User_TypeAdapter == null) {
                     this.set_User_TypeAdapter = this.gson.getAdapter(new TypeToken<Set<User>>(){}).nullSafe();
                 }
                 this.set_User_TypeAdapter.write(writer.name("contributors"), value.contributors);
             }
-            if (value.getCountsIsSet()) {
+            if (value._bits.length > COUNTS_INDEX && value._bits[COUNTS_INDEX]) {
                 if (this.map_String__Integer_TypeAdapter == null) {
                     this.map_String__Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
                 }
                 this.map_String__Integer_TypeAdapter.write(writer.name("counts"), value.counts);
             }
-            if (value.getCreatedAtIsSet()) {
+            if (value._bits.length > CREATED_AT_INDEX && value._bits[CREATED_AT_INDEX]) {
                 if (this.dateTypeAdapter == null) {
                     this.dateTypeAdapter = this.gson.getAdapter(Date.class).nullSafe();
                 }
                 this.dateTypeAdapter.write(writer.name("created_at"), value.createdAt);
             }
-            if (value.getCreatorIsSet()) {
+            if (value._bits.length > CREATOR_INDEX && value._bits[CREATOR_INDEX]) {
                 if (this.map_String__String_TypeAdapter == null) {
                     this.map_String__String_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
                 }
                 this.map_String__String_TypeAdapter.write(writer.name("creator"), value.creator);
             }
-            if (value.getCreatorURLIsSet()) {
+            if (value._bits.length > CREATOR_URL_INDEX && value._bits[CREATOR_URL_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("creator_url"), value.creatorURL);
             }
-            if (value.getDescriptionIsSet()) {
+            if (value._bits.length > DESCRIPTION_INDEX && value._bits[DESCRIPTION_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("description"), value.description);
             }
-            if (value.getImageIsSet()) {
+            if (value._bits.length > IMAGE_INDEX && value._bits[IMAGE_INDEX]) {
                 if (this.imageTypeAdapter == null) {
                     this.imageTypeAdapter = this.gson.getAdapter(Image.class).nullSafe();
                 }
                 this.imageTypeAdapter.write(writer.name("image"), value.image);
             }
-            if (value.getNameIsSet()) {
+            if (value._bits.length > NAME_INDEX && value._bits[NAME_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("name"), value.name);
             }
-            if (value.getUrlIsSet()) {
+            if (value._bits.length > URL_INDEX && value._bits[URL_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -1294,221 +1294,149 @@ public class Everything {
         }
 
         public void mergeFrom(@NonNull Everything model) {
-            if (model.getArrayPropIsSet()) {
+            if (model._bits.length > ARRAY_PROP_INDEX && model._bits[ARRAY_PROP_INDEX]) {
                 this.arrayProp = model.arrayProp;
-                if (this._bits.length > ARRAY_PROP_INDEX) {
-                    this._bits[ARRAY_PROP_INDEX] = true;
-                }
+                this._bits[ARRAY_PROP_INDEX] = true;
             }
-            if (model.getBooleanPropIsSet()) {
+            if (model._bits.length > BOOLEAN_PROP_INDEX && model._bits[BOOLEAN_PROP_INDEX]) {
                 this.booleanProp = model.booleanProp;
-                if (this._bits.length > BOOLEAN_PROP_INDEX) {
-                    this._bits[BOOLEAN_PROP_INDEX] = true;
-                }
+                this._bits[BOOLEAN_PROP_INDEX] = true;
             }
-            if (model.getCharEnumIsSet()) {
+            if (model._bits.length > CHAR_ENUM_INDEX && model._bits[CHAR_ENUM_INDEX]) {
                 this.charEnum = model.charEnum;
-                if (this._bits.length > CHAR_ENUM_INDEX) {
-                    this._bits[CHAR_ENUM_INDEX] = true;
-                }
+                this._bits[CHAR_ENUM_INDEX] = true;
             }
-            if (model.getDatePropIsSet()) {
+            if (model._bits.length > DATE_PROP_INDEX && model._bits[DATE_PROP_INDEX]) {
                 this.dateProp = model.dateProp;
-                if (this._bits.length > DATE_PROP_INDEX) {
-                    this._bits[DATE_PROP_INDEX] = true;
-                }
+                this._bits[DATE_PROP_INDEX] = true;
             }
-            if (model.getIntEnumIsSet()) {
+            if (model._bits.length > INT_ENUM_INDEX && model._bits[INT_ENUM_INDEX]) {
                 this.intEnum = model.intEnum;
-                if (this._bits.length > INT_ENUM_INDEX) {
-                    this._bits[INT_ENUM_INDEX] = true;
-                }
+                this._bits[INT_ENUM_INDEX] = true;
             }
-            if (model.getIntPropIsSet()) {
+            if (model._bits.length > INT_PROP_INDEX && model._bits[INT_PROP_INDEX]) {
                 this.intProp = model.intProp;
-                if (this._bits.length > INT_PROP_INDEX) {
-                    this._bits[INT_PROP_INDEX] = true;
-                }
+                this._bits[INT_PROP_INDEX] = true;
             }
-            if (model.getListPolymorphicValuesIsSet()) {
+            if (model._bits.length > LIST_POLYMORPHIC_VALUES_INDEX && model._bits[LIST_POLYMORPHIC_VALUES_INDEX]) {
                 this.listPolymorphicValues = model.listPolymorphicValues;
-                if (this._bits.length > LIST_POLYMORPHIC_VALUES_INDEX) {
-                    this._bits[LIST_POLYMORPHIC_VALUES_INDEX] = true;
-                }
+                this._bits[LIST_POLYMORPHIC_VALUES_INDEX] = true;
             }
-            if (model.getListWithListAndOtherModelValuesIsSet()) {
+            if (model._bits.length > LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX && model._bits[LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX]) {
                 this.listWithListAndOtherModelValues = model.listWithListAndOtherModelValues;
-                if (this._bits.length > LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX) {
-                    this._bits[LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX] = true;
-                }
+                this._bits[LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX] = true;
             }
-            if (model.getListWithMapAndOtherModelValuesIsSet()) {
+            if (model._bits.length > LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX && model._bits[LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX]) {
                 this.listWithMapAndOtherModelValues = model.listWithMapAndOtherModelValues;
-                if (this._bits.length > LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX) {
-                    this._bits[LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX] = true;
-                }
+                this._bits[LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX] = true;
             }
-            if (model.getListWithObjectValuesIsSet()) {
+            if (model._bits.length > LIST_WITH_OBJECT_VALUES_INDEX && model._bits[LIST_WITH_OBJECT_VALUES_INDEX]) {
                 this.listWithObjectValues = model.listWithObjectValues;
-                if (this._bits.length > LIST_WITH_OBJECT_VALUES_INDEX) {
-                    this._bits[LIST_WITH_OBJECT_VALUES_INDEX] = true;
-                }
+                this._bits[LIST_WITH_OBJECT_VALUES_INDEX] = true;
             }
-            if (model.getListWithOtherModelValuesIsSet()) {
+            if (model._bits.length > LIST_WITH_OTHER_MODEL_VALUES_INDEX && model._bits[LIST_WITH_OTHER_MODEL_VALUES_INDEX]) {
                 this.listWithOtherModelValues = model.listWithOtherModelValues;
-                if (this._bits.length > LIST_WITH_OTHER_MODEL_VALUES_INDEX) {
-                    this._bits[LIST_WITH_OTHER_MODEL_VALUES_INDEX] = true;
-                }
+                this._bits[LIST_WITH_OTHER_MODEL_VALUES_INDEX] = true;
             }
-            if (model.getListWithPrimitiveValuesIsSet()) {
+            if (model._bits.length > LIST_WITH_PRIMITIVE_VALUES_INDEX && model._bits[LIST_WITH_PRIMITIVE_VALUES_INDEX]) {
                 this.listWithPrimitiveValues = model.listWithPrimitiveValues;
-                if (this._bits.length > LIST_WITH_PRIMITIVE_VALUES_INDEX) {
-                    this._bits[LIST_WITH_PRIMITIVE_VALUES_INDEX] = true;
-                }
+                this._bits[LIST_WITH_PRIMITIVE_VALUES_INDEX] = true;
             }
-            if (model.getMapPolymorphicValuesIsSet()) {
+            if (model._bits.length > MAP_POLYMORPHIC_VALUES_INDEX && model._bits[MAP_POLYMORPHIC_VALUES_INDEX]) {
                 this.mapPolymorphicValues = model.mapPolymorphicValues;
-                if (this._bits.length > MAP_POLYMORPHIC_VALUES_INDEX) {
-                    this._bits[MAP_POLYMORPHIC_VALUES_INDEX] = true;
-                }
+                this._bits[MAP_POLYMORPHIC_VALUES_INDEX] = true;
             }
-            if (model.getMapPropIsSet()) {
+            if (model._bits.length > MAP_PROP_INDEX && model._bits[MAP_PROP_INDEX]) {
                 this.mapProp = model.mapProp;
-                if (this._bits.length > MAP_PROP_INDEX) {
-                    this._bits[MAP_PROP_INDEX] = true;
-                }
+                this._bits[MAP_PROP_INDEX] = true;
             }
-            if (model.getMapWithListAndOtherModelValuesIsSet()) {
+            if (model._bits.length > MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX && model._bits[MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX]) {
                 this.mapWithListAndOtherModelValues = model.mapWithListAndOtherModelValues;
-                if (this._bits.length > MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX) {
-                    this._bits[MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX] = true;
-                }
+                this._bits[MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX] = true;
             }
-            if (model.getMapWithMapAndOtherModelValuesIsSet()) {
+            if (model._bits.length > MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX && model._bits[MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX]) {
                 this.mapWithMapAndOtherModelValues = model.mapWithMapAndOtherModelValues;
-                if (this._bits.length > MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX) {
-                    this._bits[MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX] = true;
-                }
+                this._bits[MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX] = true;
             }
-            if (model.getMapWithObjectValuesIsSet()) {
+            if (model._bits.length > MAP_WITH_OBJECT_VALUES_INDEX && model._bits[MAP_WITH_OBJECT_VALUES_INDEX]) {
                 this.mapWithObjectValues = model.mapWithObjectValues;
-                if (this._bits.length > MAP_WITH_OBJECT_VALUES_INDEX) {
-                    this._bits[MAP_WITH_OBJECT_VALUES_INDEX] = true;
-                }
+                this._bits[MAP_WITH_OBJECT_VALUES_INDEX] = true;
             }
-            if (model.getMapWithOtherModelValuesIsSet()) {
+            if (model._bits.length > MAP_WITH_OTHER_MODEL_VALUES_INDEX && model._bits[MAP_WITH_OTHER_MODEL_VALUES_INDEX]) {
                 this.mapWithOtherModelValues = model.mapWithOtherModelValues;
-                if (this._bits.length > MAP_WITH_OTHER_MODEL_VALUES_INDEX) {
-                    this._bits[MAP_WITH_OTHER_MODEL_VALUES_INDEX] = true;
-                }
+                this._bits[MAP_WITH_OTHER_MODEL_VALUES_INDEX] = true;
             }
-            if (model.getMapWithPrimitiveValuesIsSet()) {
+            if (model._bits.length > MAP_WITH_PRIMITIVE_VALUES_INDEX && model._bits[MAP_WITH_PRIMITIVE_VALUES_INDEX]) {
                 this.mapWithPrimitiveValues = model.mapWithPrimitiveValues;
-                if (this._bits.length > MAP_WITH_PRIMITIVE_VALUES_INDEX) {
-                    this._bits[MAP_WITH_PRIMITIVE_VALUES_INDEX] = true;
-                }
+                this._bits[MAP_WITH_PRIMITIVE_VALUES_INDEX] = true;
             }
-            if (model.getNsintegerEnumIsSet()) {
+            if (model._bits.length > NSINTEGER_ENUM_INDEX && model._bits[NSINTEGER_ENUM_INDEX]) {
                 this.nsintegerEnum = model.nsintegerEnum;
-                if (this._bits.length > NSINTEGER_ENUM_INDEX) {
-                    this._bits[NSINTEGER_ENUM_INDEX] = true;
-                }
+                this._bits[NSINTEGER_ENUM_INDEX] = true;
             }
-            if (model.getNsuintegerEnumIsSet()) {
+            if (model._bits.length > NSUINTEGER_ENUM_INDEX && model._bits[NSUINTEGER_ENUM_INDEX]) {
                 this.nsuintegerEnum = model.nsuintegerEnum;
-                if (this._bits.length > NSUINTEGER_ENUM_INDEX) {
-                    this._bits[NSUINTEGER_ENUM_INDEX] = true;
-                }
+                this._bits[NSUINTEGER_ENUM_INDEX] = true;
             }
-            if (model.getNumberPropIsSet()) {
+            if (model._bits.length > NUMBER_PROP_INDEX && model._bits[NUMBER_PROP_INDEX]) {
                 this.numberProp = model.numberProp;
-                if (this._bits.length > NUMBER_PROP_INDEX) {
-                    this._bits[NUMBER_PROP_INDEX] = true;
-                }
+                this._bits[NUMBER_PROP_INDEX] = true;
             }
-            if (model.getOtherModelPropIsSet()) {
+            if (model._bits.length > OTHER_MODEL_PROP_INDEX && model._bits[OTHER_MODEL_PROP_INDEX]) {
                 this.otherModelProp = model.otherModelProp;
-                if (this._bits.length > OTHER_MODEL_PROP_INDEX) {
-                    this._bits[OTHER_MODEL_PROP_INDEX] = true;
-                }
+                this._bits[OTHER_MODEL_PROP_INDEX] = true;
             }
-            if (model.getPolymorphicPropIsSet()) {
+            if (model._bits.length > POLYMORPHIC_PROP_INDEX && model._bits[POLYMORPHIC_PROP_INDEX]) {
                 this.polymorphicProp = model.polymorphicProp;
-                if (this._bits.length > POLYMORPHIC_PROP_INDEX) {
-                    this._bits[POLYMORPHIC_PROP_INDEX] = true;
-                }
+                this._bits[POLYMORPHIC_PROP_INDEX] = true;
             }
-            if (model.getSetPropIsSet()) {
+            if (model._bits.length > SET_PROP_INDEX && model._bits[SET_PROP_INDEX]) {
                 this.setProp = model.setProp;
-                if (this._bits.length > SET_PROP_INDEX) {
-                    this._bits[SET_PROP_INDEX] = true;
-                }
+                this._bits[SET_PROP_INDEX] = true;
             }
-            if (model.getSetPropWithOtherModelValuesIsSet()) {
+            if (model._bits.length > SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX && model._bits[SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX]) {
                 this.setPropWithOtherModelValues = model.setPropWithOtherModelValues;
-                if (this._bits.length > SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX) {
-                    this._bits[SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX] = true;
-                }
+                this._bits[SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX] = true;
             }
-            if (model.getSetPropWithPrimitiveValuesIsSet()) {
+            if (model._bits.length > SET_PROP_WITH_PRIMITIVE_VALUES_INDEX && model._bits[SET_PROP_WITH_PRIMITIVE_VALUES_INDEX]) {
                 this.setPropWithPrimitiveValues = model.setPropWithPrimitiveValues;
-                if (this._bits.length > SET_PROP_WITH_PRIMITIVE_VALUES_INDEX) {
-                    this._bits[SET_PROP_WITH_PRIMITIVE_VALUES_INDEX] = true;
-                }
+                this._bits[SET_PROP_WITH_PRIMITIVE_VALUES_INDEX] = true;
             }
-            if (model.getSetPropWithValuesIsSet()) {
+            if (model._bits.length > SET_PROP_WITH_VALUES_INDEX && model._bits[SET_PROP_WITH_VALUES_INDEX]) {
                 this.setPropWithValues = model.setPropWithValues;
-                if (this._bits.length > SET_PROP_WITH_VALUES_INDEX) {
-                    this._bits[SET_PROP_WITH_VALUES_INDEX] = true;
-                }
+                this._bits[SET_PROP_WITH_VALUES_INDEX] = true;
             }
-            if (model.getShortEnumIsSet()) {
+            if (model._bits.length > SHORT_ENUM_INDEX && model._bits[SHORT_ENUM_INDEX]) {
                 this.shortEnum = model.shortEnum;
-                if (this._bits.length > SHORT_ENUM_INDEX) {
-                    this._bits[SHORT_ENUM_INDEX] = true;
-                }
+                this._bits[SHORT_ENUM_INDEX] = true;
             }
-            if (model.getStringEnumIsSet()) {
+            if (model._bits.length > STRING_ENUM_INDEX && model._bits[STRING_ENUM_INDEX]) {
                 this.stringEnum = model.stringEnum;
-                if (this._bits.length > STRING_ENUM_INDEX) {
-                    this._bits[STRING_ENUM_INDEX] = true;
-                }
+                this._bits[STRING_ENUM_INDEX] = true;
             }
-            if (model.getStringPropIsSet()) {
+            if (model._bits.length > STRING_PROP_INDEX && model._bits[STRING_PROP_INDEX]) {
                 this.stringProp = model.stringProp;
-                if (this._bits.length > STRING_PROP_INDEX) {
-                    this._bits[STRING_PROP_INDEX] = true;
-                }
+                this._bits[STRING_PROP_INDEX] = true;
             }
-            if (model.getTypeIsSet()) {
+            if (model._bits.length > TYPE_INDEX && model._bits[TYPE_INDEX]) {
                 this.type = model.type;
-                if (this._bits.length > TYPE_INDEX) {
-                    this._bits[TYPE_INDEX] = true;
-                }
+                this._bits[TYPE_INDEX] = true;
             }
-            if (model.getUnsignedCharEnumIsSet()) {
+            if (model._bits.length > UNSIGNED_CHAR_ENUM_INDEX && model._bits[UNSIGNED_CHAR_ENUM_INDEX]) {
                 this.unsignedCharEnum = model.unsignedCharEnum;
-                if (this._bits.length > UNSIGNED_CHAR_ENUM_INDEX) {
-                    this._bits[UNSIGNED_CHAR_ENUM_INDEX] = true;
-                }
+                this._bits[UNSIGNED_CHAR_ENUM_INDEX] = true;
             }
-            if (model.getUnsignedIntEnumIsSet()) {
+            if (model._bits.length > UNSIGNED_INT_ENUM_INDEX && model._bits[UNSIGNED_INT_ENUM_INDEX]) {
                 this.unsignedIntEnum = model.unsignedIntEnum;
-                if (this._bits.length > UNSIGNED_INT_ENUM_INDEX) {
-                    this._bits[UNSIGNED_INT_ENUM_INDEX] = true;
-                }
+                this._bits[UNSIGNED_INT_ENUM_INDEX] = true;
             }
-            if (model.getUnsignedShortEnumIsSet()) {
+            if (model._bits.length > UNSIGNED_SHORT_ENUM_INDEX && model._bits[UNSIGNED_SHORT_ENUM_INDEX]) {
                 this.unsignedShortEnum = model.unsignedShortEnum;
-                if (this._bits.length > UNSIGNED_SHORT_ENUM_INDEX) {
-                    this._bits[UNSIGNED_SHORT_ENUM_INDEX] = true;
-                }
+                this._bits[UNSIGNED_SHORT_ENUM_INDEX] = true;
             }
-            if (model.getUriPropIsSet()) {
+            if (model._bits.length > URI_PROP_INDEX && model._bits[URI_PROP_INDEX]) {
                 this.uriProp = model.uriProp;
-                if (this._bits.length > URI_PROP_INDEX) {
-                    this._bits[URI_PROP_INDEX] = true;
-                }
+                this._bits[URI_PROP_INDEX] = true;
             }
         }
     }
@@ -1573,217 +1501,217 @@ public class Everything {
                 return;
             }
             writer.beginObject();
-            if (value.getArrayPropIsSet()) {
+            if (value._bits.length > ARRAY_PROP_INDEX && value._bits[ARRAY_PROP_INDEX]) {
                 if (this.list_Object_TypeAdapter == null) {
                     this.list_Object_TypeAdapter = this.gson.getAdapter(new TypeToken<List<Object>>(){}).nullSafe();
                 }
                 this.list_Object_TypeAdapter.write(writer.name("array_prop"), value.arrayProp);
             }
-            if (value.getBooleanPropIsSet()) {
+            if (value._bits.length > BOOLEAN_PROP_INDEX && value._bits[BOOLEAN_PROP_INDEX]) {
                 if (this.booleanTypeAdapter == null) {
                     this.booleanTypeAdapter = this.gson.getAdapter(Boolean.class).nullSafe();
                 }
                 this.booleanTypeAdapter.write(writer.name("boolean_prop"), value.booleanProp);
             }
-            if (value.getCharEnumIsSet()) {
+            if (value._bits.length > CHAR_ENUM_INDEX && value._bits[CHAR_ENUM_INDEX]) {
                 if (this.everythingCharEnumTypeAdapter == null) {
                     this.everythingCharEnumTypeAdapter = this.gson.getAdapter(EverythingCharEnum.class).nullSafe();
                 }
                 this.everythingCharEnumTypeAdapter.write(writer.name("char_enum"), value.charEnum);
             }
-            if (value.getDatePropIsSet()) {
+            if (value._bits.length > DATE_PROP_INDEX && value._bits[DATE_PROP_INDEX]) {
                 if (this.dateTypeAdapter == null) {
                     this.dateTypeAdapter = this.gson.getAdapter(Date.class).nullSafe();
                 }
                 this.dateTypeAdapter.write(writer.name("date_prop"), value.dateProp);
             }
-            if (value.getIntEnumIsSet()) {
+            if (value._bits.length > INT_ENUM_INDEX && value._bits[INT_ENUM_INDEX]) {
                 if (this.everythingIntEnumTypeAdapter == null) {
                     this.everythingIntEnumTypeAdapter = this.gson.getAdapter(EverythingIntEnum.class).nullSafe();
                 }
                 this.everythingIntEnumTypeAdapter.write(writer.name("int_enum"), value.intEnum);
             }
-            if (value.getIntPropIsSet()) {
+            if (value._bits.length > INT_PROP_INDEX && value._bits[INT_PROP_INDEX]) {
                 if (this.integerTypeAdapter == null) {
                     this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
                 }
                 this.integerTypeAdapter.write(writer.name("int_prop"), value.intProp);
             }
-            if (value.getListPolymorphicValuesIsSet()) {
+            if (value._bits.length > LIST_POLYMORPHIC_VALUES_INDEX && value._bits[LIST_POLYMORPHIC_VALUES_INDEX]) {
                 if (this.list_Object_TypeAdapter == null) {
                     this.list_Object_TypeAdapter = this.gson.getAdapter(new TypeToken<List<Object>>(){}).nullSafe();
                 }
                 this.list_Object_TypeAdapter.write(writer.name("list_polymorphic_values"), value.listPolymorphicValues);
             }
-            if (value.getListWithListAndOtherModelValuesIsSet()) {
+            if (value._bits.length > LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX && value._bits[LIST_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX]) {
                 if (this.list_List_User__TypeAdapter == null) {
                     this.list_List_User__TypeAdapter = this.gson.getAdapter(new TypeToken<List<List<User>>>(){}).nullSafe();
                 }
                 this.list_List_User__TypeAdapter.write(writer.name("list_with_list_and_other_model_values"), value.listWithListAndOtherModelValues);
             }
-            if (value.getListWithMapAndOtherModelValuesIsSet()) {
+            if (value._bits.length > LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX && value._bits[LIST_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX]) {
                 if (this.list_Map_String__User__TypeAdapter == null) {
                     this.list_Map_String__User__TypeAdapter = this.gson.getAdapter(new TypeToken<List<Map<String, User>>>(){}).nullSafe();
                 }
                 this.list_Map_String__User__TypeAdapter.write(writer.name("list_with_map_and_other_model_values"), value.listWithMapAndOtherModelValues);
             }
-            if (value.getListWithObjectValuesIsSet()) {
+            if (value._bits.length > LIST_WITH_OBJECT_VALUES_INDEX && value._bits[LIST_WITH_OBJECT_VALUES_INDEX]) {
                 if (this.list_String_TypeAdapter == null) {
                     this.list_String_TypeAdapter = this.gson.getAdapter(new TypeToken<List<String>>(){}).nullSafe();
                 }
                 this.list_String_TypeAdapter.write(writer.name("list_with_object_values"), value.listWithObjectValues);
             }
-            if (value.getListWithOtherModelValuesIsSet()) {
+            if (value._bits.length > LIST_WITH_OTHER_MODEL_VALUES_INDEX && value._bits[LIST_WITH_OTHER_MODEL_VALUES_INDEX]) {
                 if (this.list_User_TypeAdapter == null) {
                     this.list_User_TypeAdapter = this.gson.getAdapter(new TypeToken<List<User>>(){}).nullSafe();
                 }
                 this.list_User_TypeAdapter.write(writer.name("list_with_other_model_values"), value.listWithOtherModelValues);
             }
-            if (value.getListWithPrimitiveValuesIsSet()) {
+            if (value._bits.length > LIST_WITH_PRIMITIVE_VALUES_INDEX && value._bits[LIST_WITH_PRIMITIVE_VALUES_INDEX]) {
                 if (this.list_Integer_TypeAdapter == null) {
                     this.list_Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<List<Integer>>(){}).nullSafe();
                 }
                 this.list_Integer_TypeAdapter.write(writer.name("list_with_primitive_values"), value.listWithPrimitiveValues);
             }
-            if (value.getMapPolymorphicValuesIsSet()) {
+            if (value._bits.length > MAP_POLYMORPHIC_VALUES_INDEX && value._bits[MAP_POLYMORPHIC_VALUES_INDEX]) {
                 if (this.map_String__EverythingMapPolymorphicValues_TypeAdapter == null) {
                     this.map_String__EverythingMapPolymorphicValues_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, EverythingMapPolymorphicValues>>(){}).nullSafe();
                 }
                 this.map_String__EverythingMapPolymorphicValues_TypeAdapter.write(writer.name("map_polymorphic_values"), value.mapPolymorphicValues);
             }
-            if (value.getMapPropIsSet()) {
+            if (value._bits.length > MAP_PROP_INDEX && value._bits[MAP_PROP_INDEX]) {
                 if (this.map_String__Object_TypeAdapter == null) {
                     this.map_String__Object_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Object>>(){}).nullSafe();
                 }
                 this.map_String__Object_TypeAdapter.write(writer.name("map_prop"), value.mapProp);
             }
-            if (value.getMapWithListAndOtherModelValuesIsSet()) {
+            if (value._bits.length > MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX && value._bits[MAP_WITH_LIST_AND_OTHER_MODEL_VALUES_INDEX]) {
                 if (this.map_String__List_User__TypeAdapter == null) {
                     this.map_String__List_User__TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, List<User>>>(){}).nullSafe();
                 }
                 this.map_String__List_User__TypeAdapter.write(writer.name("map_with_list_and_other_model_values"), value.mapWithListAndOtherModelValues);
             }
-            if (value.getMapWithMapAndOtherModelValuesIsSet()) {
+            if (value._bits.length > MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX && value._bits[MAP_WITH_MAP_AND_OTHER_MODEL_VALUES_INDEX]) {
                 if (this.map_String__Map_String__Object__TypeAdapter == null) {
                     this.map_String__Map_String__Object__TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Map<String, Object>>>(){}).nullSafe();
                 }
                 this.map_String__Map_String__Object__TypeAdapter.write(writer.name("map_with_map_and_other_model_values"), value.mapWithMapAndOtherModelValues);
             }
-            if (value.getMapWithObjectValuesIsSet()) {
+            if (value._bits.length > MAP_WITH_OBJECT_VALUES_INDEX && value._bits[MAP_WITH_OBJECT_VALUES_INDEX]) {
                 if (this.map_String__String_TypeAdapter == null) {
                     this.map_String__String_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
                 }
                 this.map_String__String_TypeAdapter.write(writer.name("map_with_object_values"), value.mapWithObjectValues);
             }
-            if (value.getMapWithOtherModelValuesIsSet()) {
+            if (value._bits.length > MAP_WITH_OTHER_MODEL_VALUES_INDEX && value._bits[MAP_WITH_OTHER_MODEL_VALUES_INDEX]) {
                 if (this.map_String__User_TypeAdapter == null) {
                     this.map_String__User_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, User>>(){}).nullSafe();
                 }
                 this.map_String__User_TypeAdapter.write(writer.name("map_with_other_model_values"), value.mapWithOtherModelValues);
             }
-            if (value.getMapWithPrimitiveValuesIsSet()) {
+            if (value._bits.length > MAP_WITH_PRIMITIVE_VALUES_INDEX && value._bits[MAP_WITH_PRIMITIVE_VALUES_INDEX]) {
                 if (this.map_String__Integer_TypeAdapter == null) {
                     this.map_String__Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
                 }
                 this.map_String__Integer_TypeAdapter.write(writer.name("map_with_primitive_values"), value.mapWithPrimitiveValues);
             }
-            if (value.getNsintegerEnumIsSet()) {
+            if (value._bits.length > NSINTEGER_ENUM_INDEX && value._bits[NSINTEGER_ENUM_INDEX]) {
                 if (this.everythingNsintegerEnumTypeAdapter == null) {
                     this.everythingNsintegerEnumTypeAdapter = this.gson.getAdapter(EverythingNsintegerEnum.class).nullSafe();
                 }
                 this.everythingNsintegerEnumTypeAdapter.write(writer.name("nsinteger_enum"), value.nsintegerEnum);
             }
-            if (value.getNsuintegerEnumIsSet()) {
+            if (value._bits.length > NSUINTEGER_ENUM_INDEX && value._bits[NSUINTEGER_ENUM_INDEX]) {
                 if (this.everythingNsuintegerEnumTypeAdapter == null) {
                     this.everythingNsuintegerEnumTypeAdapter = this.gson.getAdapter(EverythingNsuintegerEnum.class).nullSafe();
                 }
                 this.everythingNsuintegerEnumTypeAdapter.write(writer.name("nsuinteger_enum"), value.nsuintegerEnum);
             }
-            if (value.getNumberPropIsSet()) {
+            if (value._bits.length > NUMBER_PROP_INDEX && value._bits[NUMBER_PROP_INDEX]) {
                 if (this.doubleTypeAdapter == null) {
                     this.doubleTypeAdapter = this.gson.getAdapter(Double.class).nullSafe();
                 }
                 this.doubleTypeAdapter.write(writer.name("number_prop"), value.numberProp);
             }
-            if (value.getOtherModelPropIsSet()) {
+            if (value._bits.length > OTHER_MODEL_PROP_INDEX && value._bits[OTHER_MODEL_PROP_INDEX]) {
                 if (this.userTypeAdapter == null) {
                     this.userTypeAdapter = this.gson.getAdapter(User.class).nullSafe();
                 }
                 this.userTypeAdapter.write(writer.name("other_model_prop"), value.otherModelProp);
             }
-            if (value.getPolymorphicPropIsSet()) {
+            if (value._bits.length > POLYMORPHIC_PROP_INDEX && value._bits[POLYMORPHIC_PROP_INDEX]) {
                 if (this.everythingPolymorphicPropTypeAdapter == null) {
                     this.everythingPolymorphicPropTypeAdapter = this.gson.getAdapter(EverythingPolymorphicProp.class).nullSafe();
                 }
                 this.everythingPolymorphicPropTypeAdapter.write(writer.name("polymorphic_prop"), value.polymorphicProp);
             }
-            if (value.getSetPropIsSet()) {
+            if (value._bits.length > SET_PROP_INDEX && value._bits[SET_PROP_INDEX]) {
                 if (this.set_Object_TypeAdapter == null) {
                     this.set_Object_TypeAdapter = this.gson.getAdapter(new TypeToken<Set<Object>>(){}).nullSafe();
                 }
                 this.set_Object_TypeAdapter.write(writer.name("set_prop"), value.setProp);
             }
-            if (value.getSetPropWithOtherModelValuesIsSet()) {
+            if (value._bits.length > SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX && value._bits[SET_PROP_WITH_OTHER_MODEL_VALUES_INDEX]) {
                 if (this.set_User_TypeAdapter == null) {
                     this.set_User_TypeAdapter = this.gson.getAdapter(new TypeToken<Set<User>>(){}).nullSafe();
                 }
                 this.set_User_TypeAdapter.write(writer.name("set_prop_with_other_model_values"), value.setPropWithOtherModelValues);
             }
-            if (value.getSetPropWithPrimitiveValuesIsSet()) {
+            if (value._bits.length > SET_PROP_WITH_PRIMITIVE_VALUES_INDEX && value._bits[SET_PROP_WITH_PRIMITIVE_VALUES_INDEX]) {
                 if (this.set_Integer_TypeAdapter == null) {
                     this.set_Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<Set<Integer>>(){}).nullSafe();
                 }
                 this.set_Integer_TypeAdapter.write(writer.name("set_prop_with_primitive_values"), value.setPropWithPrimitiveValues);
             }
-            if (value.getSetPropWithValuesIsSet()) {
+            if (value._bits.length > SET_PROP_WITH_VALUES_INDEX && value._bits[SET_PROP_WITH_VALUES_INDEX]) {
                 if (this.set_String_TypeAdapter == null) {
                     this.set_String_TypeAdapter = this.gson.getAdapter(new TypeToken<Set<String>>(){}).nullSafe();
                 }
                 this.set_String_TypeAdapter.write(writer.name("set_prop_with_values"), value.setPropWithValues);
             }
-            if (value.getShortEnumIsSet()) {
+            if (value._bits.length > SHORT_ENUM_INDEX && value._bits[SHORT_ENUM_INDEX]) {
                 if (this.everythingShortEnumTypeAdapter == null) {
                     this.everythingShortEnumTypeAdapter = this.gson.getAdapter(EverythingShortEnum.class).nullSafe();
                 }
                 this.everythingShortEnumTypeAdapter.write(writer.name("short_enum"), value.shortEnum);
             }
-            if (value.getStringEnumIsSet()) {
+            if (value._bits.length > STRING_ENUM_INDEX && value._bits[STRING_ENUM_INDEX]) {
                 if (this.everythingStringEnumTypeAdapter == null) {
                     this.everythingStringEnumTypeAdapter = this.gson.getAdapter(EverythingStringEnum.class).nullSafe();
                 }
                 this.everythingStringEnumTypeAdapter.write(writer.name("string_enum"), value.stringEnum);
             }
-            if (value.getStringPropIsSet()) {
+            if (value._bits.length > STRING_PROP_INDEX && value._bits[STRING_PROP_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("string_prop"), value.stringProp);
             }
-            if (value.getTypeIsSet()) {
+            if (value._bits.length > TYPE_INDEX && value._bits[TYPE_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("type"), value.type);
             }
-            if (value.getUnsignedCharEnumIsSet()) {
+            if (value._bits.length > UNSIGNED_CHAR_ENUM_INDEX && value._bits[UNSIGNED_CHAR_ENUM_INDEX]) {
                 if (this.everythingUnsignedCharEnumTypeAdapter == null) {
                     this.everythingUnsignedCharEnumTypeAdapter = this.gson.getAdapter(EverythingUnsignedCharEnum.class).nullSafe();
                 }
                 this.everythingUnsignedCharEnumTypeAdapter.write(writer.name("unsigned_char_enum"), value.unsignedCharEnum);
             }
-            if (value.getUnsignedIntEnumIsSet()) {
+            if (value._bits.length > UNSIGNED_INT_ENUM_INDEX && value._bits[UNSIGNED_INT_ENUM_INDEX]) {
                 if (this.everythingUnsignedIntEnumTypeAdapter == null) {
                     this.everythingUnsignedIntEnumTypeAdapter = this.gson.getAdapter(EverythingUnsignedIntEnum.class).nullSafe();
                 }
                 this.everythingUnsignedIntEnumTypeAdapter.write(writer.name("unsigned_int_enum"), value.unsignedIntEnum);
             }
-            if (value.getUnsignedShortEnumIsSet()) {
+            if (value._bits.length > UNSIGNED_SHORT_ENUM_INDEX && value._bits[UNSIGNED_SHORT_ENUM_INDEX]) {
                 if (this.everythingUnsignedShortEnumTypeAdapter == null) {
                     this.everythingUnsignedShortEnumTypeAdapter = this.gson.getAdapter(EverythingUnsignedShortEnum.class).nullSafe();
                 }
                 this.everythingUnsignedShortEnumTypeAdapter.write(writer.name("unsigned_short_enum"), value.unsignedShortEnum);
             }
-            if (value.getUriPropIsSet()) {
+            if (value._bits.length > URI_PROP_INDEX && value._bits[URI_PROP_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -180,23 +180,17 @@ public class Image {
         }
 
         public void mergeFrom(@NonNull Image model) {
-            if (model.getHeightIsSet()) {
+            if (model._bits.length > HEIGHT_INDEX && model._bits[HEIGHT_INDEX]) {
                 this.height = model.height;
-                if (this._bits.length > HEIGHT_INDEX) {
-                    this._bits[HEIGHT_INDEX] = true;
-                }
+                this._bits[HEIGHT_INDEX] = true;
             }
-            if (model.getUrlIsSet()) {
+            if (model._bits.length > URL_INDEX && model._bits[URL_INDEX]) {
                 this.url = model.url;
-                if (this._bits.length > URL_INDEX) {
-                    this._bits[URL_INDEX] = true;
-                }
+                this._bits[URL_INDEX] = true;
             }
-            if (model.getWidthIsSet()) {
+            if (model._bits.length > WIDTH_INDEX && model._bits[WIDTH_INDEX]) {
                 this.width = model.width;
-                if (this._bits.length > WIDTH_INDEX) {
-                    this._bits[WIDTH_INDEX] = true;
-                }
+                this._bits[WIDTH_INDEX] = true;
             }
         }
     }
@@ -230,19 +224,19 @@ public class Image {
                 return;
             }
             writer.beginObject();
-            if (value.getHeightIsSet()) {
+            if (value._bits.length > HEIGHT_INDEX && value._bits[HEIGHT_INDEX]) {
                 if (this.integerTypeAdapter == null) {
                     this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
                 }
                 this.integerTypeAdapter.write(writer.name("height"), value.height);
             }
-            if (value.getUrlIsSet()) {
+            if (value._bits.length > URL_INDEX && value._bits[URL_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("url"), value.url);
             }
-            if (value.getWidthIsSet()) {
+            if (value._bits.length > WIDTH_INDEX && value._bits[WIDTH_INDEX]) {
                 if (this.integerTypeAdapter == null) {
                     this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
                 }

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -118,11 +118,9 @@ public class Model {
         }
 
         public void mergeFrom(@NonNull Model model) {
-            if (model.getUidIsSet()) {
+            if (model._bits.length > ID_INDEX && model._bits[ID_INDEX]) {
                 this.uid = model.uid;
-                if (this._bits.length > ID_INDEX) {
-                    this._bits[ID_INDEX] = true;
-                }
+                this._bits[ID_INDEX] = true;
             }
         }
     }
@@ -155,7 +153,7 @@ public class Model {
                 return;
             }
             writer.beginObject();
-            if (value.getUidIsSet()) {
+            if (value._bits.length > ID_INDEX && value._bits[ID_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -619,107 +619,73 @@ public class Pin {
         }
 
         public void mergeFrom(@NonNull Pin model) {
-            if (model.getAttributionIsSet()) {
+            if (model._bits.length > ATTRIBUTION_INDEX && model._bits[ATTRIBUTION_INDEX]) {
                 this.attribution = model.attribution;
-                if (this._bits.length > ATTRIBUTION_INDEX) {
-                    this._bits[ATTRIBUTION_INDEX] = true;
-                }
+                this._bits[ATTRIBUTION_INDEX] = true;
             }
-            if (model.getAttributionObjectsIsSet()) {
+            if (model._bits.length > ATTRIBUTION_OBJECTS_INDEX && model._bits[ATTRIBUTION_OBJECTS_INDEX]) {
                 this.attributionObjects = model.attributionObjects;
-                if (this._bits.length > ATTRIBUTION_OBJECTS_INDEX) {
-                    this._bits[ATTRIBUTION_OBJECTS_INDEX] = true;
-                }
+                this._bits[ATTRIBUTION_OBJECTS_INDEX] = true;
             }
-            if (model.getBoardIsSet()) {
+            if (model._bits.length > BOARD_INDEX && model._bits[BOARD_INDEX]) {
                 this.board = model.board;
-                if (this._bits.length > BOARD_INDEX) {
-                    this._bits[BOARD_INDEX] = true;
-                }
+                this._bits[BOARD_INDEX] = true;
             }
-            if (model.getColorIsSet()) {
+            if (model._bits.length > COLOR_INDEX && model._bits[COLOR_INDEX]) {
                 this.color = model.color;
-                if (this._bits.length > COLOR_INDEX) {
-                    this._bits[COLOR_INDEX] = true;
-                }
+                this._bits[COLOR_INDEX] = true;
             }
-            if (model.getCountsIsSet()) {
+            if (model._bits.length > COUNTS_INDEX && model._bits[COUNTS_INDEX]) {
                 this.counts = model.counts;
-                if (this._bits.length > COUNTS_INDEX) {
-                    this._bits[COUNTS_INDEX] = true;
-                }
+                this._bits[COUNTS_INDEX] = true;
             }
-            if (model.getCreatedAtIsSet()) {
+            if (model._bits.length > CREATED_AT_INDEX && model._bits[CREATED_AT_INDEX]) {
                 this.createdAt = model.createdAt;
-                if (this._bits.length > CREATED_AT_INDEX) {
-                    this._bits[CREATED_AT_INDEX] = true;
-                }
+                this._bits[CREATED_AT_INDEX] = true;
             }
-            if (model.getCreatorIsSet()) {
+            if (model._bits.length > CREATOR_INDEX && model._bits[CREATOR_INDEX]) {
                 this.creator = model.creator;
-                if (this._bits.length > CREATOR_INDEX) {
-                    this._bits[CREATOR_INDEX] = true;
-                }
+                this._bits[CREATOR_INDEX] = true;
             }
-            if (model.getDescriptionIsSet()) {
+            if (model._bits.length > DESCRIPTION_INDEX && model._bits[DESCRIPTION_INDEX]) {
                 this.description = model.description;
-                if (this._bits.length > DESCRIPTION_INDEX) {
-                    this._bits[DESCRIPTION_INDEX] = true;
-                }
+                this._bits[DESCRIPTION_INDEX] = true;
             }
-            if (model.getUidIsSet()) {
+            if (model._bits.length > ID_INDEX && model._bits[ID_INDEX]) {
                 this.uid = model.uid;
-                if (this._bits.length > ID_INDEX) {
-                    this._bits[ID_INDEX] = true;
-                }
+                this._bits[ID_INDEX] = true;
             }
-            if (model.getImageIsSet()) {
+            if (model._bits.length > IMAGE_INDEX && model._bits[IMAGE_INDEX]) {
                 this.image = model.image;
-                if (this._bits.length > IMAGE_INDEX) {
-                    this._bits[IMAGE_INDEX] = true;
-                }
+                this._bits[IMAGE_INDEX] = true;
             }
-            if (model.getInStockIsSet()) {
+            if (model._bits.length > IN_STOCK_INDEX && model._bits[IN_STOCK_INDEX]) {
                 this.inStock = model.inStock;
-                if (this._bits.length > IN_STOCK_INDEX) {
-                    this._bits[IN_STOCK_INDEX] = true;
-                }
+                this._bits[IN_STOCK_INDEX] = true;
             }
-            if (model.getLinkIsSet()) {
+            if (model._bits.length > LINK_INDEX && model._bits[LINK_INDEX]) {
                 this.link = model.link;
-                if (this._bits.length > LINK_INDEX) {
-                    this._bits[LINK_INDEX] = true;
-                }
+                this._bits[LINK_INDEX] = true;
             }
-            if (model.getMediaIsSet()) {
+            if (model._bits.length > MEDIA_INDEX && model._bits[MEDIA_INDEX]) {
                 this.media = model.media;
-                if (this._bits.length > MEDIA_INDEX) {
-                    this._bits[MEDIA_INDEX] = true;
-                }
+                this._bits[MEDIA_INDEX] = true;
             }
-            if (model.getNoteIsSet()) {
+            if (model._bits.length > NOTE_INDEX && model._bits[NOTE_INDEX]) {
                 this.note = model.note;
-                if (this._bits.length > NOTE_INDEX) {
-                    this._bits[NOTE_INDEX] = true;
-                }
+                this._bits[NOTE_INDEX] = true;
             }
-            if (model.getTagsIsSet()) {
+            if (model._bits.length > TAGS_INDEX && model._bits[TAGS_INDEX]) {
                 this.tags = model.tags;
-                if (this._bits.length > TAGS_INDEX) {
-                    this._bits[TAGS_INDEX] = true;
-                }
+                this._bits[TAGS_INDEX] = true;
             }
-            if (model.getUrlIsSet()) {
+            if (model._bits.length > URL_INDEX && model._bits[URL_INDEX]) {
                 this.url = model.url;
-                if (this._bits.length > URL_INDEX) {
-                    this._bits[URL_INDEX] = true;
-                }
+                this._bits[URL_INDEX] = true;
             }
-            if (model.getVisualSearchAttrsIsSet()) {
+            if (model._bits.length > VISUAL_SEARCH_ATTRS_INDEX && model._bits[VISUAL_SEARCH_ATTRS_INDEX]) {
                 this.visualSearchAttrs = model.visualSearchAttrs;
-                if (this._bits.length > VISUAL_SEARCH_ATTRS_INDEX) {
-                    this._bits[VISUAL_SEARCH_ATTRS_INDEX] = true;
-                }
+                this._bits[VISUAL_SEARCH_ATTRS_INDEX] = true;
             }
         }
     }
@@ -762,103 +728,103 @@ public class Pin {
                 return;
             }
             writer.beginObject();
-            if (value.getAttributionIsSet()) {
+            if (value._bits.length > ATTRIBUTION_INDEX && value._bits[ATTRIBUTION_INDEX]) {
                 if (this.map_String__String_TypeAdapter == null) {
                     this.map_String__String_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
                 }
                 this.map_String__String_TypeAdapter.write(writer.name("attribution"), value.attribution);
             }
-            if (value.getAttributionObjectsIsSet()) {
+            if (value._bits.length > ATTRIBUTION_OBJECTS_INDEX && value._bits[ATTRIBUTION_OBJECTS_INDEX]) {
                 if (this.list_PinAttributionObjects_TypeAdapter == null) {
                     this.list_PinAttributionObjects_TypeAdapter = this.gson.getAdapter(new TypeToken<List<PinAttributionObjects>>(){}).nullSafe();
                 }
                 this.list_PinAttributionObjects_TypeAdapter.write(writer.name("attribution_objects"), value.attributionObjects);
             }
-            if (value.getBoardIsSet()) {
+            if (value._bits.length > BOARD_INDEX && value._bits[BOARD_INDEX]) {
                 if (this.boardTypeAdapter == null) {
                     this.boardTypeAdapter = this.gson.getAdapter(Board.class).nullSafe();
                 }
                 this.boardTypeAdapter.write(writer.name("board"), value.board);
             }
-            if (value.getColorIsSet()) {
+            if (value._bits.length > COLOR_INDEX && value._bits[COLOR_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("color"), value.color);
             }
-            if (value.getCountsIsSet()) {
+            if (value._bits.length > COUNTS_INDEX && value._bits[COUNTS_INDEX]) {
                 if (this.map_String__Integer_TypeAdapter == null) {
                     this.map_String__Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
                 }
                 this.map_String__Integer_TypeAdapter.write(writer.name("counts"), value.counts);
             }
-            if (value.getCreatedAtIsSet()) {
+            if (value._bits.length > CREATED_AT_INDEX && value._bits[CREATED_AT_INDEX]) {
                 if (this.dateTypeAdapter == null) {
                     this.dateTypeAdapter = this.gson.getAdapter(Date.class).nullSafe();
                 }
                 this.dateTypeAdapter.write(writer.name("created_at"), value.createdAt);
             }
-            if (value.getCreatorIsSet()) {
+            if (value._bits.length > CREATOR_INDEX && value._bits[CREATOR_INDEX]) {
                 if (this.map_String__User_TypeAdapter == null) {
                     this.map_String__User_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, User>>(){}).nullSafe();
                 }
                 this.map_String__User_TypeAdapter.write(writer.name("creator"), value.creator);
             }
-            if (value.getDescriptionIsSet()) {
+            if (value._bits.length > DESCRIPTION_INDEX && value._bits[DESCRIPTION_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("description"), value.description);
             }
-            if (value.getUidIsSet()) {
+            if (value._bits.length > ID_INDEX && value._bits[ID_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("id"), value.uid);
             }
-            if (value.getImageIsSet()) {
+            if (value._bits.length > IMAGE_INDEX && value._bits[IMAGE_INDEX]) {
                 if (this.imageTypeAdapter == null) {
                     this.imageTypeAdapter = this.gson.getAdapter(Image.class).nullSafe();
                 }
                 this.imageTypeAdapter.write(writer.name("image"), value.image);
             }
-            if (value.getInStockIsSet()) {
+            if (value._bits.length > IN_STOCK_INDEX && value._bits[IN_STOCK_INDEX]) {
                 if (this.pinInStockTypeAdapter == null) {
                     this.pinInStockTypeAdapter = this.gson.getAdapter(PinInStock.class).nullSafe();
                 }
                 this.pinInStockTypeAdapter.write(writer.name("in_stock"), value.inStock);
             }
-            if (value.getLinkIsSet()) {
+            if (value._bits.length > LINK_INDEX && value._bits[LINK_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("link"), value.link);
             }
-            if (value.getMediaIsSet()) {
+            if (value._bits.length > MEDIA_INDEX && value._bits[MEDIA_INDEX]) {
                 if (this.map_String__String_TypeAdapter == null) {
                     this.map_String__String_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, String>>(){}).nullSafe();
                 }
                 this.map_String__String_TypeAdapter.write(writer.name("media"), value.media);
             }
-            if (value.getNoteIsSet()) {
+            if (value._bits.length > NOTE_INDEX && value._bits[NOTE_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("note"), value.note);
             }
-            if (value.getTagsIsSet()) {
+            if (value._bits.length > TAGS_INDEX && value._bits[TAGS_INDEX]) {
                 if (this.list_Map_String__Object__TypeAdapter == null) {
                     this.list_Map_String__Object__TypeAdapter = this.gson.getAdapter(new TypeToken<List<Map<String, Object>>>(){}).nullSafe();
                 }
                 this.list_Map_String__Object__TypeAdapter.write(writer.name("tags"), value.tags);
             }
-            if (value.getUrlIsSet()) {
+            if (value._bits.length > URL_INDEX && value._bits[URL_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("url"), value.url);
             }
-            if (value.getVisualSearchAttrsIsSet()) {
+            if (value._bits.length > VISUAL_SEARCH_ATTRS_INDEX && value._bits[VISUAL_SEARCH_ATTRS_INDEX]) {
                 if (this.map_String__Object_TypeAdapter == null) {
                     this.map_String__Object_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Object>>(){}).nullSafe();
                 }

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -394,65 +394,45 @@ public class User {
         }
 
         public void mergeFrom(@NonNull User model) {
-            if (model.getBioIsSet()) {
+            if (model._bits.length > BIO_INDEX && model._bits[BIO_INDEX]) {
                 this.bio = model.bio;
-                if (this._bits.length > BIO_INDEX) {
-                    this._bits[BIO_INDEX] = true;
-                }
+                this._bits[BIO_INDEX] = true;
             }
-            if (model.getCountsIsSet()) {
+            if (model._bits.length > COUNTS_INDEX && model._bits[COUNTS_INDEX]) {
                 this.counts = model.counts;
-                if (this._bits.length > COUNTS_INDEX) {
-                    this._bits[COUNTS_INDEX] = true;
-                }
+                this._bits[COUNTS_INDEX] = true;
             }
-            if (model.getCreatedAtIsSet()) {
+            if (model._bits.length > CREATED_AT_INDEX && model._bits[CREATED_AT_INDEX]) {
                 this.createdAt = model.createdAt;
-                if (this._bits.length > CREATED_AT_INDEX) {
-                    this._bits[CREATED_AT_INDEX] = true;
-                }
+                this._bits[CREATED_AT_INDEX] = true;
             }
-            if (model.getEmailFrequencyIsSet()) {
+            if (model._bits.length > EMAIL_FREQUENCY_INDEX && model._bits[EMAIL_FREQUENCY_INDEX]) {
                 this.emailFrequency = model.emailFrequency;
-                if (this._bits.length > EMAIL_FREQUENCY_INDEX) {
-                    this._bits[EMAIL_FREQUENCY_INDEX] = true;
-                }
+                this._bits[EMAIL_FREQUENCY_INDEX] = true;
             }
-            if (model.getFirstNameIsSet()) {
+            if (model._bits.length > FIRST_NAME_INDEX && model._bits[FIRST_NAME_INDEX]) {
                 this.firstName = model.firstName;
-                if (this._bits.length > FIRST_NAME_INDEX) {
-                    this._bits[FIRST_NAME_INDEX] = true;
-                }
+                this._bits[FIRST_NAME_INDEX] = true;
             }
-            if (model.getUidIsSet()) {
+            if (model._bits.length > ID_INDEX && model._bits[ID_INDEX]) {
                 this.uid = model.uid;
-                if (this._bits.length > ID_INDEX) {
-                    this._bits[ID_INDEX] = true;
-                }
+                this._bits[ID_INDEX] = true;
             }
-            if (model.getImageIsSet()) {
+            if (model._bits.length > IMAGE_INDEX && model._bits[IMAGE_INDEX]) {
                 this.image = model.image;
-                if (this._bits.length > IMAGE_INDEX) {
-                    this._bits[IMAGE_INDEX] = true;
-                }
+                this._bits[IMAGE_INDEX] = true;
             }
-            if (model.getLastNameIsSet()) {
+            if (model._bits.length > LAST_NAME_INDEX && model._bits[LAST_NAME_INDEX]) {
                 this.lastName = model.lastName;
-                if (this._bits.length > LAST_NAME_INDEX) {
-                    this._bits[LAST_NAME_INDEX] = true;
-                }
+                this._bits[LAST_NAME_INDEX] = true;
             }
-            if (model.getTypeIsSet()) {
+            if (model._bits.length > TYPE_INDEX && model._bits[TYPE_INDEX]) {
                 this.type = model.type;
-                if (this._bits.length > TYPE_INDEX) {
-                    this._bits[TYPE_INDEX] = true;
-                }
+                this._bits[TYPE_INDEX] = true;
             }
-            if (model.getUsernameIsSet()) {
+            if (model._bits.length > USERNAME_INDEX && model._bits[USERNAME_INDEX]) {
                 this.username = model.username;
-                if (this._bits.length > USERNAME_INDEX) {
-                    this._bits[USERNAME_INDEX] = true;
-                }
+                this._bits[USERNAME_INDEX] = true;
             }
         }
     }
@@ -489,61 +469,61 @@ public class User {
                 return;
             }
             writer.beginObject();
-            if (value.getBioIsSet()) {
+            if (value._bits.length > BIO_INDEX && value._bits[BIO_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("bio"), value.bio);
             }
-            if (value.getCountsIsSet()) {
+            if (value._bits.length > COUNTS_INDEX && value._bits[COUNTS_INDEX]) {
                 if (this.map_String__Integer_TypeAdapter == null) {
                     this.map_String__Integer_TypeAdapter = this.gson.getAdapter(new TypeToken<Map<String, Integer>>(){}).nullSafe();
                 }
                 this.map_String__Integer_TypeAdapter.write(writer.name("counts"), value.counts);
             }
-            if (value.getCreatedAtIsSet()) {
+            if (value._bits.length > CREATED_AT_INDEX && value._bits[CREATED_AT_INDEX]) {
                 if (this.dateTypeAdapter == null) {
                     this.dateTypeAdapter = this.gson.getAdapter(Date.class).nullSafe();
                 }
                 this.dateTypeAdapter.write(writer.name("created_at"), value.createdAt);
             }
-            if (value.getEmailFrequencyIsSet()) {
+            if (value._bits.length > EMAIL_FREQUENCY_INDEX && value._bits[EMAIL_FREQUENCY_INDEX]) {
                 if (this.userEmailFrequencyTypeAdapter == null) {
                     this.userEmailFrequencyTypeAdapter = this.gson.getAdapter(UserEmailFrequency.class).nullSafe();
                 }
                 this.userEmailFrequencyTypeAdapter.write(writer.name("email_frequency"), value.emailFrequency);
             }
-            if (value.getFirstNameIsSet()) {
+            if (value._bits.length > FIRST_NAME_INDEX && value._bits[FIRST_NAME_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("first_name"), value.firstName);
             }
-            if (value.getUidIsSet()) {
+            if (value._bits.length > ID_INDEX && value._bits[ID_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("id"), value.uid);
             }
-            if (value.getImageIsSet()) {
+            if (value._bits.length > IMAGE_INDEX && value._bits[IMAGE_INDEX]) {
                 if (this.imageTypeAdapter == null) {
                     this.imageTypeAdapter = this.gson.getAdapter(Image.class).nullSafe();
                 }
                 this.imageTypeAdapter.write(writer.name("image"), value.image);
             }
-            if (value.getLastNameIsSet()) {
+            if (value._bits.length > LAST_NAME_INDEX && value._bits[LAST_NAME_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("last_name"), value.lastName);
             }
-            if (value.getTypeIsSet()) {
+            if (value._bits.length > TYPE_INDEX && value._bits[TYPE_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }
                 this.stringTypeAdapter.write(writer.name("type"), value.type);
             }
-            if (value.getUsernameIsSet()) {
+            if (value._bits.length > USERNAME_INDEX && value._bits[USERNAME_INDEX]) {
                 if (this.stringTypeAdapter == null) {
                     this.stringTypeAdapter = this.gson.getAdapter(String.class).nullSafe();
                 }

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -212,29 +212,21 @@ public class VariableSubtitution {
         }
 
         public void mergeFrom(@NonNull VariableSubtitution model) {
-            if (model.getAllocPropIsSet()) {
+            if (model._bits.length > ALLOC_PROP_INDEX && model._bits[ALLOC_PROP_INDEX]) {
                 this.allocProp = model.allocProp;
-                if (this._bits.length > ALLOC_PROP_INDEX) {
-                    this._bits[ALLOC_PROP_INDEX] = true;
-                }
+                this._bits[ALLOC_PROP_INDEX] = true;
             }
-            if (model.getCopyPropIsSet()) {
+            if (model._bits.length > COPY_PROP_INDEX && model._bits[COPY_PROP_INDEX]) {
                 this.copyProp = model.copyProp;
-                if (this._bits.length > COPY_PROP_INDEX) {
-                    this._bits[COPY_PROP_INDEX] = true;
-                }
+                this._bits[COPY_PROP_INDEX] = true;
             }
-            if (model.getMutableCopyPropIsSet()) {
+            if (model._bits.length > MUTABLE_COPY_PROP_INDEX && model._bits[MUTABLE_COPY_PROP_INDEX]) {
                 this.mutableCopyProp = model.mutableCopyProp;
-                if (this._bits.length > MUTABLE_COPY_PROP_INDEX) {
-                    this._bits[MUTABLE_COPY_PROP_INDEX] = true;
-                }
+                this._bits[MUTABLE_COPY_PROP_INDEX] = true;
             }
-            if (model.getNewPropIsSet()) {
+            if (model._bits.length > NEW_PROP_INDEX && model._bits[NEW_PROP_INDEX]) {
                 this.newProp = model.newProp;
-                if (this._bits.length > NEW_PROP_INDEX) {
-                    this._bits[NEW_PROP_INDEX] = true;
-                }
+                this._bits[NEW_PROP_INDEX] = true;
             }
         }
     }
@@ -267,25 +259,25 @@ public class VariableSubtitution {
                 return;
             }
             writer.beginObject();
-            if (value.getAllocPropIsSet()) {
+            if (value._bits.length > ALLOC_PROP_INDEX && value._bits[ALLOC_PROP_INDEX]) {
                 if (this.integerTypeAdapter == null) {
                     this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
                 }
                 this.integerTypeAdapter.write(writer.name("alloc_prop"), value.allocProp);
             }
-            if (value.getCopyPropIsSet()) {
+            if (value._bits.length > COPY_PROP_INDEX && value._bits[COPY_PROP_INDEX]) {
                 if (this.integerTypeAdapter == null) {
                     this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
                 }
                 this.integerTypeAdapter.write(writer.name("copy_prop"), value.copyProp);
             }
-            if (value.getMutableCopyPropIsSet()) {
+            if (value._bits.length > MUTABLE_COPY_PROP_INDEX && value._bits[MUTABLE_COPY_PROP_INDEX]) {
                 if (this.integerTypeAdapter == null) {
                     this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
                 }
                 this.integerTypeAdapter.write(writer.name("mutable_copy_prop"), value.mutableCopyProp);
             }
-            if (value.getNewPropIsSet()) {
+            if (value._bits.length > NEW_PROP_INDEX && value._bits[NEW_PROP_INDEX]) {
                 if (this.integerTypeAdapter == null) {
                     this.integerTypeAdapter = this.gson.getAdapter(Integer.class).nullSafe();
                 }

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -230,11 +230,9 @@ public struct JavaModelRenderer: JavaFileRenderer {
 
     func renderBuilderMerge() -> JavaIR.Method {
         let body = (transitiveProperties.map { param, _ in
-            JavaIR.ifBlock(condition: "model.get" + Languages.java.snakeCaseToCapitalizedPropertyName(param) + "IsSet()") { [
+            JavaIR.ifBlock(condition: "model._bits.length > " + param.uppercased() + "_INDEX && model._bits[" + param.uppercased() + "_INDEX]") { [
                 "this." + Languages.java.snakeCaseToPropertyName(param) + " = model." + Languages.java.snakeCaseToPropertyName(param) + ";",
-                JavaIR.ifBlock(condition: "this._bits.length > " + param.uppercased() + "_INDEX") { [
-                    "this._bits[" + param.uppercased() + "_INDEX] = true;",
-                ] },
+                "this._bits[" + param.uppercased() + "_INDEX] = true;",
             ] }
         })
         return JavaIR.method([.public], "void mergeFrom(@NonNull " + className + " model)") { body }
@@ -318,7 +316,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
             transitiveProperties.map { param, schemaObj in
                 let type = unwrappedTypeFromSchema(param, schemaObj.schema)
                 let typeAdapterVariableName = typeAdapterVariableNameForType(type)
-                return JavaIR.ifBlock(condition: "value.get" + Languages.java.snakeCaseToCapitalizedPropertyName(param) + "IsSet()") { [
+                return JavaIR.ifBlock(condition: "value._bits.length > " + param.uppercased() + "_INDEX && value._bits[" + param.uppercased() + "_INDEX]") { [
                     // Creates TypeAdapter if necessary
                     JavaIR.ifBlock(condition: "this." + typeAdapterVariableName + " == null") { [
                         schemaObj.schema.isJavaCollection ? "this.\(typeAdapterVariableName) = this.gson.getAdapter(new TypeToken<\(type)>(){}).nullSafe();" : "this.\(typeAdapterVariableName) = this.gson.getAdapter(\(type).class).nullSafe();",


### PR DESCRIPTION
Avoid calling our generated get{Foo}IsSet() methods from within the
Builder's methods because we have access to the models' _bits array.

This saves the method call and, in most cases, removes the only caller
of those methods, allowing them to be potentially stripped out from the
final build artifact if they're otherwise unused.