### PR TITLE
Allow for annotations to be applied to generated Java TypeAdapterFactory classes

### DIFF
--- a/Sources/Core/JavaADTRenderer.swift
+++ b/Sources/Core/JavaADTRenderer.swift
@@ -20,7 +20,7 @@ extension JavaModelRenderer {
 
      }
      */
-    func adtRootsForSchema(property: String, schemas: [SchemaObjectProperty]) -> [JavaIR.Root] {
+    func adtRootsForSchema(property: String, schemas: [SchemaObjectProperty], decorations: JavaDecorations) -> [JavaIR.Root] {
         let adtName = "\(rootSchema.name)_\(property)"
         let formattedADTName = Languages.java.snakeCaseToCamelCase(adtName)
 
@@ -63,7 +63,7 @@ extension JavaModelRenderer {
                                methods: [emptyConstructor] + typeConstructors + [matcherMethod],
                                enums: [],
                                innerClasses: [
-                                   adtTypeAdapterFactory(property: property, schemas: schemas),
+                                   adtTypeAdapterFactory(property: property, schemas: schemas, decorations: decorations),
                                    adtTypeAdapter(property: property, schemas: schemas),
                                ],
                                interfaces: [matcherInterface],
@@ -72,7 +72,7 @@ extension JavaModelRenderer {
         return [JavaIR.Root.classDecl(aClass: cls)]
     }
 
-    func adtTypeAdapterFactory(property: String, schemas _: [SchemaObjectProperty]) -> JavaIR.Class {
+    func adtTypeAdapterFactory(property: String, schemas _: [SchemaObjectProperty], decorations: JavaDecorations) -> JavaIR.Class {
         let adtName = "\(rootSchema.name)_\(property)"
         let formattedADTName = Languages.java.snakeCaseToCamelCase(adtName)
 
@@ -84,7 +84,7 @@ extension JavaModelRenderer {
         ] }
 
         return JavaIR.Class(
-            annotations: [],
+            annotations: decorations.annotationsForTypeAdapterFactories(),
             modifiers: [.public, .static],
             extends: nil,
             implements: ["TypeAdapterFactory"],

--- a/Sources/Core/JavaIR.swift
+++ b/Sources/Core/JavaIR.swift
@@ -119,6 +119,7 @@ struct JavaDecorations: Codable {
     var properties: [String: PropertyDecorations]?
     var methods: [String: MethodDecorations]?
     var variables: [String: VariableDecorations]?
+    var typeAdapterFactories: ClassDecorations?
     var imports: [String]?
 
     func annotationsForClass() -> Set<JavaAnnotation> {
@@ -204,6 +205,18 @@ struct JavaDecorations: Codable {
             return []
         }
         guard let annotations = variable.annotations else {
+            return []
+        }
+        return Set(annotations.map { annotationString in
+            JavaAnnotation.custom(annotationString)
+        })
+    }
+
+    func annotationsForTypeAdapterFactories() -> Set<JavaAnnotation> {
+        guard let typeAdapterFactoriesDecorations = typeAdapterFactories else {
+            return []
+        }
+        guard let annotations = typeAdapterFactoriesDecorations.annotations else {
             return []
         }
         return Set(annotations.map { annotationString in

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -480,19 +480,19 @@ public struct JavaModelRenderer: JavaFileRenderer {
             switch prop.schema {
             case let .oneOf(types: possibleTypes):
                 let objProps = possibleTypes.map { $0.nullableProperty() }
-                return adtRootsForSchema(property: param, schemas: objProps)
+                return adtRootsForSchema(property: param, schemas: objProps, decorations: decorations)
             case let .array(itemType: .some(itemType)):
                 switch itemType {
                 case let .oneOf(types: possibleTypes):
                     let objProps = possibleTypes.map { $0.nullableProperty() }
-                    return adtRootsForSchema(property: param, schemas: objProps)
+                    return adtRootsForSchema(property: param, schemas: objProps, decorations: decorations)
                 default: return []
                 }
             case let .map(valueType: .some(additionalProperties)):
                 switch additionalProperties {
                 case let .oneOf(types: possibleTypes):
                     let objProps = possibleTypes.map { $0.nullableProperty() }
-                    return adtRootsForSchema(property: param, schemas: objProps)
+                    return adtRootsForSchema(property: param, schemas: objProps, decorations: decorations)
                 default: return []
                 }
             default: return []
@@ -525,7 +525,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
         )
 
         let typeAdapterFactoryClass = JavaIR.Class(
-            annotations: [],
+            annotations: decorations.annotationsForTypeAdapterFactories(),
             modifiers: [.public, .static],
             extends: nil,
             implements: ["TypeAdapterFactory"],


### PR DESCRIPTION
One TypeAdapterFactory is generated at a minimum for each model, and more may be generated for cases such as algebraic data types ("oneOf" fields).