### PR TITLE
Make "copy" an objectiveCReservedWord

### DIFF
--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -71,6 +71,7 @@ let objectiveCReservedWords = Set<String>([
     "char",
     "const",
     "continue",
+    "copy",
     "default",
     "do",
     "double",

--- a/Tests/CoreTests/LanguagesTests.swift
+++ b/Tests/CoreTests/LanguagesTests.swift
@@ -41,5 +41,8 @@ class LanguagesTests: XCTestCase {
 
         XCTAssert(Languages.objectiveC.snakeCaseToPropertyName("id") == "identifier")
         XCTAssert(Languages.java.snakeCaseToPropertyName("id") == "uid")
+
+        XCTAssertEqual(Languages.objectiveC.snakeCaseToPropertyName("copy"), "copyProperty")
+        XCTAssertEqual(Languages.java.snakeCaseToPropertyName("copy"), "copy")
     }
 }


### PR DESCRIPTION
This way the property will not be conflated with the ObjC convenience method `-copy`.