### PR TITLE
Fix: Variables with same name are within the same scope

### DIFF
--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -122,7 +122,6 @@ extension ObjCModelRenderer {
                 ]
             }
 
-            
             switch schema {
             case let .array(itemType: .some(itemType)):
                 let currentResult = "result\(counter)"

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -122,11 +122,13 @@ extension ObjCModelRenderer {
                 ]
             }
 
+            
             switch schema {
             case let .array(itemType: .some(itemType)):
                 let currentResult = "result\(counter)"
                 let currentTmp = "tmp\(counter)"
                 let currentObj = "obj\(counter)"
+                let currentItems = "items\(counter)"
                 if itemType.isPrimitiveType {
                     return renderTypeCheck { [
                         "\(propertyToAssign) = \(rawObjectName);",
@@ -134,9 +136,9 @@ extension ObjCModelRenderer {
                 }
                 let propertyInit = renderPropertyInit(currentTmp, currentObj, keyPath: keyPath + ["?".objcLiteral()], schema: itemType, firstName: firstName, counter: counter + 1).joined(separator: "\n")
                 return renderTypeCheck { [
-                    "NSArray *items = \(rawObjectName);",
-                    "NSMutableArray *\(currentResult) = [NSMutableArray arrayWithCapacity:items.count];",
-                    ObjCIR.forStmt("id \(currentObj) in items") { [
+                    "NSArray *\(currentItems) = \(rawObjectName);",
+                    "NSMutableArray *\(currentResult) = [NSMutableArray arrayWithCapacity:\(currentItems).count];",
+                    ObjCIR.forStmt("id \(currentObj) in \(currentItems)") { [
                         ObjCIR.ifStmt("\(currentObj) != (id)kCFNull") { [
                             "id \(currentTmp) = nil;",
                             propertyInit,
@@ -151,17 +153,18 @@ extension ObjCModelRenderer {
                 let currentResult = "result\(counter)"
                 let currentTmp = "tmp\(counter)"
                 let currentObj = "obj\(counter)"
+                let currentItems = "items\(counter)"
                 if itemType.isPrimitiveType {
                     return renderTypeCheck { [
-                        "NSArray *items = \(rawObjectName);",
-                        "\(propertyToAssign) = [NSSet setWithArray:items];",
+                        "NSArray *\(currentItems) = \(rawObjectName);",
+                        "\(propertyToAssign) = [NSSet setWithArray:\(currentItems)];",
                     ] }
                 }
                 let propertyInit = renderPropertyInit(currentTmp, currentObj, keyPath: keyPath + ["?".objcLiteral()], schema: itemType, firstName: firstName, counter: counter + 1).joined(separator: "\n")
                 return renderTypeCheck { [
-                    "NSArray *items = \(rawObjectName);",
-                    "NSMutableSet *\(currentResult) = [NSMutableSet setWithCapacity:items.count];",
-                    ObjCIR.forStmt("id \(currentObj) in items") { [
+                    "NSArray *\(currentItems) = \(rawObjectName);",
+                    "NSMutableSet *\(currentResult) = [NSMutableSet setWithCapacity:\(currentItems).count];",
+                    ObjCIR.forStmt("id \(currentObj) in \(currentItems)") { [
                         ObjCIR.ifStmt("\(currentObj) != (id)kCFNull") { [
                             "id \(currentTmp) = nil;",
                             propertyInit,


### PR DESCRIPTION
Issue:
When creating an array or set that has objects nested inside them, the code generated wouldnt add a suffix for the depth of the given variable or set of variables. This would in turn cause compiler warnings/errors.
A given schema that would cause the issue looks like this:
```json
{
  "id": "component.json",
  "title": "component",
  "extends": { "$ref" : "base_component.json" },
  "description": "Schema definition of a component",
  "$schema": "http://json-schema.org/schema#",
  "type": "object",
  "properties": {
    "content": {
      "type": "array",
      "items": {
        "type": "array",
        "items": {
          "type": "string"
        }
      }
    }
  },
  "required": ["type", "content"]
}
```

The items variable would be of the same name as the previously defined items, even though the second items would be one level deeper. When the top level is a Dictionary for instance this wouldnt be the issue because that initializer appends the counter to the currentItems variable.

Solution:
Store a scoped variable that uses the current counter as part of the variable name. This is incremented as the code is generated.

Potential downside:
This doesnt take into account that when there is only a single depth in the schema. In that case a `0` would be added even if there will never be an `items1`.