### PR TITLE
Optionally log unknown properties in TypeAdapter.read

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -604,6 +604,7 @@ public class Board {
                         break;
                     default:
                         reader.skipValue();
+                        break;
                 }
             }
             reader.endObject();

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -1950,6 +1950,7 @@ public class Everything {
                         break;
                     default:
                         reader.skipValue();
+                        break;
                 }
             }
             reader.endObject();

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -277,6 +277,7 @@ public class Image {
                         break;
                     default:
                         reader.skipValue();
+                        break;
                 }
             }
             reader.endObject();

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -182,6 +182,7 @@ public class Model {
                         break;
                     default:
                         reader.skipValue();
+                        break;
                 }
             }
             reader.endObject();

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -949,6 +949,7 @@ public class Pin {
                         break;
                     default:
                         reader.skipValue();
+                        break;
                 }
             }
             reader.endObject();

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -606,6 +606,7 @@ public class User {
                         break;
                     default:
                         reader.skipValue();
+                        break;
                 }
             }
             reader.endObject();

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -324,6 +324,7 @@ public class VariableSubtitution {
                         break;
                     default:
                         reader.skipValue();
+                        break;
                 }
             }
             reader.endObject();

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -22,6 +22,7 @@ public enum GenerationParameterType {
     case javaNullabilityAnnotationType
     case javaGeneratePackagePrivateSetters
     case javaDecorations
+    case javaUnknownPropertyLogging
 }
 
 // Most of these are derived from https://www.binpress.com/tutorial/objective-c-reserved-keywords/43

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -66,6 +66,23 @@ enum JavaNullabilityAnnotationType: String {
     }
 }
 
+enum JavaLoggingType {
+    case androidLog(level: String)
+
+    init?(param: String) {
+        switch param {
+        case "android-log-d": self = .androidLog(level: "d")
+        default: fatalError("Unsupported logging type: " + param)
+        }
+    }
+
+    var imports: [String] {
+        switch self {
+        case .androidLog: return ["android.util.Log"]
+        }
+    }
+}
+
 //
 // The json file passed in via java_decorations_beta=model_decorations.json is deserialized into this.
 //

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -20,6 +20,7 @@ enum FlagOptions: String {
     case javaNullabilityAnnotationType = "java_nullability_annotation_type"
     case javaGeneratePackagePrivateSetters = "java_generate_package_private_setters_beta"
     case javaDecorations = "java_decorations_beta"
+    case javaUnknownPropertyLogging = "java_unknown_property_logging"
     case printDeps = "print_deps"
     case noRecursive = "no_recursive"
     case noRuntime = "no_runtime"
@@ -45,6 +46,7 @@ enum FlagOptions: String {
         case .javaNullabilityAnnotationType: return true
         case .javaGeneratePackagePrivateSetters: return false
         case .javaDecorations: return true
+        case .javaUnknownPropertyLogging: return true
         }
     }
 }
@@ -70,6 +72,7 @@ extension FlagOptions: HelpCommandOutput {
             "    --\(FlagOptions.javaNullabilityAnnotationType.rawValue) - The type of nullability annotations to use. Can be either \"android-support\" (default) or \"androidx\".",
             "    --\(FlagOptions.javaGeneratePackagePrivateSetters.rawValue) - Generate package-private setter methods (beta)",
             "    --\(FlagOptions.javaDecorations.rawValue) - Custom decorations to apply to the generated Java model (beta).",
+            "    --\(FlagOptions.javaUnknownPropertyLogging.rawValue) - Enable unknown property logging. Can be \"android-log-d\".",
         ].joined(separator: "\n")
     }
 }
@@ -156,6 +159,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     let javaNullabilityAnnotationType: String? = flags[.javaNullabilityAnnotationType]
     let javaGeneratePackagePrivateSetters: String? = (flags[.javaGeneratePackagePrivateSetters] == nil) ? .none : .some("")
     let javaDecorations: String? = flags[.javaDecorations]
+    let javaUnknownPropertyLogging: String? = flags[.javaUnknownPropertyLogging]
 
     let generationParameters: GenerationParameters = [
         (.recursive, recursive),
@@ -166,6 +170,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
         (.javaNullabilityAnnotationType, javaNullabilityAnnotationType),
         (.javaGeneratePackagePrivateSetters, javaGeneratePackagePrivateSetters),
         (.javaDecorations, javaDecorations),
+        (.javaUnknownPropertyLogging, javaUnknownPropertyLogging),
     ].reduce([:]) { (dict: GenerationParameters, tuple: (GenerationParameterType, String?)) in
         var mutableDict = dict
         if let val = tuple.1 {


### PR DESCRIPTION
It can be useful to log JSON keys that don't map to model properties.
These usually indicate a mismatch between the input data and the model
schema.

This is controlled via a new `--java_unknown_property_logging` parameter:

```
--java_unknown_property_logging - Enable unknown property logging. Can be "android-log-d".
```