### PR TITLE
Remove trailing space after integer-based enums

### DIFF
--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -40,7 +40,7 @@ public class Everything {
     }
 
     public enum EverythingIntEnum {
-        @SerializedName("-1") INT_CASE_1(-1), 
+        @SerializedName("-1") INT_CASE_1(-1),
         @SerializedName("65536") INT_CASE_2(65536);
         private final int value;
         EverythingIntEnum(int value) {
@@ -52,7 +52,7 @@ public class Everything {
     }
 
     public enum EverythingNsintegerEnum {
-        @SerializedName("-1") NSINTEGER_CASE_1(-1), 
+        @SerializedName("-1") NSINTEGER_CASE_1(-1),
         @SerializedName("4294967295") NSINTEGER_CASE_2(4294967295);
         private final int value;
         EverythingNsintegerEnum(int value) {
@@ -75,7 +75,7 @@ public class Everything {
     }
 
     public enum EverythingShortEnum {
-        @SerializedName("-1") SHORT_CASE_1(-1), 
+        @SerializedName("-1") SHORT_CASE_1(-1),
         @SerializedName("256") SHORT_CASE_2(256);
         private final int value;
         EverythingShortEnum(int value) {

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -28,8 +28,8 @@ import java.util.Objects;
 public class Pin {
 
     public enum PinInStock {
-        @SerializedName("-1") UNKNOWN(-1), 
-        @SerializedName("0") OUT_OF_STOCK(0), 
+        @SerializedName("-1") UNKNOWN(-1),
+        @SerializedName("0") OUT_OF_STOCK(0),
         @SerializedName("1") IN_STOCK(1);
         private final int value;
         PinInStock(int value) {

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -379,7 +379,7 @@ public struct JavaIR {
             case let .integer(values):
                 let names = values
                     .map { ($0.description, $0.defaultValue) }
-                    .map { "@\(JavaAnnotation.serializedName(name: "\($0.1)").rendered) \($0.0.uppercased())(\($0.1))" }.joined(separator: ", \n")
+                    .map { "@\(JavaAnnotation.serializedName(name: "\($0.1)").rendered) \($0.0.uppercased())(\($0.1))" }.joined(separator: ",\n")
                 let enumInitializer = JavaIR.method([], "\(name)(int value)") { [
                     "this.value = value;",
                 ] }


### PR DESCRIPTION
This was accidentally introduced as part of #253.