### PR TITLE
Mark generated files using 'linguist-generated'

### DIFF
--- a/Examples/.gitattributes
+++ b/Examples/.gitattributes
@@ -1,0 +1,3 @@
+Cocoa/Sources/* linguist-generated=true
+Java/Sources/* linguist-generated=true
+JS/flow/* linguist-generated=true


### PR DESCRIPTION
This automatically collapses these files in diffs.

See: https://github.com/github/linguist#generated-code