### PR TITLE
A no-arg constructor should always be created

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -56,6 +56,10 @@ public class Board {
 
     private boolean[] _bits;
 
+    public Board() {
+        this._bits = new boolean[10];
+    }
+
     private Board(
         @Nullable String uid,
         @Nullable Set<User> contributors,

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -207,6 +207,10 @@ public class Everything {
 
     private boolean[] _bits;
 
+    public Everything() {
+        this._bits = new boolean[37];
+    }
+
     private Everything(
         @Nullable List<Object> arrayProp,
         @Nullable Boolean booleanProp,

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -39,6 +39,10 @@ public class Image {
 
     private boolean[] _bits;
 
+    public Image() {
+        this._bits = new boolean[3];
+    }
+
     private Image(
         @Nullable Integer height,
         @Nullable String url,

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -35,6 +35,10 @@ public class Model {
 
     private boolean[] _bits;
 
+    public Model() {
+        this._bits = new boolean[1];
+    }
+
     private Model(
         @Nullable String uid,
         boolean[] _bits

--- a/Examples/Java/Sources/Nested.java
+++ b/Examples/Java/Sources/Nested.java
@@ -35,6 +35,10 @@ public class Nested {
 
     private boolean[] _bits;
 
+    public Nested() {
+        this._bits = new boolean[1];
+    }
+
     private Nested(
         @Nullable Integer uid,
         boolean[] _bits

--- a/Examples/Java/Sources/OneofObject.java
+++ b/Examples/Java/Sources/OneofObject.java
@@ -35,6 +35,10 @@ public class OneofObject {
 
     private boolean[] _bits;
 
+    public OneofObject() {
+        this._bits = new boolean[1];
+    }
+
     private OneofObject(
         @Nullable Integer uid,
         boolean[] _bits

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -84,6 +84,10 @@ public class Pin {
 
     private boolean[] _bits;
 
+    public Pin() {
+        this._bits = new boolean[17];
+    }
+
     private Pin(
         @Nullable Map<String, String> attribution,
         @Nullable List<PinAttributionObjects> attributionObjects,

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -59,6 +59,10 @@ public class User {
 
     private boolean[] _bits;
 
+    public User() {
+        this._bits = new boolean[10];
+    }
+
     private User(
         @Nullable String bio,
         @Nullable Map<String, Integer> counts,

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -41,6 +41,10 @@ public class VariableSubtitution {
 
     private boolean[] _bits;
 
+    public VariableSubtitution() {
+        this._bits = new boolean[4];
+    }
+
     private VariableSubtitution(
         @Nullable Integer allocProp,
         @Nullable Integer copyProp,

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -64,11 +64,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
             } + ["this._bits = _bits;"]
         }
 
-        if params[.javaGeneratePackagePrivateSetters] == nil {
-            return [privateConstructor]
-        } else {
-            return [publicConstructor, privateConstructor]
-        }
+        return [publicConstructor, privateConstructor]
     }
 
     func renderStaticTypeString() -> JavaIR.Property {


### PR DESCRIPTION
Gson recommends having a no-arg constructor. Without that, an UnsafeAllocator will be used to create the models.
This isn't really a problem because the generated TypeAdapter will construct through the Builder, but it's best to follow the recommendation.