### PR TITLE
Add missing import for com.google.gson.JsonObject if you have a top-level oneOf field

### DIFF
--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -431,6 +431,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
                 }
             case .set: return ["java.util.Set"]
             case .string(format: .some(.dateTime)): return ["java.util.Date"]
+            case .oneOf: return ["com.google.gson.JsonObject"]
             default: return []
             }
         }.reduce(into: []) {


### PR DESCRIPTION
We add the import if the oneOf field is in a list or map, but not if it's on its own.