### PR TITLE
Simplify string operations in -debugDescription

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -191,31 +191,31 @@ struct BoardDirtyProperties {
     [descriptionFields addObject:parentDebugDescription];
     struct BoardDirtyProperties props = _boardDirtyProperties;
     if (props.BoardDirtyPropertyContributors) {
-        [descriptionFields addObject:[@"_contributors = " stringByAppendingFormat:@"%@", _contributors]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_contributors = %@", _contributors]];
     }
     if (props.BoardDirtyPropertyCounts) {
-        [descriptionFields addObject:[@"_counts = " stringByAppendingFormat:@"%@", _counts]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_counts = %@", _counts]];
     }
     if (props.BoardDirtyPropertyCreatedAt) {
-        [descriptionFields addObject:[@"_createdAt = " stringByAppendingFormat:@"%@", _createdAt]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_createdAt = %@", _createdAt]];
     }
     if (props.BoardDirtyPropertyCreator) {
-        [descriptionFields addObject:[@"_creator = " stringByAppendingFormat:@"%@", _creator]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_creator = %@", _creator]];
     }
     if (props.BoardDirtyPropertyCreatorURL) {
-        [descriptionFields addObject:[@"_creatorURL = " stringByAppendingFormat:@"%@", _creatorURL]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_creatorURL = %@", _creatorURL]];
     }
     if (props.BoardDirtyPropertyDescriptionText) {
-        [descriptionFields addObject:[@"_descriptionText = " stringByAppendingFormat:@"%@", _descriptionText]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_descriptionText = %@", _descriptionText]];
     }
     if (props.BoardDirtyPropertyImage) {
-        [descriptionFields addObject:[@"_image = " stringByAppendingFormat:@"%@", _image]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_image = %@", _image]];
     }
     if (props.BoardDirtyPropertyName) {
-        [descriptionFields addObject:[@"_name = " stringByAppendingFormat:@"%@", _name]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_name = %@", _name]];
     }
     if (props.BoardDirtyPropertyUrl) {
-        [descriptionFields addObject:[@"_url = " stringByAppendingFormat:@"%@", _url]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_url = %@", _url]];
     }
     return [NSString stringWithFormat:@"Board = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }

--- a/Examples/Cocoa/Sources/Objective_C/Everything.m
+++ b/Examples/Cocoa/Sources/Objective_C/Everything.m
@@ -1316,115 +1316,115 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     [descriptionFields addObject:parentDebugDescription];
     struct EverythingDirtyProperties props = _everythingDirtyProperties;
     if (props.EverythingDirtyPropertyArrayProp) {
-        [descriptionFields addObject:[@"_arrayProp = " stringByAppendingFormat:@"%@", _arrayProp]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_arrayProp = %@", _arrayProp]];
     }
     if (props.EverythingDirtyPropertyCharEnum) {
-        [descriptionFields addObject:[@"_charEnum = " stringByAppendingFormat:@"%@", @(_charEnum)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_charEnum = %@", @(_charEnum)]];
     }
     if (props.EverythingDirtyPropertyDateProp) {
-        [descriptionFields addObject:[@"_dateProp = " stringByAppendingFormat:@"%@", _dateProp]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_dateProp = %@", _dateProp]];
     }
     if (props.EverythingDirtyPropertyIntEnum) {
-        [descriptionFields addObject:[@"_intEnum = " stringByAppendingFormat:@"%@", @(_intEnum)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_intEnum = %@", @(_intEnum)]];
     }
     if (props.EverythingDirtyPropertyIntProp) {
-        [descriptionFields addObject:[@"_intProp = " stringByAppendingFormat:@"%@", @(_intProp)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_intProp = %@", @(_intProp)]];
     }
     if (props.EverythingDirtyPropertyListPolymorphicValues) {
-        [descriptionFields addObject:[@"_listPolymorphicValues = " stringByAppendingFormat:@"%@", _listPolymorphicValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_listPolymorphicValues = %@", _listPolymorphicValues]];
     }
     if (props.EverythingDirtyPropertyListWithListAndOtherModelValues) {
-        [descriptionFields addObject:[@"_listWithListAndOtherModelValues = " stringByAppendingFormat:@"%@", _listWithListAndOtherModelValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_listWithListAndOtherModelValues = %@", _listWithListAndOtherModelValues]];
     }
     if (props.EverythingDirtyPropertyListWithMapAndOtherModelValues) {
-        [descriptionFields addObject:[@"_listWithMapAndOtherModelValues = " stringByAppendingFormat:@"%@", _listWithMapAndOtherModelValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_listWithMapAndOtherModelValues = %@", _listWithMapAndOtherModelValues]];
     }
     if (props.EverythingDirtyPropertyListWithObjectValues) {
-        [descriptionFields addObject:[@"_listWithObjectValues = " stringByAppendingFormat:@"%@", _listWithObjectValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_listWithObjectValues = %@", _listWithObjectValues]];
     }
     if (props.EverythingDirtyPropertyListWithOtherModelValues) {
-        [descriptionFields addObject:[@"_listWithOtherModelValues = " stringByAppendingFormat:@"%@", _listWithOtherModelValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_listWithOtherModelValues = %@", _listWithOtherModelValues]];
     }
     if (props.EverythingDirtyPropertyListWithPrimitiveValues) {
-        [descriptionFields addObject:[@"_listWithPrimitiveValues = " stringByAppendingFormat:@"%@", _listWithPrimitiveValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_listWithPrimitiveValues = %@", _listWithPrimitiveValues]];
     }
     if (props.EverythingDirtyPropertyMapPolymorphicValues) {
-        [descriptionFields addObject:[@"_mapPolymorphicValues = " stringByAppendingFormat:@"%@", _mapPolymorphicValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_mapPolymorphicValues = %@", _mapPolymorphicValues]];
     }
     if (props.EverythingDirtyPropertyMapProp) {
-        [descriptionFields addObject:[@"_mapProp = " stringByAppendingFormat:@"%@", _mapProp]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_mapProp = %@", _mapProp]];
     }
     if (props.EverythingDirtyPropertyMapWithListAndOtherModelValues) {
-        [descriptionFields addObject:[@"_mapWithListAndOtherModelValues = " stringByAppendingFormat:@"%@", _mapWithListAndOtherModelValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_mapWithListAndOtherModelValues = %@", _mapWithListAndOtherModelValues]];
     }
     if (props.EverythingDirtyPropertyMapWithMapAndOtherModelValues) {
-        [descriptionFields addObject:[@"_mapWithMapAndOtherModelValues = " stringByAppendingFormat:@"%@", _mapWithMapAndOtherModelValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_mapWithMapAndOtherModelValues = %@", _mapWithMapAndOtherModelValues]];
     }
     if (props.EverythingDirtyPropertyMapWithObjectValues) {
-        [descriptionFields addObject:[@"_mapWithObjectValues = " stringByAppendingFormat:@"%@", _mapWithObjectValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_mapWithObjectValues = %@", _mapWithObjectValues]];
     }
     if (props.EverythingDirtyPropertyMapWithOtherModelValues) {
-        [descriptionFields addObject:[@"_mapWithOtherModelValues = " stringByAppendingFormat:@"%@", _mapWithOtherModelValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_mapWithOtherModelValues = %@", _mapWithOtherModelValues]];
     }
     if (props.EverythingDirtyPropertyMapWithPrimitiveValues) {
-        [descriptionFields addObject:[@"_mapWithPrimitiveValues = " stringByAppendingFormat:@"%@", _mapWithPrimitiveValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_mapWithPrimitiveValues = %@", _mapWithPrimitiveValues]];
     }
     if (props.EverythingDirtyPropertyNestedObject) {
-        [descriptionFields addObject:[@"_nestedObject = " stringByAppendingFormat:@"%@", _nestedObject]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_nestedObject = %@", _nestedObject]];
     }
     if (props.EverythingDirtyPropertyNsintegerEnum) {
-        [descriptionFields addObject:[@"_nsintegerEnum = " stringByAppendingFormat:@"%@", @(_nsintegerEnum)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_nsintegerEnum = %@", @(_nsintegerEnum)]];
     }
     if (props.EverythingDirtyPropertyNsuintegerEnum) {
-        [descriptionFields addObject:[@"_nsuintegerEnum = " stringByAppendingFormat:@"%@", @(_nsuintegerEnum)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_nsuintegerEnum = %@", @(_nsuintegerEnum)]];
     }
     if (props.EverythingDirtyPropertyNumberProp) {
-        [descriptionFields addObject:[@"_numberProp = " stringByAppendingFormat:@"%@", @(_numberProp)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_numberProp = %@", @(_numberProp)]];
     }
     if (props.EverythingDirtyPropertyOtherModelProp) {
-        [descriptionFields addObject:[@"_otherModelProp = " stringByAppendingFormat:@"%@", _otherModelProp]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_otherModelProp = %@", _otherModelProp]];
     }
     if (props.EverythingDirtyPropertyPolymorphicProp) {
-        [descriptionFields addObject:[@"_polymorphicProp = " stringByAppendingFormat:@"%@", _polymorphicProp]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_polymorphicProp = %@", _polymorphicProp]];
     }
     if (props.EverythingDirtyPropertySetProp) {
-        [descriptionFields addObject:[@"_setProp = " stringByAppendingFormat:@"%@", _setProp]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_setProp = %@", _setProp]];
     }
     if (props.EverythingDirtyPropertySetPropWithOtherModelValues) {
-        [descriptionFields addObject:[@"_setPropWithOtherModelValues = " stringByAppendingFormat:@"%@", _setPropWithOtherModelValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_setPropWithOtherModelValues = %@", _setPropWithOtherModelValues]];
     }
     if (props.EverythingDirtyPropertySetPropWithPrimitiveValues) {
-        [descriptionFields addObject:[@"_setPropWithPrimitiveValues = " stringByAppendingFormat:@"%@", _setPropWithPrimitiveValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_setPropWithPrimitiveValues = %@", _setPropWithPrimitiveValues]];
     }
     if (props.EverythingDirtyPropertySetPropWithValues) {
-        [descriptionFields addObject:[@"_setPropWithValues = " stringByAppendingFormat:@"%@", _setPropWithValues]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_setPropWithValues = %@", _setPropWithValues]];
     }
     if (props.EverythingDirtyPropertyShortEnum) {
-        [descriptionFields addObject:[@"_shortEnum = " stringByAppendingFormat:@"%@", @(_shortEnum)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_shortEnum = %@", @(_shortEnum)]];
     }
     if (props.EverythingDirtyPropertyStringEnum) {
-        [descriptionFields addObject:[@"_stringEnum = " stringByAppendingFormat:@"%@", EverythingStringEnumToString(_stringEnum)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_stringEnum = %@", EverythingStringEnumToString(_stringEnum)]];
     }
     if (props.EverythingDirtyPropertyStringProp) {
-        [descriptionFields addObject:[@"_stringProp = " stringByAppendingFormat:@"%@", _stringProp]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_stringProp = %@", _stringProp]];
     }
     if (props.EverythingDirtyPropertyType) {
-        [descriptionFields addObject:[@"_type = " stringByAppendingFormat:@"%@", _type]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_type = %@", _type]];
     }
     if (props.EverythingDirtyPropertyUnsignedCharEnum) {
-        [descriptionFields addObject:[@"_unsignedCharEnum = " stringByAppendingFormat:@"%@", @(_unsignedCharEnum)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_unsignedCharEnum = %@", @(_unsignedCharEnum)]];
     }
     if (props.EverythingDirtyPropertyUnsignedIntEnum) {
-        [descriptionFields addObject:[@"_unsignedIntEnum = " stringByAppendingFormat:@"%@", @(_unsignedIntEnum)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_unsignedIntEnum = %@", @(_unsignedIntEnum)]];
     }
     if (props.EverythingDirtyPropertyUnsignedShortEnum) {
-        [descriptionFields addObject:[@"_unsignedShortEnum = " stringByAppendingFormat:@"%@", @(_unsignedShortEnum)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_unsignedShortEnum = %@", @(_unsignedShortEnum)]];
     }
     if (props.EverythingDirtyPropertyUriProp) {
-        [descriptionFields addObject:[@"_uriProp = " stringByAppendingFormat:@"%@", _uriProp]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_uriProp = %@", _uriProp]];
     }
     if (props.EverythingDirtyPropertyBooleanProp) {
-        [descriptionFields addObject:[@"_everythingBooleanProperties.EverythingBooleanBooleanProp = " stringByAppendingFormat:@"%@", @(_everythingBooleanProperties.EverythingBooleanBooleanProp)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_everythingBooleanProperties.EverythingBooleanBooleanProp = %@", @(_everythingBooleanProperties.EverythingBooleanBooleanProp)]];
     }
     return [NSString stringWithFormat:@"Everything = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }

--- a/Examples/Cocoa/Sources/Objective_C/Image.m
+++ b/Examples/Cocoa/Sources/Objective_C/Image.m
@@ -107,13 +107,13 @@ struct ImageDirtyProperties {
     [descriptionFields addObject:parentDebugDescription];
     struct ImageDirtyProperties props = _imageDirtyProperties;
     if (props.ImageDirtyPropertyHeight) {
-        [descriptionFields addObject:[@"_height = " stringByAppendingFormat:@"%@", @(_height)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_height = %@", @(_height)]];
     }
     if (props.ImageDirtyPropertyUrl) {
-        [descriptionFields addObject:[@"_url = " stringByAppendingFormat:@"%@", _url]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_url = %@", _url]];
     }
     if (props.ImageDirtyPropertyWidth) {
-        [descriptionFields addObject:[@"_width = " stringByAppendingFormat:@"%@", @(_width)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_width = %@", @(_width)]];
     }
     return [NSString stringWithFormat:@"Image = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }

--- a/Examples/Cocoa/Sources/Objective_C/Model.m
+++ b/Examples/Cocoa/Sources/Objective_C/Model.m
@@ -85,7 +85,7 @@ struct ModelDirtyProperties {
     [descriptionFields addObject:parentDebugDescription];
     struct ModelDirtyProperties props = _modelDirtyProperties;
     if (props.ModelDirtyPropertyIdentifier) {
-        [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", _identifier]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_identifier = %@", _identifier]];
     }
     return [NSString stringWithFormat:@"Model = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }

--- a/Examples/Cocoa/Sources/Objective_C/Nested.m
+++ b/Examples/Cocoa/Sources/Objective_C/Nested.m
@@ -85,7 +85,7 @@ struct NestedDirtyProperties {
     [descriptionFields addObject:parentDebugDescription];
     struct NestedDirtyProperties props = _nestedDirtyProperties;
     if (props.NestedDirtyPropertyIdentifier) {
-        [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", @(_identifier)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_identifier = %@", @(_identifier)]];
     }
     return [NSString stringWithFormat:@"Nested = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }

--- a/Examples/Cocoa/Sources/Objective_C/OneofObject.m
+++ b/Examples/Cocoa/Sources/Objective_C/OneofObject.m
@@ -85,7 +85,7 @@ struct OneofObjectDirtyProperties {
     [descriptionFields addObject:parentDebugDescription];
     struct OneofObjectDirtyProperties props = _oneofObjectDirtyProperties;
     if (props.OneofObjectDirtyPropertyIdentifier) {
-        [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", @(_identifier)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_identifier = %@", @(_identifier)]];
     }
     return [NSString stringWithFormat:@"OneofObject = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }

--- a/Examples/Cocoa/Sources/Objective_C/Pin.m
+++ b/Examples/Cocoa/Sources/Objective_C/Pin.m
@@ -427,55 +427,55 @@ struct PinDirtyProperties {
     [descriptionFields addObject:parentDebugDescription];
     struct PinDirtyProperties props = _pinDirtyProperties;
     if (props.PinDirtyPropertyAttribution) {
-        [descriptionFields addObject:[@"_attribution = " stringByAppendingFormat:@"%@", _attribution]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_attribution = %@", _attribution]];
     }
     if (props.PinDirtyPropertyAttributionObjects) {
-        [descriptionFields addObject:[@"_attributionObjects = " stringByAppendingFormat:@"%@", _attributionObjects]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_attributionObjects = %@", _attributionObjects]];
     }
     if (props.PinDirtyPropertyBoard) {
-        [descriptionFields addObject:[@"_board = " stringByAppendingFormat:@"%@", _board]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_board = %@", _board]];
     }
     if (props.PinDirtyPropertyColor) {
-        [descriptionFields addObject:[@"_color = " stringByAppendingFormat:@"%@", _color]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_color = %@", _color]];
     }
     if (props.PinDirtyPropertyCounts) {
-        [descriptionFields addObject:[@"_counts = " stringByAppendingFormat:@"%@", _counts]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_counts = %@", _counts]];
     }
     if (props.PinDirtyPropertyCreatedAt) {
-        [descriptionFields addObject:[@"_createdAt = " stringByAppendingFormat:@"%@", _createdAt]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_createdAt = %@", _createdAt]];
     }
     if (props.PinDirtyPropertyCreator) {
-        [descriptionFields addObject:[@"_creator = " stringByAppendingFormat:@"%@", _creator]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_creator = %@", _creator]];
     }
     if (props.PinDirtyPropertyDescriptionText) {
-        [descriptionFields addObject:[@"_descriptionText = " stringByAppendingFormat:@"%@", _descriptionText]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_descriptionText = %@", _descriptionText]];
     }
     if (props.PinDirtyPropertyIdentifier) {
-        [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", _identifier]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_identifier = %@", _identifier]];
     }
     if (props.PinDirtyPropertyImage) {
-        [descriptionFields addObject:[@"_image = " stringByAppendingFormat:@"%@", _image]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_image = %@", _image]];
     }
     if (props.PinDirtyPropertyInStock) {
-        [descriptionFields addObject:[@"_inStock = " stringByAppendingFormat:@"%@", @(_inStock)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_inStock = %@", @(_inStock)]];
     }
     if (props.PinDirtyPropertyLink) {
-        [descriptionFields addObject:[@"_link = " stringByAppendingFormat:@"%@", _link]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_link = %@", _link]];
     }
     if (props.PinDirtyPropertyMedia) {
-        [descriptionFields addObject:[@"_media = " stringByAppendingFormat:@"%@", _media]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_media = %@", _media]];
     }
     if (props.PinDirtyPropertyNote) {
-        [descriptionFields addObject:[@"_note = " stringByAppendingFormat:@"%@", _note]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_note = %@", _note]];
     }
     if (props.PinDirtyPropertyTags) {
-        [descriptionFields addObject:[@"_tags = " stringByAppendingFormat:@"%@", _tags]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_tags = %@", _tags]];
     }
     if (props.PinDirtyPropertyUrl) {
-        [descriptionFields addObject:[@"_url = " stringByAppendingFormat:@"%@", _url]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_url = %@", _url]];
     }
     if (props.PinDirtyPropertyVisualSearchAttrs) {
-        [descriptionFields addObject:[@"_visualSearchAttrs = " stringByAppendingFormat:@"%@", _visualSearchAttrs]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_visualSearchAttrs = %@", _visualSearchAttrs]];
     }
     return [NSString stringWithFormat:@"Pin = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }

--- a/Examples/Cocoa/Sources/Objective_C/User.m
+++ b/Examples/Cocoa/Sources/Objective_C/User.m
@@ -217,34 +217,34 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
     [descriptionFields addObject:parentDebugDescription];
     struct UserDirtyProperties props = _userDirtyProperties;
     if (props.UserDirtyPropertyBio) {
-        [descriptionFields addObject:[@"_bio = " stringByAppendingFormat:@"%@", _bio]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_bio = %@", _bio]];
     }
     if (props.UserDirtyPropertyCounts) {
-        [descriptionFields addObject:[@"_counts = " stringByAppendingFormat:@"%@", _counts]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_counts = %@", _counts]];
     }
     if (props.UserDirtyPropertyCreatedAt) {
-        [descriptionFields addObject:[@"_createdAt = " stringByAppendingFormat:@"%@", _createdAt]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_createdAt = %@", _createdAt]];
     }
     if (props.UserDirtyPropertyEmailFrequency) {
-        [descriptionFields addObject:[@"_emailFrequency = " stringByAppendingFormat:@"%@", UserEmailFrequencyToString(_emailFrequency)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_emailFrequency = %@", UserEmailFrequencyToString(_emailFrequency)]];
     }
     if (props.UserDirtyPropertyFirstName) {
-        [descriptionFields addObject:[@"_firstName = " stringByAppendingFormat:@"%@", _firstName]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_firstName = %@", _firstName]];
     }
     if (props.UserDirtyPropertyIdentifier) {
-        [descriptionFields addObject:[@"_identifier = " stringByAppendingFormat:@"%@", _identifier]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_identifier = %@", _identifier]];
     }
     if (props.UserDirtyPropertyImage) {
-        [descriptionFields addObject:[@"_image = " stringByAppendingFormat:@"%@", _image]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_image = %@", _image]];
     }
     if (props.UserDirtyPropertyLastName) {
-        [descriptionFields addObject:[@"_lastName = " stringByAppendingFormat:@"%@", _lastName]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_lastName = %@", _lastName]];
     }
     if (props.UserDirtyPropertyType) {
-        [descriptionFields addObject:[@"_type = " stringByAppendingFormat:@"%@", _type]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_type = %@", _type]];
     }
     if (props.UserDirtyPropertyUsername) {
-        [descriptionFields addObject:[@"_username = " stringByAppendingFormat:@"%@", _username]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_username = %@", _username]];
     }
     return [NSString stringWithFormat:@"User = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }

--- a/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
+++ b/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
@@ -118,16 +118,16 @@ struct VariableSubtitutionDirtyProperties {
     [descriptionFields addObject:parentDebugDescription];
     struct VariableSubtitutionDirtyProperties props = _variableSubtitutionDirtyProperties;
     if (props.VariableSubtitutionDirtyPropertyAllocProp) {
-        [descriptionFields addObject:[@"_allocProp = " stringByAppendingFormat:@"%@", @(_allocProp)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_allocProp = %@", @(_allocProp)]];
     }
     if (props.VariableSubtitutionDirtyPropertyCopyProp) {
-        [descriptionFields addObject:[@"_copyProp = " stringByAppendingFormat:@"%@", @(_copyProp)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_copyProp = %@", @(_copyProp)]];
     }
     if (props.VariableSubtitutionDirtyPropertyMutableCopyProp) {
-        [descriptionFields addObject:[@"_mutableCopyProp = " stringByAppendingFormat:@"%@", @(_mutableCopyProp)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_mutableCopyProp = %@", @(_mutableCopyProp)]];
     }
     if (props.VariableSubtitutionDirtyPropertyNewProp) {
-        [descriptionFields addObject:[@"_newProp = " stringByAppendingFormat:@"%@", @(_newProp)]];
+        [descriptionFields addObject:[NSString stringWithFormat:@"_newProp = %@", @(_newProp)]];
     }
     return [NSString stringWithFormat:@"VariableSubtitution = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }

--- a/Sources/Core/ObjectiveCDebugExtension.swift
+++ b/Sources/Core/ObjectiveCDebugExtension.swift
@@ -15,7 +15,7 @@ extension ObjCModelRenderer {
         }.map { (param, prop) -> String in
             ObjCIR.ifStmt("props.\(dirtyPropertyOption(propertyName: param, className: self.className))") {
                 let ivarName = "_\(Languages.objectiveC.snakeCaseToPropertyName(param))"
-                return ["[descriptionFields addObject:[\((ivarName + " = ").objcLiteral()) stringByAppendingFormat:\("%@".objcLiteral()), \(renderDebugStatement(param, prop.schema))]];"]
+                return ["[descriptionFields addObject:[NSString stringWithFormat:\("\(ivarName) = %@".objcLiteral()), \(renderDebugStatement(param, prop.schema))]];"]
             }
         }.joined(separator: "\n")
 
@@ -24,7 +24,7 @@ extension ObjCModelRenderer {
         }.map { (param, _) -> String in
             ObjCIR.ifStmt("props.\(dirtyPropertyOption(propertyName: param, className: self.className))") {
                 let ivarName = "_\(booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: param, className: self.className))"
-                return ["[descriptionFields addObject:[@\"\(ivarName) = \" stringByAppendingFormat:\("%@".objcLiteral()), @(\(ivarName))]];"]
+                return ["[descriptionFields addObject:[NSString stringWithFormat:\("\(ivarName) = %@".objcLiteral()), @(\(ivarName))]];"]
             }
         }
 
@@ -44,7 +44,7 @@ extension ObjCADTRenderer {
         let props = properties.map { (param, prop) -> String in
             ObjCIR.ifStmt("self.internalType == \(self.renderInternalEnumTypeCase(name: ObjCADTRenderer.objectName(prop.schema)))") {
                 let ivarName = "_\(Languages.objectiveC.snakeCaseToPropertyName(param))"
-                return ["[descriptionFields addObject:[\((ivarName + " = ").objcLiteral()) stringByAppendingFormat:\("%@".objcLiteral()), \(renderDebugStatement(param, prop.schema))]];"]
+                return ["[descriptionFields addObject:[NSString stringWithFormat:\("\(ivarName) = %@".objcLiteral()), \(renderDebugStatement(param, prop.schema))]];"]
             }
         }.joined(separator: "\n")
 


### PR DESCRIPTION
Instead of using two string literals to build the formatted strings,
combine them into a single `+[NSString stringWithFormat:]` call.