### PR TITLE
Allows setting a header prefix for Objective-C

### DIFF
--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -283,7 +283,7 @@ public protocol FileGeneratorManager {
 }
 
 public protocol FileGenerator {
-    func renderFile(_ : GenerationParameters) -> String
+    func renderFile(_: GenerationParameters) -> String
     var fileName: String { mutating get }
     var indent: Int { get }
 }

--- a/Sources/Core/FileGenerator.swift
+++ b/Sources/Core/FileGenerator.swift
@@ -15,6 +15,7 @@ let date = Date()
 
 public enum GenerationParameterType {
     case classPrefix
+    case headerPrefix
     case recursive
     case includeRuntime
     case indent
@@ -282,13 +283,13 @@ public protocol FileGeneratorManager {
 }
 
 public protocol FileGenerator {
-    func renderFile() -> String
+    func renderFile(_ : GenerationParameters) -> String
     var fileName: String { mutating get }
     var indent: Int { get }
 }
 
 protocol RootRenderer {
-    func renderImplementation() -> [String]
+    func renderImplementation(_ params: GenerationParameters) -> [String]
 }
 
 protocol FileRenderer {
@@ -452,7 +453,7 @@ public func writeFile(file: FileGenerator, outputDirectory: URL, generationParam
     var file = file
     let indent = generationParameters.indent(file: file)
     let indentSpaces = String(repeating: " ", count: indent)
-    let fileContents = file.renderFile()
+    let fileContents = file.renderFile(generationParameters)
         .replacingOccurrences(of: "\t", with: indentSpaces)
         .appending("\n") // Ensure there is exactly one new line a the end of the file
     do {

--- a/Sources/Core/JSFileGenerator.swift
+++ b/Sources/Core/JSFileGenerator.swift
@@ -34,10 +34,10 @@ struct JSModelFile: FileGenerator {
         return 2
     }
 
-    func renderFile(_ paramaters: GenerationParameters) -> String {
+    func renderFile(_ parameters: GenerationParameters) -> String {
         return (
             [self.renderCommentHeader()] +
-                roots.map { $0.renderImplementation(paramaters).joined(separator: "\n") }
+                roots.map { $0.renderImplementation(parameters).joined(separator: "\n") }
         )
         .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
         .filter { $0 != "" }

--- a/Sources/Core/JSFileGenerator.swift
+++ b/Sources/Core/JSFileGenerator.swift
@@ -34,10 +34,10 @@ struct JSModelFile: FileGenerator {
         return 2
     }
 
-    func renderFile() -> String {
+    func renderFile(_ paramaters: GenerationParameters) -> String {
         return (
             [self.renderCommentHeader()] +
-                roots.map { $0.renderImplementation().joined(separator: "\n") }
+                roots.map { $0.renderImplementation(paramaters).joined(separator: "\n") }
         )
         .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
         .filter { $0 != "" }

--- a/Sources/Core/JSIR.swift
+++ b/Sources/Core/JSIR.swift
@@ -124,7 +124,7 @@ public struct JSIR {
         )
         case enumDecl(name: String, values: EnumType)
 
-        func renderImplementation(_ params: GenerationParameters) -> [String] {
+        func renderImplementation(_: GenerationParameters) -> [String] {
             switch self {
             case .structDecl(name: _, fields: _):
                 // Structs are not supported

--- a/Sources/Core/JSIR.swift
+++ b/Sources/Core/JSIR.swift
@@ -124,7 +124,7 @@ public struct JSIR {
         )
         case enumDecl(name: String, values: EnumType)
 
-        func renderImplementation() -> [String] {
+        func renderImplementation(_ params: GenerationParameters) -> [String] {
             switch self {
             case .structDecl(name: _, fields: _):
                 // Structs are not supported

--- a/Sources/Core/JSRuntimeFile.swift
+++ b/Sources/Core/JSRuntimeFile.swift
@@ -33,7 +33,7 @@ struct JSRuntimeFile: FileGenerator {
             .joined(separator: "\n")
     }
 
-    func renderFile(_ paramaters: GenerationParameters) -> String {
+    func renderFile(_: GenerationParameters) -> String {
         let output = (
             [self.renderCommentHeader()] + [self.renderContent()]
         )

--- a/Sources/Core/JSRuntimeFile.swift
+++ b/Sources/Core/JSRuntimeFile.swift
@@ -33,7 +33,7 @@ struct JSRuntimeFile: FileGenerator {
             .joined(separator: "\n")
     }
 
-    func renderFile() -> String {
+    func renderFile(_ paramaters: GenerationParameters) -> String {
         let output = (
             [self.renderCommentHeader()] + [self.renderContent()]
         )

--- a/Sources/Core/JavaFileGenerator.swift
+++ b/Sources/Core/JavaFileGenerator.swift
@@ -28,10 +28,10 @@ struct JavaFileGenerator: FileGenerator {
         return "\(className).java"
     }
 
-    func renderFile(_ paramaters: GenerationParameters) -> String {
+    func renderFile(_ parameters: GenerationParameters) -> String {
         return (
             [self.renderCommentHeader()] +
-                roots.map { $0.renderImplementation(paramaters).joined(separator: "\n") }
+                roots.map { $0.renderImplementation(parameters).joined(separator: "\n") }
         )
         .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
         .map { $0.replacingOccurrences(of: "  ", with: " ") }

--- a/Sources/Core/JavaFileGenerator.swift
+++ b/Sources/Core/JavaFileGenerator.swift
@@ -28,10 +28,10 @@ struct JavaFileGenerator: FileGenerator {
         return "\(className).java"
     }
 
-    func renderFile() -> String {
+    func renderFile(_ paramaters: GenerationParameters) -> String {
         return (
             [self.renderCommentHeader()] +
-                roots.map { $0.renderImplementation().joined(separator: "\n") }
+                roots.map { $0.renderImplementation(paramaters).joined(separator: "\n") }
         )
         .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
         .map { $0.replacingOccurrences(of: "  ", with: " ") }

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -487,7 +487,7 @@ public struct JavaIR {
         case classDecl(aClass: JavaIR.Class)
         case interfaceDecl(aInterface: JavaIR.Interface)
 
-        func renderImplementation() -> [String] {
+        func renderImplementation(_ params: GenerationParameters) -> [String] {
             switch self {
             case let .packages(names):
                 return names.sorted().map { "package \($0);" }

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -487,7 +487,7 @@ public struct JavaIR {
         case classDecl(aClass: JavaIR.Class)
         case interfaceDecl(aInterface: JavaIR.Interface)
 
-        func renderImplementation(_ params: GenerationParameters) -> [String] {
+        func renderImplementation(_: GenerationParameters) -> [String] {
             switch self {
             case let .packages(names):
                 return names.sorted().map { "package \($0);" }

--- a/Sources/Core/ObjectiveCFileGenerator.swift
+++ b/Sources/Core/ObjectiveCFileGenerator.swift
@@ -43,10 +43,10 @@ struct ObjCHeaderFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile(_ paramaters: GenerationParameters) -> String {
+    func renderFile(_ parameters: GenerationParameters) -> String {
         let output = (
             [self.renderCommentHeader()] +
-                roots.compactMap { $0.renderHeader(paramaters).joined(separator: "\n") }
+                roots.compactMap { $0.renderHeader(parameters).joined(separator: "\n") }
         )
         .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
         .filter { $0 != "" }
@@ -67,10 +67,10 @@ struct ObjCImplementationFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile(_ paramaters: GenerationParameters) -> String {
+    func renderFile(_ parameters: GenerationParameters) -> String {
         let output = (
             [self.renderCommentHeader()] +
-                roots.map { $0.renderImplementation(paramaters).joined(separator: "\n") }
+                roots.map { $0.renderImplementation(parameters).joined(separator: "\n") }
         )
         .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
         .filter { $0 != "" }
@@ -163,20 +163,19 @@ struct ObjCRuntimeFile {
 }
 
 struct ObjCRuntimeHeaderFile: FileGenerator {
+    let fileNamePrefix = "PlankModelRuntime"
+    let fileNameExtension = "h"
     var fileName: String {
         return "\(fileNamePrefix).\(fileNameExtension)"
     }
-    
-    let fileNamePrefix = "PlankModelRuntime"
-    let fileNameExtension = "h"
 
     var indent: Int {
         return objcDefaultIndent
     }
 
-    func renderFile(_ paramaters: GenerationParameters) -> String {
+    func renderFile(_ parameters: GenerationParameters) -> String {
         let roots: [ObjCIR.Root] = ObjCRuntimeFile.renderRoots()
-        let outputs = roots.map { $0.renderHeader(paramaters) }.reduce([], +)
+        let outputs = roots.map { $0.renderHeader(parameters) }.reduce([], +)
         return ([self.renderCommentHeader(), "", "#import <Foundation/Foundation.h>", ""] + outputs)
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }
@@ -193,12 +192,12 @@ struct ObjCRuntimeImplementationFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile(_ paramaters: GenerationParameters) -> String {
+    func renderFile(_ parameters: GenerationParameters) -> String {
         let roots: [ObjCIR.Root] = ObjCRuntimeFile.renderRoots()
-        let outputs = roots.map { $0.renderImplementation(paramaters) }.reduce([], +)
+        let outputs = roots.map { $0.renderImplementation(parameters) }.reduce([], +)
         return ([self.renderCommentHeader(), "", "#import <Foundation/Foundation.h>",
                  "",
-                 ObjCIR.fileImportStmt(ObjCRuntimeHeaderFile().fileNamePrefix, headerPrefix: paramaters[GenerationParameterType.headerPrefix]),
+                 ObjCIR.fileImportStmt(ObjCRuntimeHeaderFile().fileNamePrefix, headerPrefix: parameters[GenerationParameterType.headerPrefix]),
                  outputs.joined(separator: "\n")])
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }

--- a/Sources/Core/ObjectiveCFileGenerator.swift
+++ b/Sources/Core/ObjectiveCFileGenerator.swift
@@ -43,10 +43,10 @@ struct ObjCHeaderFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(_ paramaters: GenerationParameters) -> String {
         let output = (
             [self.renderCommentHeader()] +
-                roots.compactMap { $0.renderHeader().joined(separator: "\n") }
+                roots.compactMap { $0.renderHeader(paramaters).joined(separator: "\n") }
         )
         .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
         .filter { $0 != "" }
@@ -67,10 +67,10 @@ struct ObjCImplementationFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(_ paramaters: GenerationParameters) -> String {
         let output = (
             [self.renderCommentHeader()] +
-                roots.map { $0.renderImplementation().joined(separator: "\n") }
+                roots.map { $0.renderImplementation(paramaters).joined(separator: "\n") }
         )
         .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
         .filter { $0 != "" }
@@ -164,16 +164,19 @@ struct ObjCRuntimeFile {
 
 struct ObjCRuntimeHeaderFile: FileGenerator {
     var fileName: String {
-        return "PlankModelRuntime.h"
+        return "\(fileNamePrefix).\(fileNameExtension)"
     }
+    
+    let fileNamePrefix = "PlankModelRuntime"
+    let fileNameExtension = "h"
 
     var indent: Int {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(_ paramaters: GenerationParameters) -> String {
         let roots: [ObjCIR.Root] = ObjCRuntimeFile.renderRoots()
-        let outputs = roots.map { $0.renderHeader() }.reduce([], +)
+        let outputs = roots.map { $0.renderHeader(paramaters) }.reduce([], +)
         return ([self.renderCommentHeader(), "", "#import <Foundation/Foundation.h>", ""] + outputs)
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }
@@ -190,10 +193,13 @@ struct ObjCRuntimeImplementationFile: FileGenerator {
         return objcDefaultIndent
     }
 
-    func renderFile() -> String {
+    func renderFile(_ paramaters: GenerationParameters) -> String {
         let roots: [ObjCIR.Root] = ObjCRuntimeFile.renderRoots()
-        let outputs = roots.map { $0.renderImplementation() }.reduce([], +)
-        return ([self.renderCommentHeader(), "", "#import <Foundation/Foundation.h>", "", "#import \"\(ObjCRuntimeHeaderFile().fileName)\"", outputs.joined(separator: "\n")])
+        let outputs = roots.map { $0.renderImplementation(paramaters) }.reduce([], +)
+        return ([self.renderCommentHeader(), "", "#import <Foundation/Foundation.h>",
+                 "",
+                 ObjCIR.fileImportStmt(ObjCRuntimeHeaderFile().fileNamePrefix, headerPrefix: paramaters[GenerationParameterType.headerPrefix]),
+                 outputs.joined(separator: "\n")])
             .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
             .filter { $0 != "" }
             .joined(separator: "\n\n")

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -290,7 +290,10 @@ public struct ObjCIR {
         ].joined(separator: "\n")
     }
 
-    static func fileImportStmt(_ filename: String) -> String {
+    static func fileImportStmt(_ filename: String, headerPrefix: String?) -> String {
+        if let headerPrefix = headerPrefix {
+            return "#import \"\(headerPrefix)\(filename).h\""
+        }
         return "#import \"\(filename).h\""
     }
 
@@ -347,7 +350,7 @@ public struct ObjCIR {
         case enumDecl(name: String, values: EnumType)
         case optionSetEnum(name: String, values: [EnumValue<Int>])
 
-        func renderHeader() -> [String] {
+        func renderHeader(_ params: GenerationParameters) -> [String] {
             switch self {
             case .structDecl:
                 // skip structs in header
@@ -355,9 +358,13 @@ public struct ObjCIR {
             case let .macro(macro):
                 return [macro]
             case let .imports(classNames, myName, parentName):
+                var parentImport = ""
+                if let parentName = parentName {
+                    parentImport = ObjCIR.fileImportStmt(parentName, headerPrefix: nil)
+                }
                 return [
                     "#import <Foundation/Foundation.h>",
-                    parentName.map(ObjCIR.fileImportStmt) ?? "",
+                    parentImport,
                     "#import \"\(ObjCRuntimeHeaderFile().fileName)\"",
                 ].filter { $0 != "" } + (["\(myName)Builder"] + classNames)
                     .sorted().map { "@class \($0.trimmingCharacters(in: .whitespaces));" }
@@ -408,7 +415,7 @@ public struct ObjCIR {
             }
         }
 
-        func renderImplementation() -> [String] {
+        func renderImplementation(_ params: GenerationParameters) -> [String] {
             switch self {
             case let .structDecl(name: name, fields: fields):
                 return [
@@ -423,7 +430,7 @@ public struct ObjCIR {
                 return [classNames.union(Set([myName]))
                     .sorted()
                     .map { $0.trimmingCharacters(in: .whitespaces) }
-                    .map(ObjCIR.fileImportStmt)
+                            .map({ObjCIR.fileImportStmt($0, headerPrefix: params[GenerationParameterType.headerPrefix])})
                     .joined(separator: "\n")]
             case .classDecl(name: let className, extends: _, methods: let methods, properties: _, protocols: let protocols):
                 return [

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -350,7 +350,7 @@ public struct ObjCIR {
         case enumDecl(name: String, values: EnumType)
         case optionSetEnum(name: String, values: [EnumValue<Int>])
 
-        func renderHeader(_ params: GenerationParameters) -> [String] {
+        func renderHeader(_: GenerationParameters) -> [String] {
             switch self {
             case .structDecl:
                 // skip structs in header
@@ -359,7 +359,7 @@ public struct ObjCIR {
                 return [macro]
             case let .imports(classNames, myName, parentName):
                 var parentImport = ""
-                if let parentName = parentName {
+                if parentName != nil {
                     parentImport = ObjCIR.fileImportStmt(parentName, headerPrefix: nil)
                 }
                 return [
@@ -430,7 +430,7 @@ public struct ObjCIR {
                 return [classNames.union(Set([myName]))
                     .sorted()
                     .map { $0.trimmingCharacters(in: .whitespaces) }
-                            .map({ObjCIR.fileImportStmt($0, headerPrefix: params[GenerationParameterType.headerPrefix])})
+                    .map { ObjCIR.fileImportStmt($0, headerPrefix: params[GenerationParameterType.headerPrefix]) }
                     .joined(separator: "\n")]
             case .classDecl(name: let className, extends: _, methods: let methods, properties: _, protocols: let protocols):
                 return [

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -359,7 +359,7 @@ public struct ObjCIR {
                 return [macro]
             case let .imports(classNames, myName, parentName):
                 var parentImport = ""
-                if parentName != nil {
+                if let parentName = parentName {
                     parentImport = ObjCIR.fileImportStmt(parentName, headerPrefix: nil)
                 }
                 return [

--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -358,10 +358,7 @@ public struct ObjCIR {
             case let .macro(macro):
                 return [macro]
             case let .imports(classNames, myName, parentName):
-                var parentImport = ""
-                if let parentName = parentName {
-                    parentImport = ObjCIR.fileImportStmt(parentName, headerPrefix: nil)
-                }
+                let parentImport = (parentName != nil) ? ObjCIR.fileImportStmt(parentName!, headerPrefix: nil) : ""
                 return [
                     "#import <Foundation/Foundation.h>",
                     parentImport,

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -16,6 +16,7 @@ protocol HelpCommandOutput {
 enum FlagOptions: String {
     case outputDirectory = "output_dir"
     case objectiveCClassPrefix = "objc_class_prefix"
+    case objectiveCHeaderPrefix = "objc_header_prefix"
     case javaPackageName = "java_package_name"
     case javaNullabilityAnnotationType = "java_nullability_annotation_type"
     case javaGeneratePackagePrivateSetters = "java_generate_package_private_setters_beta"
@@ -35,6 +36,7 @@ enum FlagOptions: String {
         switch self {
         case .outputDirectory: return true
         case .objectiveCClassPrefix: return true
+        case .objectiveCHeaderPrefix: return true
         case .indent: return true
         case .printDeps: return false
         case .noRecursive: return false
@@ -68,6 +70,7 @@ extension FlagOptions: HelpCommandOutput {
             "",
             "    Objective-C:",
             "    --\(FlagOptions.objectiveCClassPrefix.rawValue) - The prefix to add to all generated class names",
+            "    --\(FlagOptions.objectiveCHeaderPrefix.rawValue) - The prefix to add to header include for all generated classes",
             "",
             "    Java:",
             "    --\(FlagOptions.javaPackageName.rawValue) - The package name to associate with generated Java sources",
@@ -156,6 +159,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     // need to be lifted out of literal because https://bugs.swift.org/browse/SR-2372
     let recursive: String? = (flags[.noRecursive] == nil) ? .some("") : .none
     let classPrefix: String? = flags[.objectiveCClassPrefix]
+    let headerPrefix: String? = flags[.objectiveCHeaderPrefix]
     let includeRuntime: String? = flags[.onlyRuntime] != nil || (flags[.noRuntime] == nil || flags[.noRecursive] != nil) ? .some("") : .none
     let indent: String? = flags[.indent]
     let packageName: String? = flags[.javaPackageName]
@@ -168,6 +172,7 @@ func handleGenerateCommand(withArguments arguments: [String]) {
     let generationParameters: GenerationParameters = [
         (.recursive, recursive),
         (.classPrefix, classPrefix),
+        (.headerPrefix, headerPrefix),
         (.includeRuntime, includeRuntime),
         (.indent, indent),
         (.packageName, packageName),

--- a/Sources/plank/Cli.swift
+++ b/Sources/plank/Cli.swift
@@ -70,7 +70,7 @@ extension FlagOptions: HelpCommandOutput {
             "",
             "    Objective-C:",
             "    --\(FlagOptions.objectiveCClassPrefix.rawValue) - The prefix to add to all generated class names",
-            "    --\(FlagOptions.objectiveCHeaderPrefix.rawValue) - The prefix to add to header include for all generated classes",
+            "    --\(FlagOptions.objectiveCHeaderPrefix.rawValue) - The prefix to add before all generated header includes",
             "",
             "    Java:",
             "    --\(FlagOptions.javaPackageName.rawValue) - The package name to associate with generated Java sources",

--- a/Tests/CoreTests/LinuxTestIndex.swift
+++ b/Tests/CoreTests/LinuxTestIndex.swift
@@ -51,7 +51,8 @@ extension ObjectiveCIRTests {
        ("testElseStmt", testElseStmt),
        ("testIfElseStmt", testIfElseStmt),
        ("testMethod", testMethod),
-       ("testMethodDebug", testMethodDebug)
+       ("testMethodDebug", testMethodDebug),
+       ("testFileImport", testFileImport)
    ]
 }
 // Generated Test Extension for ObjectiveCInitTests

--- a/Tests/CoreTests/ObjectiveCIRTests.swift
+++ b/Tests/CoreTests/ObjectiveCIRTests.swift
@@ -183,7 +183,7 @@ class ObjectiveCIRTests: XCTestCase {
         }.render()
         XCTAssertEqual(expected, actual)
     }
-    
+
     func testFileImport() {
         XCTAssertEqual("#import \"include/ModelClass.h\"", ObjCIR.fileImportStmt("ModelClass", headerPrefix: "include/"))
         XCTAssertEqual("#import \"ModelClass.h\"", ObjCIR.fileImportStmt("ModelClass", headerPrefix: nil))

--- a/Tests/CoreTests/ObjectiveCIRTests.swift
+++ b/Tests/CoreTests/ObjectiveCIRTests.swift
@@ -183,4 +183,9 @@ class ObjectiveCIRTests: XCTestCase {
         }.render()
         XCTAssertEqual(expected, actual)
     }
+    
+    func testFileImport() {
+        XCTAssertEqual("#import \"include/ModelClass.h\"", ObjCIR.fileImportStmt("ModelClass", headerPrefix: "include/"))
+        XCTAssertEqual("#import \"ModelClass.h\"", ObjCIR.fileImportStmt("ModelClass", headerPrefix: nil))
+    }
 }


### PR DESCRIPTION
Setting an include prefix is necessary to build the 'Bazel' way (relative to your WORKSPACE file).