### PR TITLE
Fix DEBUG preprocessor checks

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -245,7 +245,7 @@ struct BoardDirtyProperties {
     }
     return self;
 }
-#ifdef DEBUG
+#if DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];

--- a/Examples/Cocoa/Sources/Objective_C/Everything.m
+++ b/Examples/Cocoa/Sources/Objective_C/Everything.m
@@ -1549,7 +1549,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
     }
     return self;
 }
-#ifdef DEBUG
+#if DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];

--- a/Examples/Cocoa/Sources/Objective_C/Image.m
+++ b/Examples/Cocoa/Sources/Objective_C/Image.m
@@ -123,7 +123,7 @@ struct ImageDirtyProperties {
     }
     return self;
 }
-#ifdef DEBUG
+#if DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];

--- a/Examples/Cocoa/Sources/Objective_C/Model.m
+++ b/Examples/Cocoa/Sources/Objective_C/Model.m
@@ -91,7 +91,7 @@ struct ModelDirtyProperties {
     }
     return self;
 }
-#ifdef DEBUG
+#if DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];

--- a/Examples/Cocoa/Sources/Objective_C/Nested.m
+++ b/Examples/Cocoa/Sources/Objective_C/Nested.m
@@ -91,7 +91,7 @@ struct NestedDirtyProperties {
     }
     return self;
 }
-#ifdef DEBUG
+#if DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];

--- a/Examples/Cocoa/Sources/Objective_C/OneofObject.m
+++ b/Examples/Cocoa/Sources/Objective_C/OneofObject.m
@@ -91,7 +91,7 @@ struct OneofObjectDirtyProperties {
     }
     return self;
 }
-#ifdef DEBUG
+#if DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];

--- a/Examples/Cocoa/Sources/Objective_C/Pin.m
+++ b/Examples/Cocoa/Sources/Objective_C/Pin.m
@@ -529,7 +529,7 @@ struct PinDirtyProperties {
     }
     return self;
 }
-#ifdef DEBUG
+#if DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];

--- a/Examples/Cocoa/Sources/Objective_C/User.m
+++ b/Examples/Cocoa/Sources/Objective_C/User.m
@@ -268,7 +268,7 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
     }
     return self;
 }
-#ifdef DEBUG
+#if DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];

--- a/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
+++ b/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
@@ -139,7 +139,7 @@ struct VariableSubtitutionDirtyProperties {
     }
     return self;
 }
-#ifdef DEBUG
+#if DEBUG
 - (NSString *)debugDescription
 {
     NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:@"\n"];

--- a/Sources/Core/ObjectiveCDebugExtension.swift
+++ b/Sources/Core/ObjectiveCDebugExtension.swift
@@ -29,7 +29,7 @@ extension ObjCModelRenderer {
         }
 
         let printFormat = "\(className) = {\\n%@\\n}".objcLiteral()
-        return ObjCIR.method("- (NSString *)debugDescription", ifdef: "DEBUG") { [
+        return ObjCIR.method("- (NSString *)debugDescription", debug: true) { [
             "NSArray<NSString *> *parentDebugDescription = [[super debugDescription] componentsSeparatedByString:\("\\n".objcLiteral())];",
             "NSMutableArray *descriptionFields = [NSMutableArray arrayWithCapacity:\(self.properties.count)];",
             "[descriptionFields addObject:parentDebugDescription];",

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -186,8 +186,8 @@ func == (lhs: MethodVisibility, rhs: MethodVisibility) -> Bool {
 }
 
 public struct ObjCIR {
-    static func method(_ signature: String, ifdef: String? = nil, body: () -> [String]) -> ObjCIR.Method {
-        return ObjCIR.Method(body: body(), signature: signature, ifdef: ifdef)
+    static func method(_ signature: String, debug: Bool = false, body: () -> [String]) -> ObjCIR.Method {
+        return ObjCIR.Method(body: body(), signature: signature, debug: debug)
     }
 
     static func stmt(_ body: String) -> String {
@@ -313,7 +313,7 @@ public struct ObjCIR {
     public struct Method {
         let body: [String]
         let signature: String
-        let ifdef: String?
+        let debug: Bool
 
         func render() -> [String] {
             let lines = [
@@ -322,8 +322,8 @@ public struct ObjCIR {
                 -->body,
                 "}",
             ]
-            if ifdef != nil {
-                return ["#ifdef " + ifdef!] + lines + ["#endif"]
+            if debug {
+                return ["#if DEBUG"] + lines + ["#endif"]
             }
             return lines
         }

--- a/Tests/CoreTests/LinuxTestIndex.swift
+++ b/Tests/CoreTests/LinuxTestIndex.swift
@@ -51,7 +51,7 @@ extension ObjectiveCIRTests {
        ("testElseStmt", testElseStmt),
        ("testIfElseStmt", testIfElseStmt),
        ("testMethod", testMethod),
-       ("testMethodIfdef", testMethodIfdef)
+       ("testMethodDebug", testMethodDebug)
    ]
 }
 // Generated Test Extension for ObjectiveCInitTests

--- a/Tests/CoreTests/ObjectiveCIRTests.swift
+++ b/Tests/CoreTests/ObjectiveCIRTests.swift
@@ -169,16 +169,16 @@ class ObjectiveCIRTests: XCTestCase {
         XCTAssertEqual(expected, actual)
     }
 
-    func testMethodIfdef() {
+    func testMethodDebug() {
         let expected = [
-            "#ifdef DEBUG",
+            "#if DEBUG",
             "- (id)method",
             "{",
             "\treturn nil",
             "}",
             "#endif",
         ]
-        let actual = ObjCIR.method("- (id)method", ifdef: "DEBUG") {
+        let actual = ObjCIR.method("- (id)method", debug: true) {
             ["return nil"]
         }.render()
         XCTAssertEqual(expected, actual)


### PR DESCRIPTION
These should use `#if`, not `#ifdef`, for the DEBUG case. Simplify this
further by only supporting a `debug` boolean flag.