### PR TITLE
Allow nil modelDictionaries to fully initialize NSObject

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -58,10 +58,10 @@ struct BoardDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
+    if (!(self = [super initWithModelDictionary:modelDictionary error:error])) { return self; }
     if (!modelDictionary) {
         return self;
     }
-    if (!(self = [super initWithModelDictionary:modelDictionary error:error])) { return self; }
     {
         __unsafe_unretained id value = modelDictionary[@"contributors"];
         if (value != nil) {

--- a/Examples/Cocoa/Sources/Objective_C/Everything.m
+++ b/Examples/Cocoa/Sources/Objective_C/Everything.m
@@ -725,10 +725,10 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
-    if (!modelDictionary) {
+    if (!(self = [super init])) {
         return self;
     }
-    if (!(self = [super init])) {
+    if (!modelDictionary) {
         return self;
     }
     {

--- a/Examples/Cocoa/Sources/Objective_C/Image.m
+++ b/Examples/Cocoa/Sources/Objective_C/Image.m
@@ -50,10 +50,10 @@ struct ImageDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
-    if (!modelDictionary) {
+    if (!(self = [super init])) {
         return self;
     }
-    if (!(self = [super init])) {
+    if (!modelDictionary) {
         return self;
     }
     {

--- a/Examples/Cocoa/Sources/Objective_C/Model.m
+++ b/Examples/Cocoa/Sources/Objective_C/Model.m
@@ -48,10 +48,10 @@ struct ModelDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
-    if (!modelDictionary) {
+    if (!(self = [super init])) {
         return self;
     }
-    if (!(self = [super init])) {
+    if (!modelDictionary) {
         return self;
     }
     {

--- a/Examples/Cocoa/Sources/Objective_C/Nested.m
+++ b/Examples/Cocoa/Sources/Objective_C/Nested.m
@@ -48,10 +48,10 @@ struct NestedDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
-    if (!modelDictionary) {
+    if (!(self = [super init])) {
         return self;
     }
-    if (!(self = [super init])) {
+    if (!modelDictionary) {
         return self;
     }
     {

--- a/Examples/Cocoa/Sources/Objective_C/OneofObject.m
+++ b/Examples/Cocoa/Sources/Objective_C/OneofObject.m
@@ -48,10 +48,10 @@ struct OneofObjectDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
-    if (!modelDictionary) {
+    if (!(self = [super init])) {
         return self;
     }
-    if (!(self = [super init])) {
+    if (!modelDictionary) {
         return self;
     }
     {

--- a/Examples/Cocoa/Sources/Objective_C/Pin.m
+++ b/Examples/Cocoa/Sources/Objective_C/Pin.m
@@ -182,10 +182,10 @@ struct PinDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
-    if (!modelDictionary) {
+    if (!(self = [super init])) {
         return self;
     }
-    if (!(self = [super init])) {
+    if (!modelDictionary) {
         return self;
     }
     {

--- a/Examples/Cocoa/Sources/Objective_C/User.m
+++ b/Examples/Cocoa/Sources/Objective_C/User.m
@@ -90,10 +90,10 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
-    if (!modelDictionary) {
+    if (!(self = [super init])) {
         return self;
     }
-    if (!(self = [super init])) {
+    if (!modelDictionary) {
         return self;
     }
     {

--- a/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
+++ b/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
@@ -51,10 +51,10 @@ struct VariableSubtitutionDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
-    if (!modelDictionary) {
+    if (!(self = [super init])) {
         return self;
     }
-    if (!(self = [super init])) {
+    if (!modelDictionary) {
         return self;
     }
     {

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -316,9 +316,9 @@ extension ObjCModelRenderer {
         return ObjCIR.method("- (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error") {
             [
                 "NSParameterAssert(modelDictionary);",
-                ObjCIR.ifStmt("!modelDictionary") { ["return self;"] },
                 self.isBaseClass ? ObjCIR.ifStmt("!(self = [super init])") { ["return self;"] } :
                     "if (!(self = [super initWithModelDictionary:modelDictionary error:error])) { return self; }",
+                ObjCIR.ifStmt("!modelDictionary") { ["return self;"] },
                 self.properties.map { name, prop in
                     ObjCIR.scope { [
                         "__unsafe_unretained id value = modelDictionary[\(name.objcLiteral())];",


### PR DESCRIPTION
Otherwise `-[NSObject init]` is not being called, yet the code is returning `self`.