### PR TITLE
Assert that modelDictionary is a NSDictionary when creating models

### DIFF
--- a/Examples/Cocoa/Sources/Objective_C/Board.m
+++ b/Examples/Cocoa/Sources/Objective_C/Board.m
@@ -58,6 +58,7 @@ struct BoardDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
+    NSParameterAssert([modelDictionary isKindOfClass:[NSDictionary class]]);
     if (!(self = [super initWithModelDictionary:modelDictionary error:error])) { return self; }
     if (!modelDictionary) {
         return self;

--- a/Examples/Cocoa/Sources/Objective_C/Everything.m
+++ b/Examples/Cocoa/Sources/Objective_C/Everything.m
@@ -725,6 +725,7 @@ extern EverythingStringEnum EverythingStringEnumFromString(NSString * _Nonnull s
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
+    NSParameterAssert([modelDictionary isKindOfClass:[NSDictionary class]]);
     if (!(self = [super init])) {
         return self;
     }

--- a/Examples/Cocoa/Sources/Objective_C/Image.m
+++ b/Examples/Cocoa/Sources/Objective_C/Image.m
@@ -50,6 +50,7 @@ struct ImageDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
+    NSParameterAssert([modelDictionary isKindOfClass:[NSDictionary class]]);
     if (!(self = [super init])) {
         return self;
     }

--- a/Examples/Cocoa/Sources/Objective_C/Model.m
+++ b/Examples/Cocoa/Sources/Objective_C/Model.m
@@ -48,6 +48,7 @@ struct ModelDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
+    NSParameterAssert([modelDictionary isKindOfClass:[NSDictionary class]]);
     if (!(self = [super init])) {
         return self;
     }

--- a/Examples/Cocoa/Sources/Objective_C/Nested.m
+++ b/Examples/Cocoa/Sources/Objective_C/Nested.m
@@ -48,6 +48,7 @@ struct NestedDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
+    NSParameterAssert([modelDictionary isKindOfClass:[NSDictionary class]]);
     if (!(self = [super init])) {
         return self;
     }

--- a/Examples/Cocoa/Sources/Objective_C/OneofObject.m
+++ b/Examples/Cocoa/Sources/Objective_C/OneofObject.m
@@ -48,6 +48,7 @@ struct OneofObjectDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
+    NSParameterAssert([modelDictionary isKindOfClass:[NSDictionary class]]);
     if (!(self = [super init])) {
         return self;
     }

--- a/Examples/Cocoa/Sources/Objective_C/Pin.m
+++ b/Examples/Cocoa/Sources/Objective_C/Pin.m
@@ -182,6 +182,7 @@ struct PinDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
+    NSParameterAssert([modelDictionary isKindOfClass:[NSDictionary class]]);
     if (!(self = [super init])) {
         return self;
     }

--- a/Examples/Cocoa/Sources/Objective_C/User.m
+++ b/Examples/Cocoa/Sources/Objective_C/User.m
@@ -90,6 +90,7 @@ extern UserEmailFrequency UserEmailFrequencyFromString(NSString * _Nonnull str)
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
+    NSParameterAssert([modelDictionary isKindOfClass:[NSDictionary class]]);
     if (!(self = [super init])) {
         return self;
     }

--- a/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
+++ b/Examples/Cocoa/Sources/Objective_C/VariableSubtitution.m
@@ -51,6 +51,7 @@ struct VariableSubtitutionDirtyProperties {
 - (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error
 {
     NSParameterAssert(modelDictionary);
+    NSParameterAssert([modelDictionary isKindOfClass:[NSDictionary class]]);
     if (!(self = [super init])) {
         return self;
     }

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -316,6 +316,7 @@ extension ObjCModelRenderer {
         return ObjCIR.method("- (instancetype)initWithModelDictionary:(NS_VALID_UNTIL_END_OF_SCOPE NSDictionary *)modelDictionary error:(NSError *__autoreleasing *)error") {
             [
                 "NSParameterAssert(modelDictionary);",
+                "NSParameterAssert([modelDictionary isKindOfClass:[NSDictionary class]]);",
                 self.isBaseClass ? ObjCIR.ifStmt("!(self = [super init])") { ["return self;"] } :
                     "if (!(self = [super initWithModelDictionary:modelDictionary error:error])) { return self; }",
                 ObjCIR.ifStmt("!modelDictionary") { ["return self;"] },


### PR DESCRIPTION
This may catch some bad casts in client code during development. This is basically a small first step towards #279.