### PR TITLE
Wrap -debugDescription in `#ifdef DEBUG`

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -184,6 +184,7 @@ struct BoardDirtyProperties {
     }
     return self;
 }
+#ifdef DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
@@ -219,6 +220,7 @@ struct BoardDirtyProperties {
     }
     return [NSString stringWithFormat:@"Board = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
+#endif
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(BoardBuilder *builder))block
 {
     NSParameterAssert(block);

--- a/Examples/Cocoa/Sources/Objective_C/Everything.m
+++ b/Examples/Cocoa/Sources/Objective_C/Everything.m
@@ -1309,6 +1309,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     }
     return self;
 }
+#ifdef DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
@@ -1428,6 +1429,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     }
     return [NSString stringWithFormat:@"Everything = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
+#endif
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(EverythingBuilder *builder))block
 {
     NSParameterAssert(block);

--- a/Examples/Cocoa/Sources/Objective_C/Image.m
+++ b/Examples/Cocoa/Sources/Objective_C/Image.m
@@ -100,6 +100,7 @@ struct ImageDirtyProperties {
     }
     return self;
 }
+#ifdef DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
@@ -117,6 +118,7 @@ struct ImageDirtyProperties {
     }
     return [NSString stringWithFormat:@"Image = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
+#endif
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(ImageBuilder *builder))block
 {
     NSParameterAssert(block);

--- a/Examples/Cocoa/Sources/Objective_C/Model.m
+++ b/Examples/Cocoa/Sources/Objective_C/Model.m
@@ -78,6 +78,7 @@ struct ModelDirtyProperties {
     }
     return self;
 }
+#ifdef DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
@@ -89,6 +90,7 @@ struct ModelDirtyProperties {
     }
     return [NSString stringWithFormat:@"Model = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
+#endif
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(ModelBuilder *builder))block
 {
     NSParameterAssert(block);

--- a/Examples/Cocoa/Sources/Objective_C/Nested.m
+++ b/Examples/Cocoa/Sources/Objective_C/Nested.m
@@ -78,6 +78,7 @@ struct NestedDirtyProperties {
     }
     return self;
 }
+#ifdef DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
@@ -89,6 +90,7 @@ struct NestedDirtyProperties {
     }
     return [NSString stringWithFormat:@"Nested = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
+#endif
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(NestedBuilder *builder))block
 {
     NSParameterAssert(block);

--- a/Examples/Cocoa/Sources/Objective_C/OneofObject.m
+++ b/Examples/Cocoa/Sources/Objective_C/OneofObject.m
@@ -78,6 +78,7 @@ struct OneofObjectDirtyProperties {
     }
     return self;
 }
+#ifdef DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
@@ -89,6 +90,7 @@ struct OneofObjectDirtyProperties {
     }
     return [NSString stringWithFormat:@"OneofObject = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
+#endif
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(OneofObjectBuilder *builder))block
 {
     NSParameterAssert(block);

--- a/Examples/Cocoa/Sources/Objective_C/Pin.m
+++ b/Examples/Cocoa/Sources/Objective_C/Pin.m
@@ -420,6 +420,7 @@ struct PinDirtyProperties {
     }
     return self;
 }
+#ifdef DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
@@ -479,6 +480,7 @@ struct PinDirtyProperties {
     }
     return [NSString stringWithFormat:@"Pin = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
+#endif
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(PinBuilder *builder))block
 {
     NSParameterAssert(block);

--- a/Examples/Cocoa/Sources/Objective_C/User.m
+++ b/Examples/Cocoa/Sources/Objective_C/User.m
@@ -210,6 +210,7 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
     }
     return self;
 }
+#ifdef DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
@@ -248,6 +249,7 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
     }
     return [NSString stringWithFormat:@"User = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
+#endif
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(UserBuilder *builder))block
 {
     NSParameterAssert(block);

--- a/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
+++ b/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
@@ -111,6 +111,7 @@ struct VariableSubtitutionDirtyProperties {
     }
     return self;
 }
