### PR TITLE
Java model builder should not mutate the original model

### DIFF
--- a/Examples/Java/Sources/Board.java
+++ b/Examples/Java/Sources/Board.java
@@ -19,6 +19,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
@@ -251,7 +252,7 @@ public class Board {
             this.image = model.image;
             this.name = model.name;
             this.url = model.url;
-            this._bits = model._bits;
+            this._bits = Arrays.copyOf(model._bits, model._bits.length);
         }
 
         @NonNull

--- a/Examples/Java/Sources/Everything.java
+++ b/Examples/Java/Sources/Everything.java
@@ -20,6 +20,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -783,7 +784,7 @@ public class Everything {
             this.unsignedIntEnum = model.unsignedIntEnum;
             this.unsignedShortEnum = model.unsignedShortEnum;
             this.uriProp = model.uriProp;
-            this._bits = model._bits;
+            this._bits = Arrays.copyOf(model._bits, model._bits.length);
         }
 
         @NonNull

--- a/Examples/Java/Sources/Image.java
+++ b/Examples/Java/Sources/Image.java
@@ -19,6 +19,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -138,7 +139,7 @@ public class Image {
             this.height = model.height;
             this.url = model.url;
             this.width = model.width;
-            this._bits = model._bits;
+            this._bits = Arrays.copyOf(model._bits, model._bits.length);
         }
 
         @NonNull

--- a/Examples/Java/Sources/Model.java
+++ b/Examples/Java/Sources/Model.java
@@ -19,6 +19,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -104,7 +105,7 @@ public class Model {
 
         private Builder(@NonNull Model model) {
             this.uid = model.uid;
-            this._bits = model._bits;
+            this._bits = Arrays.copyOf(model._bits, model._bits.length);
         }
 
         @NonNull

--- a/Examples/Java/Sources/Nested.java
+++ b/Examples/Java/Sources/Nested.java
@@ -19,6 +19,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -105,7 +106,7 @@ public class Nested {
 
         private Builder(@NonNull Nested model) {
             this.uid = model.uid;
-            this._bits = model._bits;
+            this._bits = Arrays.copyOf(model._bits, model._bits.length);
         }
 
         @NonNull

--- a/Examples/Java/Sources/OneofObject.java
+++ b/Examples/Java/Sources/OneofObject.java
@@ -19,6 +19,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -105,7 +106,7 @@ public class OneofObject {
 
         private Builder(@NonNull OneofObject model) {
             this.uid = model.uid;
-            this._bits = model._bits;
+            this._bits = Arrays.copyOf(model._bits, model._bits.length);
         }
 
         @NonNull

--- a/Examples/Java/Sources/Pin.java
+++ b/Examples/Java/Sources/Pin.java
@@ -20,6 +20,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -377,7 +378,7 @@ public class Pin {
             this.tags = model.tags;
             this.url = model.url;
             this.visualSearchAttrs = model.visualSearchAttrs;
-            this._bits = model._bits;
+            this._bits = Arrays.copyOf(model._bits, model._bits.length);
         }
 
         @NonNull

--- a/Examples/Java/Sources/User.java
+++ b/Examples/Java/Sources/User.java
@@ -19,6 +19,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
@@ -254,7 +255,7 @@ public class User {
             this.lastName = model.lastName;
             this.type = model.type;
             this.username = model.username;
-            this._bits = model._bits;
+            this._bits = Arrays.copyOf(model._bits, model._bits.length);
         }
 
         @NonNull

--- a/Examples/Java/Sources/VariableSubtitution.java
+++ b/Examples/Java/Sources/VariableSubtitution.java
@@ -19,6 +19,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -156,7 +157,7 @@ public class VariableSubtitution {
             this.copyProp = model.copyProp;
             this.mutableCopyProp = model.mutableCopyProp;
             this.newProp = model.newProp;
-            this._bits = model._bits;
+            this._bits = Arrays.copyOf(model._bits, model._bits.length);
         }
 
         @NonNull

--- a/Sources/Core/JavaModelRenderer.swift
+++ b/Sources/Core/JavaModelRenderer.swift
@@ -214,7 +214,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
         let privateConstructor = JavaIR.method([.private], "Builder(@NonNull " + className + " model)") {
             self.transitiveProperties.map { param, _ in
                 "this." + Languages.java.snakeCaseToPropertyName(param) + " = model." + Languages.java.snakeCaseToPropertyName(param) + ";"
-            } + ["this._bits = model._bits;"]
+            } + ["this._bits = Arrays.copyOf(model._bits, model._bits.length);"]
         }
 
         return [emptyConstructor, privateConstructor]
@@ -457,6 +457,7 @@ public struct JavaModelRenderer: JavaFileRenderer {
                 "com.google.gson.stream.JsonToken",
                 "com.google.gson.stream.JsonWriter",
                 "java.io.IOException",
+                "java.util.Arrays",
                 "java.util.Objects",
                 nullabilityAnnotationType.package + ".NonNull",
                 nullabilityAnnotationType.package + ".Nullable",


### PR DESCRIPTION
When building models from an existing model (`model.toBuilder().build()`), the _bits array (used to signal which fields are set) is being copied into the builder and mutated in place. This means that the original model is being altered to indicate that fields are set, even if they are not. Effectively the original model is corrupted.

Instead of passing a reference to the _bits array, a separate copy should be made so that the "old" model is not changed in any way.

Example bug:
```
val model: Person.builder().apply { name = "jane" }.build()
assertFalse(model.ageIsSet) // age was not set, so this passes
val newModel = model.builder().apply { age = 100 }.build()
assertFalse(model.ageIsSet) // age was still not set on the original model, but this assertion would fail
```