### PR TITLE
Support configurable URI types for Java

### DIFF
--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -23,6 +23,7 @@ public enum GenerationParameterType {
     case javaGeneratePackagePrivateSetters
     case javaDecorations
     case javaUnknownPropertyLogging
+    case javaURIType
 }
 
 // Most of these are derived from https://www.binpress.com/tutorial/objective-c-reserved-keywords/43

--- a/Sources/Core/JavaFileRenderer.swift
+++ b/Sources/Core/JavaFileRenderer.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-protocol JavaFileRenderer: FileRenderer {}
+protocol JavaFileRenderer: FileRenderer {
+    func renderURIType() -> String
+}
 
 extension JavaFileRenderer {
     func interfaceName() -> String {
@@ -67,9 +69,10 @@ extension JavaFileRenderer {
              .string(format: .some(.email)),
              .string(format: .some(.hostname)),
              .string(format: .some(.ipv4)),
-             .string(format: .some(.ipv6)),
-             .string(format: .some(.uri)):
+             .string(format: .some(.ipv6)):
             return "String"
+        case .string(format: .some(.uri)):
+            return renderURIType()
         case .string(format: .some(.dateTime)):
             return "Date"
         case .integer:

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -83,6 +83,33 @@ enum JavaLoggingType {
     }
 }
 
+enum JavaURIType: String, CaseIterable {
+    case androidNetUri = "android.net.Uri"
+    case javaNetURI = "java.net.URI"
+    case okHttp3HttpUrl = "okhttp3.HttpUrl"
+    case string = "String"
+
+    static var options: String {
+        return allCases.map({ "\"\($0.rawValue)\"" }).joined(separator: ", ")
+    }
+
+    var type: String {
+        switch self {
+        case .androidNetUri: return "Uri"
+        case .javaNetURI: return "URI"
+        case .okHttp3HttpUrl: return "HttpUrl"
+        case .string: return "String"
+        }
+    }
+
+    var imports: [String] {
+        switch self {
+        case .string: return []
+        default: return [self.rawValue]
+        }
+    }
+}
+
 //
 // The json file passed in via java_decorations_beta=model_decorations.json is deserialized into this.
 //

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -12,6 +12,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
     let params: GenerationParameters
     let decorations: JavaDecorations
     let unknownPropertyLogging: JavaLoggingType?
+    let uriType: JavaURIType
 
     init(rootSchema: SchemaObjectRoot, params: GenerationParameters) {
         self.rootSchema = rootSchema
@@ -32,6 +33,18 @@ public struct JavaModelRenderer: JavaFileRenderer {
         } else {
             unknownPropertyLogging = nil
         }
+
+        if let uriType = JavaURIType(rawValue: params[.javaURIType] ?? JavaURIType.string.rawValue) {
+            self.uriType = uriType
+        } else {
+            fatalError("java_uri_type must be one of " + JavaURIType.options + ". Invalid type provided: " + params[.javaURIType]!)
+        }
+    }
+
+    // MARK: - JavaFileRenderer
+
+    func renderURIType() -> String {
+        return uriType.type
     }
 
     // MARK: - Top-level Model
@@ -405,7 +418,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
             }
         }
 
-        let additionalImports = propertyTypeImports + (unknownPropertyLogging?.imports ?? []) + (decorations.imports ?? [])
+        let additionalImports = propertyTypeImports + uriType.imports + (unknownPropertyLogging?.imports ?? []) + (decorations.imports ?? [])
 
         let imports = [
             JavaIR.Root.imports(names: Set([

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -21,6 +21,7 @@ enum FlagOptions: String {
     case javaGeneratePackagePrivateSetters = "java_generate_package_private_setters_beta"
     case javaDecorations = "java_decorations_beta"
     case javaUnknownPropertyLogging = "java_unknown_property_logging"
+    case javaURIType = "java_uri_type"
     case printDeps = "print_deps"
     case noRecursive = "no_recursive"
     case noRuntime = "no_runtime"
@@ -47,6 +48,7 @@ enum FlagOptions: String {
         case .javaGeneratePackagePrivateSetters: return false
         case .javaDecorations: return true
         case .javaUnknownPropertyLogging: return true
+        case .javaURIType: return true
         }
     }
 }
@@ -73,6 +75,7 @@ extension FlagOptions: HelpCommandOutput {
             "    --\(FlagOptions.javaGeneratePackagePrivateSetters.rawValue) - Generate package-private setter methods (beta)",
             "    --\(FlagOptions.javaDecorations.rawValue) - Custom decorations to apply to the generated Java model (beta).",
             "    --\(FlagOptions.javaUnknownPropertyLogging.rawValue) - Enable unknown property logging. Can be \"android-log-d\".",
+            "    --\(FlagOptions.javaURIType.rawValue) - The type to use for URIs. Can be \"String\" (default), \"java.net.URI\", \"android.net.Uri\", or \"okhttp3.HttpUrl\".",
         ].joined(separator: "\n")
     }
 }
@@ -160,6 +163,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     let javaGeneratePackagePrivateSetters: String? = (flags[.javaGeneratePackagePrivateSetters] == nil) ? .none : .some("")
     let javaDecorations: String? = flags[.javaDecorations]
     let javaUnknownPropertyLogging: String? = flags[.javaUnknownPropertyLogging]
+    let javaURIType: String? = flags[.javaURIType]
 
     let generationParameters: GenerationParameters = [
         (.recursive, recursive),
@@ -171,6 +175,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
         (.javaGeneratePackagePrivateSetters, javaGeneratePackagePrivateSetters),
         (.javaDecorations, javaDecorations),
         (.javaUnknownPropertyLogging, javaUnknownPropertyLogging),
+        (.javaURIType, javaURIType),
     ].reduce([:]) { (dict: GenerationParameters, tuple: (GenerationParameterType, String?)) in
         var mutableDict = dict
         if let val = tuple.1 {


### PR DESCRIPTION
The following types are supported:

- String (default)
- [java.net.URI](https://docs.oracle.com/javase/9/docs/api/java/net/URI.html)
- [android.net.Uri](https://developer.android.com/reference/android/net/Uri.html)
- [okhttp3.HttpUrl](https://square.github.io/okhttp/3.x/okhttp/okhttp3/HttpUrl.html)

Closes #179 