+#ifdef DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];
@@ -131,6 +132,7 @@ struct VariableSubtitutionDirtyProperties {
     }
     return [NSString stringWithFormat:@"VariableSubtitution = {\n%@\n}", debugDescriptionForFields(descriptionFields)];
 }
+#endif
 - (instancetype)copyWithBlock:(PLANK_NOESCAPE void (^)(VariableSubtitutionBuilder *builder))block
 {
     NSParameterAssert(block);

--- a/Sources/Core/ObjectiveCDebugExtension.swift
+++ b/Sources/Core/ObjectiveCDebugExtension.swift
@@ -29,7 +29,7 @@ extension ObjCModelRenderer {
         }
 
         let printFormat = "\(className) = {\\n%@\\n}".objcLiteral()
-        return ObjCIR.method("- (NSString *)debugDescription") { [
+        return ObjCIR.method("- (NSString *)debugDescription", ifdef: "DEBUG") { [
             "NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:\("\\n".objcLiteral())];",
             "NSMutableArray *descriptionFields = [NSMutableArray arrayWithCapacity:\(self.properties.count)];",
             "[descriptionFields addObject:parentDebugDescription];",

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -186,10 +186,8 @@ func == (lhs: MethodVisibility, rhs: MethodVisibility) -> Bool {
 }
 
 public struct ObjCIR {
-    static let ret = "return"
-
-    static func method(_ signature: String, body: () -> [String]) -> ObjCIR.Method {
-        return ObjCIR.Method(body: body(), signature: signature)
+    static func method(_ signature: String, ifdef: String? = nil, body: () -> [String]) -> ObjCIR.Method {
+        return ObjCIR.Method(body: body(), signature: signature, ifdef: ifdef)
     }
 
     static func stmt(_ body: String) -> String {
@@ -315,14 +313,19 @@ public struct ObjCIR {
     public struct Method {
         let body: [String]
         let signature: String
+        let ifdef: String?
 
         func render() -> [String] {
-            return [
+            let lines = [
                 signature,
                 "{",
                 -->body,
                 "}",
             ]
+            if ifdef != nil {
+                return ["#ifdef " + ifdef!] + lines + ["#endif"]
+            }
+            return lines
         }
     }
 

--- a/Tests/CoreTests/LinuxTestIndex.swift
+++ b/Tests/CoreTests/LinuxTestIndex.swift
@@ -49,7 +49,9 @@ extension ObjectiveCIRTests {
        ("testIfStmt", testIfStmt),
        ("testElseIfStmt", testElseIfStmt),
        ("testElseStmt", testElseStmt),
-       ("testIfElseStmt", testIfElseStmt)
+       ("testIfElseStmt", testIfElseStmt),
+       ("testMethod", testMethod),
+       ("testMethodIfdef", testMethodIfdef)
    ]
 }
 // Generated Test Extension for ObjectiveCInitTests

--- a/Tests/CoreTests/ObjectiveCIRTests.swift
+++ b/Tests/CoreTests/ObjectiveCIRTests.swift
@@ -155,4 +155,32 @@ class ObjectiveCIRTests: XCTestCase {
         ] }
         XCTAssertEqual(expected, actual)
     }
+
+    func testMethod() {
+        let expected = [
+            "- (id)method",
+            "{",
+            "\treturn nil",
+            "}",
+        ]
+        let actual = ObjCIR.method("- (id)method") {
+            ["return nil"]
+        }.render()
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testMethodIfdef() {
+        let expected = [
+            "#ifdef DEBUG",
+            "- (id)method",
+            "{",
+            "\treturn nil",
+            "}",
+            "#endif",
+        ]
+        let actual = ObjCIR.method("- (id)method", ifdef: "DEBUG") {
+            ["return nil"]
+        }.render()
+        XCTAssertEqual(expected, actual)
+    }
 }


### PR DESCRIPTION
This is a useful debugging method, but it doesn't need to be included as
part of a release build. If we discover a use case for that, we should
consider an appropriate `-description` implementation instead.

Because of the number of strings this method can use, especially for
models with many fields, this change results in a significant binary
size reduction for non-debug builds.