### PR TITLE
Fix build issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     name: Run Unit and Integration Tests (macOS)
     runs-on: macOS-latest
     steps:
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip looseversion
     - name: Checkout the Git repository
       uses: actions/checkout@v1
     - run: make ci_tests
@@ -21,6 +23,8 @@ jobs:
     name: Run Unit and Integration Tests (Ubuntu)
     runs-on: ubuntu-latest
     steps:
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip looseversion
     - name: Checkout the Git repository
       uses: actions/checkout@v1
     - name: Run tests in container 

--- a/Sources/Core/ObjectiveCInitExtension.swift
+++ b/Sources/Core/ObjectiveCInitExtension.swift
@@ -272,7 +272,7 @@ extension ObjCModelRenderer {
                         }
 
                     case .boolean:
-                        return ObjCIR.ifStmt("[\(rawObjectName) isKindOfClass:[NSNumber class]] && strcmp([\(rawObjectName) objCType], @encode(BOOL)) == 0") {
+                        return ObjCIR.ifStmt("[\(rawObjectName) isKindOfClass:[NSNumber class]] && strcmp([\(rawObjectName) objCType], [[NSNumber numberWithBool:0] objCType]) == 0") {
                             transformToADTInit(renderPropertyInit(propertyToAssign, rawObjectName, keyPath: keyPath, schema: schema, firstName: firstName, counter: counter, dirtyPropertyName: dirtyPropertyName, needsTypeCheck: false))
                         }
                     case .array(itemType: _):

--- a/Sources/Core/ObjectiveCNSCodingExtension.swift
+++ b/Sources/Core/ObjectiveCNSCodingExtension.swift
@@ -11,7 +11,7 @@ import Foundation
 extension ObjCModelRenderer {
     func renderInitWithCoder() -> ObjCIR.Method {
         return ObjCIR.method("- (instancetype)initWithCoder:(NSCoder *)aDecoder") {
-            [
+            let body: [String] = [
                 self.isBaseClass ? ObjCIR.ifStmt("!(self = [super init])") { ["return self;"] } :
                     "if (!(self = [super initWithCoder:aDecoder])) { return self; }",
                 self.properties.filter { (_, schema) -> Bool in
@@ -35,6 +35,7 @@ extension ObjCModelRenderer {
                     },
                     "return self;",
                 ]
+            return body
         }
     }
 

--- a/tools/bazel
+++ b/tools/bazel
@@ -16,7 +16,7 @@ limitations under the License.
 """
 
 from contextlib import closing
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 import json
 import os.path
 import platform


### PR DESCRIPTION
1. When running `make build` the compiler complains that it “can’t type check this expression in reasonable time” in `ObjectiveCInitExtension.swift`. I put the expression in an explicitly declared variable to help out the compiler’s tiny brain.
2. The test `testPolymorphicPropWithBool` is failing. Looking at the code, we test that an `NSNumber` is a bool by comparing its `objCType` to the result of `@encode(BOOL)`:
```
if ([value isKindOfClass:[NSNumber class]] && strcmp([value objCType], @encode(BOOL)) == 0) {
    self->_polymorphicProp = [EverythingPolymorphicProp  objectWithBoolean:[value boolValue] & 0x1];
}
```
However, I’m seeing weird behavior where `@encode(BOOL)` is not returning `c` as [Apple documentation](https://developer.apple.com/documentation/objectivec/bool) says it should: 
``` 
BOOL is explicitly signed so @encode(BOOL) is c rather than C even if -funsigned-char is used.
```

Here is what I was seeing in the debugger:
```
(lldb) po @encode(BOOL)
"B"
(lldb) po [@YES objCType]
"c"
(lldb) po [@NO objCType]
"c"
```

I am not sure why this is retuning `B`, but it seems a safer check would be to compare the `objCType` of `value` with the `objCType` of a `NSNumber` we know is created with a `BOOL`:
```
if ([value isKindOfClass:[NSNumber class]] && strcmp([value objCType], [[NSNumber numberWithBool:0] objCType]) == 0) {
    self->_polymorphicProp = [EverythingPolymorphicProp  objectWithBoolean:[value boolValue] & 0x1];
}
```
I added this change to fix the tests.