### PR TITLE
[Duplicate imports] Fix issue that would cause duplicate imports

### DIFF
--- a/Sources/Core/ObjectiveCIR.swift
+++ b/Sources/Core/ObjectiveCIR.swift
@@ -424,9 +424,9 @@ public struct ObjCIR {
                 // skip macro in impl
                 return []
             case .imports(let classNames, let myName, _):
-                return [classNames.union(Set([myName]))
+                let strippedClassNames = Set(classNames.map { $0.trimmingCharacters(in: .whitespaces) })
+                return [strippedClassNames.union(Set([myName.trimmingCharacters(in: .whitespaces)]))
                     .sorted()
-                    .map { $0.trimmingCharacters(in: .whitespaces) }
                     .map { ObjCIR.fileImportStmt($0, headerPrefix: params[GenerationParameterType.headerPrefix]) }
                     .joined(separator: "\n")]
             case .classDecl(name: let className, extends: _, methods: let methods, properties: _, protocols: let protocols):

--- a/Sources/Core/ObjectiveCNSCodingExtension.swift
+++ b/Sources/Core/ObjectiveCNSCodingExtension.swift
@@ -20,21 +20,21 @@ extension ObjCModelRenderer {
                     .map(decodeStatement)
                     .joined(separator: "\n"),
             ] +
-            self.properties.filter { (_, schema) -> Bool in
-                schema.schema.isBoolean()
-            }.map { (arg: (Parameter, SchemaObjectProperty)) -> String in
-                let (param, _) = arg
-                return "_\(booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: param, className: self.className)) = [aDecoder decodeBoolForKey:\(param.objcLiteral())] & 0x1;"
-            } + [
-                self.properties.map { (param, _) -> String in
-                    "_\(dirtyPropertiesIVarName).\(dirtyPropertyOption(propertyName: param, className: self.className)) = [aDecoder decodeIntForKey:\((param + "_dirty_property").objcLiteral())] & 0x1;"
-                }.joined(separator: "\n"),
-                
-                ObjCIR.ifStmt("[self class] == [\(self.className) class]") {
-                    [renderPostInitNotification(type: "PlankModelInitTypeDefault")]
-                },
-                "return self;",
-            ]
+                self.properties.filter { (_, schema) -> Bool in
+                    schema.schema.isBoolean()
+                }.map { (arg: (Parameter, SchemaObjectProperty)) -> String in
+                    let (param, _) = arg
+                    return "_\(booleanPropertiesIVarName).\(booleanPropertyOption(propertyName: param, className: self.className)) = [aDecoder decodeBoolForKey:\(param.objcLiteral())] & 0x1;"
+                } + [
+                    self.properties.map { (param, _) -> String in
+                        "_\(dirtyPropertiesIVarName).\(dirtyPropertyOption(propertyName: param, className: self.className)) = [aDecoder decodeIntForKey:\((param + "_dirty_property").objcLiteral())] & 0x1;"
+                    }.joined(separator: "\n"),
+
+                    ObjCIR.ifStmt("[self class] == [\(self.className) class]") {
+                        [renderPostInitNotification(type: "PlankModelInitTypeDefault")]
+                    },
+                    "return self;",
+                ]
             return body
         }
     }

--- a/Tests/CoreTests/ObjectiveCIRTests.swift
+++ b/Tests/CoreTests/ObjectiveCIRTests.swift
@@ -188,4 +188,12 @@ class ObjectiveCIRTests: XCTestCase {
         XCTAssertEqual("#import \"include/ModelClass.h\"", ObjCIR.fileImportStmt("ModelClass", headerPrefix: "include/"))
         XCTAssertEqual("#import \"ModelClass.h\"", ObjCIR.fileImportStmt("ModelClass", headerPrefix: nil))
     }
+    
+    func testImportsImplementationWithTrailingSpace() {
+        let imports = ObjCIR.Root.imports(classNames: Set(["MyClass "]), myName: "MyClass", parentName: nil)
+        let output = imports.renderImplementation(GenerationParameters())
+        XCTAssertEqual(1, output.count)
+        XCTAssertEqual("#import \"MyClass.h\"", output[0])
+
+    }
 }

--- a/Tests/CoreTests/ObjectiveCIRTests.swift
+++ b/Tests/CoreTests/ObjectiveCIRTests.swift
@@ -188,12 +188,11 @@ class ObjectiveCIRTests: XCTestCase {
         XCTAssertEqual("#import \"include/ModelClass.h\"", ObjCIR.fileImportStmt("ModelClass", headerPrefix: "include/"))
         XCTAssertEqual("#import \"ModelClass.h\"", ObjCIR.fileImportStmt("ModelClass", headerPrefix: nil))
     }
-    
+
     func testImportsImplementationWithTrailingSpace() {
         let imports = ObjCIR.Root.imports(classNames: Set(["MyClass "]), myName: "MyClass", parentName: nil)
         let output = imports.renderImplementation(GenerationParameters())
         XCTAssertEqual(1, output.count)
         XCTAssertEqual("#import \"MyClass.h\"", output[0])
-
     }
 }


### PR DESCRIPTION
In the given schema file, we can see the class `board_activity` references itself:
```
{
    "id": "board_activity.json",
    "title": "board_activity",
    "description": "Schema definition of a BoardActivity",
    "$schema": "http://json-schema.org/schema#",
    "type": "object",
    "properties": {
      "ref_board_activity": { "$ref": "board_activity.json" },
    },
}
```

This causes multiple `BoardActivity` imports in `BoardActivity.m`. The issue is in `ObjCIR.Root.imports` `renderImplementation` method. This is how the imports are being generated:
```
case .imports(let classNames, let myName, _):
    return [classNames.union(Set([myName]))
        .sorted()
        .map { $0.trimmingCharacters(in: .whitespaces) }
        .map { ObjCIR.fileImportStmt($0, headerPrefix: params[GenerationParameterType.headerPrefix]) }
        .joined(separator: "\n")]
```
Using the schema above, `classNames` would include `“BoardActivity “`. Note the space. `myName` would be `”BoardActivity”`. Note the lack of space.

These two get unioned together in a set. The result is  `["BoardActivity ", "BoardActivity"]`. We sort this set, then remove any trailing spaces. But at this point we are an array, and we now have two duplicate entries in our array:  `["BoardActivity", "BoardActivity"]`. This leads plank to render `#import "BoardActivity.h"` twice in our implementation file.

A solution would be to trim these strings BEFORE the union:
```
case .imports(let classNames, let myName, _):
    let strippedClassNames = Set(classNames.map { $0.trimmingCharacters(in: .whitespaces) })
    return [strippedClassNames.union(Set([myName.trimmingCharacters(in: .whitespaces)]))
        .sorted()
        .map { ObjCIR.fileImportStmt($0, headerPrefix: params[GenerationParameterType.headerPrefix]) }
        .joined(separator: "\n")]
```
I created `strippedClassNames` which holds the trimmed `classNames`. This gets unioned that with the stripped version of `myName` to get the list of imports. Now we end up with the array only have one entry `["BoardActivity"]`.

Note: I also made a change in `ObjectiveCNSCodingExtension.swift` because the compiler was telling me that the return value was too complicated for it to figure out.